### PR TITLE
Universal autoflow

### DIFF
--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -2,7 +2,7 @@ from functools import reduce
 
 import tensorflow as tf
 import numpy as np
-from .param import Param, Parameterized
+from .param import Param, Parameterized, AutoFlow
 from . import transforms
 
 
@@ -42,6 +42,10 @@ class Kern(Parameterized):
 
     def __mul__(self, other):
         return Prod([self, other])
+
+    @AutoFlow((tf.float64, [None, None]), (tf.float64, [None, None]))
+    def compute_K(self, X, Z):
+        return self.K(X, Z)
 
 
 class Static(Kern):

--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -2,6 +2,7 @@ import numpy as np
 import tensorflow as tf
 from . import transforms
 from contextlib import contextmanager
+from functools import wraps
 
 # when one of these attributes is set, notify a recompilation
 recompile_keys = ['prior', 'transform', 'fixed']
@@ -198,6 +199,8 @@ class Param(Parentable):
         object.__setattr__(self, key, value)
         if key in recompile_keys:
             self.highest_parent._needs_recompile = True
+            if hasattr(self.highest_parent, '_kill_autoflow'):
+                self.highest_parent._kill_autoflow()
 
     def __str__(self, prepend=''):
         return prepend + \
@@ -227,6 +230,78 @@ class Param(Parentable):
                                       else str(self.transform))
         html += "</tr>"
         return html
+
+
+class AutoFlow:
+    """
+    This decorator-class is designed for use on methods of the Parameterized class
+    (below).
+
+    The idea is that methods that compute relevant quantities (such as
+    predictions) can define a tf graph which we automatically run when the
+    (decorated) function is called.
+
+    The syntax looks like:
+
+    >>> class MyClass(Parameterized):
+    >>>
+    >>>   @AutoFlow((tf.float64), (tf.float64))
+    >>>   def my_method(self, x, y):
+    >>>       #compute something, returning a tf graph.
+    >>>       return tf.foo(self.baz, x, y)
+
+    >>> m = MyClass()
+    >>> x = np.random.randn(3,1)
+    >>> y = np.random.randn(3,1)
+    >>> result = my_method(x, y)
+
+    Now the output of the method call is the _result_ of the computation,
+    equivalent to
+
+    >>> m = MyModel()
+    >>> x = np.random.randn(3,1)
+    >>> y = np.random.randn(3,1)
+    >>> x_tf = tf.placeholder(tf.float64)
+    >>> y_tf = tf.placeholder(tf.float64)
+    >>> with m.tf_mode():
+    >>>     graph = tf.foo(m.baz, x_tf, y_tf)
+    >>> result = m._session.run(graph,
+                                feed_dict={x_tf:x,
+                                           y_tf:y,
+                                           m._free_vars:m.get_free_state()})
+
+    Not only is the syntax cleaner, but multiple calls to the method will
+    result in the graph being constructed only once.
+
+    """
+
+    def __init__(self, *tf_arg_tuples):
+        # NB. TF arg_tuples is a list of tuples, each of which can be used to
+        # construct a tf placeholder.
+        self.tf_arg_tuples = tf_arg_tuples
+
+    def __call__(self, tf_method):
+        @wraps(tf_method)
+        def runnable(instance, *np_args):
+            storage_name = '_' + tf_method.__name__ + '_AF_storage'
+            if hasattr(instance, storage_name):
+                # the method has been compiled already, get things out of storage
+                storage = getattr(instance, storage_name)
+            else:
+                # the method needs to be compiled.
+                storage = {}  # an empty dict to keep things in
+                setattr(instance, storage_name, storage)
+                storage['free_vars'] = tf.placeholder(tf.float64, [None])
+                instance.make_tf_array(storage['free_vars'])
+                storage['tf_args'] = [tf.placeholder(*a) for a in self.tf_arg_tuples]
+                with instance.tf_mode():
+                    storage['tf_result'] = tf_method(instance, *storage['tf_args'])
+                storage['session'] = tf.Session()
+            feed_dict = dict(zip(storage['tf_args'], np_args))
+            feed_dict[storage['free_vars']] = instance.get_free_state()
+            return storage['session'].run(storage['tf_result'], feed_dict=feed_dict)
+
+        return runnable
 
 
 class Parameterized(Parentable):
@@ -299,6 +374,7 @@ class Parameterized(Parentable):
             # recompile if necessary.
             if isinstance(p, Param) and isinstance(value, (Param, Parameterized)):
                 p._parent = None  # unlink the old Parameter from this tree
+                self.highest_parent._kill_autoflow()
                 if hasattr(self.highest_parent, '_needs_recompile'):
                     self.highest_parent._needs_recompile = True
 
@@ -308,6 +384,13 @@ class Parameterized(Parentable):
         # make sure a new child node knows this is the _parent:
         if isinstance(value, (Param, Parameterized)) and key is not '_parent':
             value._parent = self
+
+    def _kill_autoflow(self):
+        # remove all AutoFlow storage dicts recursively
+        for key in self.__dict__.keys():
+            if key[0] == '_' and key[-11:] == '_AF_storage':
+                delattr(self, key)
+        [p._kill_autoflow for p in self.sorted_params if isinstance(p, Parameterized)]
 
     def make_tf_array(self, X):
         """


### PR DESCRIPTION
This PR moves the autoflow functionality from the model class to the param class

This was movitated by the desire to compute the kernel matrix without constructing a model.

At the same time, the autoflow mechansim has been simplified: maintainance will hopefully be easier. 