### PR TITLE
Mean function Combination

### DIFF
--- a/GPflow/mean_functions.py
+++ b/GPflow/mean_functions.py
@@ -55,8 +55,8 @@ class Constant(MeanFunction):
 class Additive(MeanFunction):
     def __init__(self, first_part, second_part):
         MeanFunction.__init__(self)
-        self.first_part = first_part
-        self.second_part = second_part
+        self.augend = first_part
+        self.addend = second_part
         
     def __call__(self, X):
         return tf.add(self.first_part(X), self.second_part(X))
@@ -64,7 +64,8 @@ class Additive(MeanFunction):
 class Product(MeanFunction):
     def __init__(self, first_part, second_part):
         MeanFunction.__init__(self)
-        self.first_part = first_part
-        self.second_part = second_part
+        self.multiplicant = first_part
+        self.multiplier = second_part
+                 
     def __call__(self, X):
-        return tf.matmul(self.first_part(X), self.second_part(X))
+        return tf.mul(self.first_part(X), self.second_part(X))

--- a/GPflow/mean_functions.py
+++ b/GPflow/mean_functions.py
@@ -61,7 +61,7 @@ class Additive(MeanFunction):
     def __call__(self, X):
         return tf.add(self.first_part(X), self.second_part(X))
                     
-class PolyProd(MeanFunction):
+class Product(MeanFunction):
     def __init__(self, first_part, second_part):
         MeanFunction.__init__(self)
         self.first_part = first_part

--- a/GPflow/mean_functions.py
+++ b/GPflow/mean_functions.py
@@ -69,4 +69,3 @@ class Product(MeanFunction):
                  
     def __call__(self, X):
         return tf.mul(self.multiplicant(X), self.multiplier(X))
-        

--- a/GPflow/mean_functions.py
+++ b/GPflow/mean_functions.py
@@ -64,6 +64,7 @@ class Additive(MeanFunction):
 class Product(MeanFunction):
     def __init__(self, first_part, second_part):
         MeanFunction.__init__(self)
+        
         self.multiplicant = first_part
         self.multiplier = second_part
                  

--- a/GPflow/mean_functions.py
+++ b/GPflow/mean_functions.py
@@ -55,18 +55,18 @@ class Constant(MeanFunction):
 class Additive(MeanFunction):
     def __init__(self, first_part, second_part):
         MeanFunction.__init__(self)
-        self.augend = first_part
-        self.addend = second_part
+        self.add_1 = first_part
+        self.add_2= second_part
         
     def __call__(self, X):
-        return tf.add(self.augend(X), self.addend(X))
+        return tf.add(self.add_1(X), self.add_2(X))
                     
 class Product(MeanFunction):
     def __init__(self, first_part, second_part):
         MeanFunction.__init__(self)
         
-        self.multiplicant = first_part
-        self.multiplier = second_part
+        self.prod_1 = first_part
+        self.prod_2= second_part
                  
     def __call__(self, X):
-        return tf.mul(self.multiplicant(X), self.multiplier(X))
+        return tf.mul(self.prod_1(X), self.prod_2(X))

--- a/GPflow/mean_functions.py
+++ b/GPflow/mean_functions.py
@@ -1,25 +1,35 @@
 import tensorflow as tf
 import numpy as np
-from param import Param, Parameterized
-import transforms
+from GPflow.param import Param, Parameterized, ParamList
 
 class MeanFunction(Parameterized):
     """
     The base mean function class.
-
     To implement a mean funcion, write the __call__ method. This takes a 
     tensor X and returns a tensor m(X). In accordance with the GPflow
     standard, each row of X represents one datum, and each row of Y is computed
     independently for each row of X. 
-
     MeanFunction classes can have parameters, see the Linear class for an example.
     """
     def __call__(self, X):
         raise NotImplementedError, "Implement the __call__ method for this mean function"
     
+    def __add__(self, other):
+        raise NotImplementedError, "Implement the __add__ method for this mean function"
+        
+
+    def __mul__(self, other):
+        raise NotImplementedError, "Implement the __mul__ method for this mean function"
+        
+
 class Zero(MeanFunction):
     def __call__(self, X):
         return tf.zeros(tf.pack([tf.shape(X)[0], 1]), dtype='float64')
+        
+    def __add__(self, other):
+        return other
+    def __mul__(self, other):
+        return self   
 
 
 class Linear(MeanFunction):
@@ -29,7 +39,6 @@ class Linear(MeanFunction):
     def __init__(self, A=np.ones((1,1)), b=np.zeros(1)):
         """
         A is a matrix which maps each element of X to Y, b is an additive constant.
-
         If X has N rows and D columns, and Y is intended to have Q columns,
         then A must be D x Q, b must be a vector of length Q. 
         """
@@ -38,15 +47,95 @@ class Linear(MeanFunction):
         self.b = Param(b)
     def __call__(self, X):
         return tf.matmul(X, self.A) + self.b
-
+        
+    def __add__(self, other):  
+        if isinstance(other, Zero):
+            return self
+        elif isinstance(other, Constant):
+            return Linear(other.A, other.b + self.c)
+        elif isinstance(other, Linear):
+            return Linear(self.A + other.A, self.b + other.b)
+        elif isinstance(other, PolyAdd):
+            return PolyAdd(self, other)
+        elif isinstance(other, PolyProd):
+            return PolyAdd(self, other)
+            
+    def __mul__(self, other):
+        if isinstance(other, Zero):
+            return other
+        elif isinstance(other, Constant):
+            return Linear(other.A, other.b * self.c)
+        elif isinstance(other, Linear):
+            return PolyProd(self, other)
+        elif isinstance(other, PolyAdd):
+            return PolyProd(self, other)
+        elif isinstance(other, PolyProd):
+            return PolyProd(self, other)
 
 class Constant(MeanFunction):
     """
-    y_i = c
+    y_i = c,,
     """
     def __init__(self, c=np.zeros(1)):
         MeanFunction.__init__(self)
         self.c = Param(c)
     def __call__(self, X):
-        return tf.tile(tf.reshape(self.c, (1,-1)), tf.pack([tf.shape(X)[0], 1]))
+        return tf.tile(tf.reshape(self.c, (1,-1)), tf.pack([tf.shape(X)[0], 1])) 
+    def __add__(self, other):  
+        if isinstance(other, Zero):
+            return self
+        elif isinstance(other, Constant):
+            return Constant(self.c + other.c)
+        elif isinstance(other, Linear):
+            return Linear(other.A, other.b + self.c)
+        elif isinstance(other, PolyAdd):
+            return PolyAdd(self, other)
+        elif isinstance(other, PolyProd):
+            return PolyAdd(self, other)
+            
+    def __mul__(self, other):
+        if isinstance(other, Zero):
+            return other
+        elif isinstance(other, Constant):
+            return Constant(self.c * other.c)
+        elif isinstance(other, Linear):
+            return Linear(other.A, other.b * self.c)
+        elif isinstance(other, PolyAdd):
+            PolyProd(self, other)
+        elif isinstance(other, PolyProd):
+            PolyProd(self, other)
 
+class PolyAdd(MeanFunction):
+    def __init__(self, mfunA, mfunB):
+        MeanFunction.__init__(self)
+        self.mfunA = mfunA
+        self.mfunB = mfunB
+        
+    def __call__(self, X):
+        return tf.add(self.funA(X), self.funB(X))
+        
+    def __add__(self, other):
+        if isinstance(other, Zero):
+            return self
+        else: return PolyAdd(self, other)
+        
+    def __mul__(self, other):
+        if isinstance(other, Zero):
+            return other
+        else: return PolyProd(self, other)
+                    
+class PolyProd(MeanFunction):
+    def __init__(self, mfunA, mfunB):
+        MeanFunction.__init__(self)
+        self.mfunA = mfunA
+        self.mfunB = mfunB
+    def __call__(self, X):
+        return tf.matmul(self.mfunA(X), self.mfunB(X))
+    def __add__(self, other):
+        if isinstance(other, Zero):
+            return self
+        else: return PolyAdd(self, other)        
+    def __mul__(self, other):
+        if isinstance(other, Zero):
+            return other
+        else: return PolyProd(self, other)

--- a/GPflow/mean_functions.py
+++ b/GPflow/mean_functions.py
@@ -59,7 +59,7 @@ class Additive(MeanFunction):
         self.addend = second_part
         
     def __call__(self, X):
-        return tf.add(self.first_part(X), self.second_part(X))
+        return tf.add(self.augend(X), self.addend(X))
                     
 class Product(MeanFunction):
     def __init__(self, first_part, second_part):
@@ -68,4 +68,5 @@ class Product(MeanFunction):
         self.multiplier = second_part
                  
     def __call__(self, X):
-        return tf.mul(self.first_part(X), self.second_part(X))
+        return tf.mul(self.multiplicant(X), self.multiplier(X))
+        

--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -84,14 +84,14 @@ class Param(Parentable):
     There is a self._fixed flag, in which case the parameter does not get
     optimized. To enable this, during make_tf_array, the fixed values of
     the parameter are returned. Fixes and transforms can be used together, in
-    the sense that fixes tkae priority over transforms, so unfixing a parameter
+    the sense that fixes take priority over transforms, so unfixing a parameter
     is as simple as setting the flag. Example:
 
     >>> p = Param(1.0, transform=GPflow.transforms.positive)
     >>> m = GPflow.model.Model()
-    >>> m.p = p # the model has a sinlge parameter, constrained to be +ve
+    >>> m.p = p # the model has a single parameter, constrained to be +ve
     >>> m.p.fixed = True # the model now has no free parameters
-    >>> m.p.fixed = False # the model has a sinlge parameter, constrained to be +ve
+    >>> m.p.fixed = False # the model has a single parameter, constrained to be +ve
 
 
     Compiling into tensorflow
@@ -223,7 +223,7 @@ class Parameterized(Parentable):
     models on those parameters. During _tf_mode, the __getattribute__
     method is overwritten to return tf arrays in place of parameters.
 
-    Another recurseive function is build_prior wich sums the log-prior from all
+    Another recursive function is build_prior wich sums the log-prior from all
     of the tree's parameters (whilst in tf_mode!).
     """
     def __init__(self):

--- a/testing/test_mean_functions.py
+++ b/testing/test_mean_functions.py
@@ -70,6 +70,10 @@ class TestModelsWithMeanFuncs(unittest.TestCase):
     Simply check that all models have a higher prediction with a constant mean
     function than with a zero mean function.
     
+    For compositions of mean functions check that multiplication/ addition of 
+    a constant results in a higher prediction, whereas addition of zero/
+    mutliplication with one does not.
+    
     """
 
     def setUp(self):
@@ -143,7 +147,7 @@ class TestModelsWithMeanFuncs(unittest.TestCase):
             self.failUnless(np.all(np.isclose(v1, v2)))
 
 if __name__ == "__main__":
-      
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestMeanFuncs)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    #suite = unittest.TestLoader().loadTestsFromTestCase(TestMeanFuncs)
+    #unittest.TextTestRunner(verbosity=2).run(suite)
+    unittest.main()
 

--- a/testing/test_mean_functions.py
+++ b/testing/test_mean_functions.py
@@ -84,8 +84,10 @@ class TestModelCompositionOperations(unittest.TestCase):
         const2 = GPflow.mean_functions.Constant(rng.randn(self.output_dim))
         const3 = GPflow.mean_functions.Constant(rng.randn(self.output_dim))
 
-        const1inv = GPflow.mean_functions.Constant(const1.c.get_free_state() *-1)
-        linear1inv = GPflow.mean_functions.Linear(A = linear1.A.get_free_state() * -1., b = linear1.b.get_free_state() * -1.)
+        const1inv = GPflow.mean_functions.Constant(np.reshape(const1.c.get_free_state() *-1, [self.output_dim]))
+        linear1inv = GPflow.mean_functions.Linear(A = np.reshape(linear1.A.get_free_state() * -1., [self.input_dim, self.output_dim]),
+                                                                 b = np.reshape(linear1.b.get_free_state() * -1., [self.output_dim]))
+        
         
         #a * (b + c)
         const_set1 = GPflow.mean_functions.Product(const1,
@@ -142,7 +144,6 @@ class TestModelCompositionOperations(unittest.TestCase):
         self.failUnless(np.all(np.isclose(mu1_const, mu2_const)))
             
     def test_inverse_operations(self):
-        #TODO: Dimensionality issues here ValueError: Dimensions 3 and 1 are not compatible
         mu1_lin_min_lin, v1_lin_min_lin = self.m_linear_min_linear.predict_f(self.Xtest)
         mu1_const_min_const, v1_const_min_const= self.m_const_min_const.predict_f(self.Xtest)        
         
@@ -152,8 +153,8 @@ class TestModelCompositionOperations(unittest.TestCase):
         mu_constituent, v_constituent = self.m_constituent.predict_f(self.Xtest)
         mu_zero, v_zero= self.m_zero.predict_f(self.Xtest)
         
-        self.failUnless(np.all(mu1_lin_min_lin, mu_zero))
-        self.failUnless(np.all(mu1_const_min_const, mu_zero))
+        self.failUnless(np.all(np.isclose(mu1_lin_min_lin, mu_zero)))
+        self.failUnless(np.all(np.isclose(mu1_const_min_const, mu_zero)))
         
         self.failUnless(np.all(np.isclose(mu1_comp_min_constituent1, mu_constituent)))
         self.failUnless(np.all(np.isclose(mu1_comp_min_constituent2, mu_constituent)))

--- a/testing/test_mean_functions.py
+++ b/testing/test_mean_functions.py
@@ -1,4 +1,5 @@
 import GPflow
+
 import tensorflow as tf
 import numpy as np
 import unittest
@@ -9,29 +10,48 @@ class TestMeanFuncs(unittest.TestCase):
         self.output_dim=2
         self.N=20
         rng = np.random.RandomState(0)
-        self.mfs = [ GPflow.mean_functions.Zero(),
-                     GPflow.mean_functions.Linear(rng.randn(self.input_dim, self.output_dim), rng.randn(self.output_dim)),
-                     GPflow.mean_functions.Constant(rng.randn(self.output_dim))]
-
+        self.mfs = [GPflow.mean_functions.Zero(),
+                    GPflow.mean_functions.Linear(rng.randn(self.input_dim, self.output_dim), rng.randn(self.output_dim)),
+                    GPflow.mean_functions.Constant(rng.randn(self.output_dim))]
+                    
+        
+        self.composition_mfs = []
+        for mean_f1 in self.mfs:
+            self.composition_mfs.extend([mean_f1 + mean_f2 for mean_f2 in self.mfs])
+            self.composition_mfs.extend([mean_f1 * mean_f2 for mean_f2 in self.mfs])
+        
+        
         self.x = tf.placeholder('float64')
         for mf in self.mfs:
             mf.make_tf_array(self.x)
+        
 
         self.X = tf.placeholder(tf.float64, [self.N, self.input_dim])
         self.X_data = np.random.randn(self.N, self.input_dim)
 
-    def test_output_shape(self):
+    def test_basic_output_shape(self):
         for mf in self.mfs:
             with mf.tf_mode():
                 Y = tf.Session().run(mf(self.X), feed_dict={self.x: mf.get_free_state(), self.X:self.X_data})
             self.failUnless(Y.shape in [(self.N, self.output_dim), (self.N, 1)])
+    
+    def test_composition_output_shape(self):
+        for comp_mf in self.composition_mfs:
+            with comp_mf.tf_mode():
+                
+                Y = tf.Session().run(comp_mf(self.X), feed_dict={self.x: comp_mf.get_free_state(), self.X:self.X_data})
+            self.failUnless(Y.shape in [(self.N, self.output_dim), (self.N, 1)])
+            
 
 
 class TestModelsWithMeanFuncs(unittest.TestCase):
     """
     Simply check that all models have a higher prediction with a constant mean
     function than with a zero mean function.
+    
     """
+    
+    #TODO: Add 0, multiply with one --> not higher prediction
     def setUp(self):
         self.input_dim=3
         self.output_dim=2
@@ -46,7 +66,12 @@ class TestModelsWithMeanFuncs(unittest.TestCase):
         k = lambda : GPflow.kernels.Matern32(self.input_dim)
         zero = GPflow.mean_functions.Zero()
         const = GPflow.mean_functions.Constant(np.ones(self.output_dim) * 10)
-        self.models_with, self.models_without =\
+        
+        
+        mult = GPflow.mean_functions.Product(const,const)
+        add = GPflow.mean_functions.Additive(const,const)
+
+        self.models_with, self.models_without, self.models_mult, self.models_add =\
                 [[GPflow.gpr.GPR(X, Y, mean_function=mf, kern=k()),
                   GPflow.sgpr.SGPR(X, Y, mean_function=mf, Z=Z, kern=k()),
                   GPflow.sgpr.GPRFITC(X, Y, mean_function=mf, Z=Z, kern=k()),
@@ -54,16 +79,53 @@ class TestModelsWithMeanFuncs(unittest.TestCase):
                   GPflow.vgp.VGP(X, Y, mean_function=mf, kern=k(), likelihood=GPflow.likelihoods.Gaussian()),
                   GPflow.vgp.VGP(X, Y, mean_function=mf, kern=k(), likelihood=GPflow.likelihoods.Gaussian()),
                   GPflow.gpmc.GPMC(X, Y, mean_function=mf, kern=k(), likelihood=GPflow.likelihoods.Gaussian()),
-                  GPflow.sgpmc.SGPMC(X, Y, mean_function=mf, kern=k(), likelihood=GPflow.likelihoods.Gaussian(), Z=Z)] for mf in (const, zero)]
+                  GPflow.sgpmc.SGPMC(X, Y, mean_function=mf, kern=k(), likelihood=GPflow.likelihoods.Gaussian(), Z=Z)] for mf in (const, zero, mult, add)]
 
-    def test_mean_function(self):
+    def test_basic_mean_function(self):
         for m_with, m_without in zip(self.models_with, self.models_without):
             mu1, v1 = m_with.predict_f(self.Xtest)
             mu2, v2 = m_without.predict_f(self.Xtest)
             self.failUnless(np.all(v1==v2))
             self.failIf(np.all(mu1 == mu2))
+    
+    def test_add_mean_function(self):
+        for m_add, m_const in zip(self.models_add, self.models_with):
+            mu1, v1 = m_add.predict_f(self.Xtest)
+            mu2, v2 = m_const.predict_f(self.Xtest)
+            self.failUnless(np.all(v1==v2))
+            self.failIf(np.all(mu1 == mu2))
+    
+    def test_mult_mean_function(self):
+        for m_mult, m_const in zip(self.models_mult, self.models_with):
+            mu1, v1 = m_mult.predict_f(self.Xtest)
+            mu2, v2 = m_const.predict_f(self.Xtest)
+            self.failUnless(np.all(v1==v2))
+            self.failIf(np.all(mu1 == mu2))
+
+
+class TestCombinationsOfMeanFunctions(unittest.TestCase):
+    """
+    Check that the combination of mean functions returns the correct class and
+    operator precedence is correct    
+    """
+    def setUp(self):
+        #TODO: setup a list of random additions and one of random multiplications
+        print("test")
+        pass
+    def test_combination_types(self):
+        #TODO: combine elements and test their type
+        self.assertEqual('foo'.upper(), 'FOO')
+        pass
+    def test_precedence(self):
+        #TODO: check a + b * c, a* b +c etc
+        pass
+    def test_zero_operations(self):
+        #TODO: check a - a && a * zero for all a & combinations
+        pass
 
 
 if __name__ == "__main__":
-    unittest.main()
+      
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestModelsWithMeanFuncs)
+    unittest.TextTestRunner(verbosity=2).run(suite)
 

--- a/testing/test_mean_functions.py
+++ b/testing/test_mean_functions.py
@@ -31,10 +31,11 @@ class TestMeanFuncs(unittest.TestCase):
 
         for mf in self.mfs:
             mf.make_tf_array(self.x)
-        for compmf in self.composition_mfs:
-            compmf.make_tf_array(self.x)
-            
         
+        
+        #for compmf in self.composition_mfs:
+            #compmf.make_tf_array(self.x)
+            
         self.X = tf.placeholder(tf.float64, [self.N, self.input_dim])
         self.X_data = np.random.randn(self.N, self.input_dim)
 
@@ -240,7 +241,7 @@ class TestModelsWithMeanFuncs(unittest.TestCase):
             self.failUnless(np.all(np.isclose(v1, v2)))
 
 if __name__ == "__main__":
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestModelCompositionOperations)
-    unittest.TextTestRunner(verbosity=2).run(suite)
-    #unittest.main()
+    #suite = unittest.TestLoader().loadTestsFromTestCase(TestMeanFuncs)
+    #unittest.TextTestRunner(verbosity=2).run(suite)
+    unittest.main()
 


### PR DESCRIPTION
This is not functional (yet) but only serves as reference to #57 .

I introduce addition and multiplication for mean functions and provide two Polynomial mean functions to handle higher order combinations (linear * linear and combinations of polynomial with some other function).
@jameshensman I need a way to access the  parameters of the constituent mean functions (e.g. function1.A, function1.b etc.). I tried wrapping them into Parameterlists and running reduce(tf.add/tf.matmul) on them, but without any luck. Any other feedback would be highly appreciated!