### PR TITLE
Bug-fix in VGP related to mean_function

### DIFF
--- a/GPflow/vgp.py
+++ b/GPflow/vgp.py
@@ -72,7 +72,7 @@ class VGP(GPModel):
 
         with
 
-            q(f) = N(f | K alpha, [K^-1 + diag(square(lambda))]^-1) .
+            q(f) = N(f | K alpha + mean, [K^-1 + diag(square(lambda))]^-1) .
 
         """
         K = self.kern.K(self.X)
@@ -108,12 +108,12 @@ class VGP(GPModel):
         """
         The posterior variance of F is given by
 
-            q(f) = N(f | K alpha, [K^-1 + diag(lambda**2)]^-1)
+            q(f) = N(f | K alpha + mean, [K^-1 + diag(lambda**2)]^-1)
 
         Here we project this to F*, the values of the GP at Xnew which is given
         by
 
-           q(F*) = N ( F* | K_{*F} alpha , K_{**} - K_{*f}[K_{ff} +
+           q(F*) = N ( F* | K_{*F} alpha + mean, K_{**} - K_{*f}[K_{ff} +
                                            diag(lambda**-2)]^-1 K_{f*} )
 
         """

--- a/testing/test_method_equivalence.py
+++ b/testing/test_method_equivalence.py
@@ -25,20 +25,27 @@ class TestEquivalence(unittest.TestCase):
         Y = np.sin(X) + 0.9 * np.cos(X*1.6) + rng.randn(*X.shape)* 0.8
         self.Xtest = rng.rand(10,1)*10
 
-        m1 = GPflow.gpr.GPR(X, Y, kern=GPflow.kernels.RBF(1))
-        m2 = GPflow.vgp.VGP(X, Y, GPflow.kernels.RBF(1), likelihood=GPflow.likelihoods.Gaussian())
+        m1 = GPflow.gpr.GPR(X, Y, kern=GPflow.kernels.RBF(1),\
+                                mean_function=GPflow.mean_functions.Constant())                                
+        m2 = GPflow.vgp.VGP(X, Y, GPflow.kernels.RBF(1), likelihood=GPflow.likelihoods.Gaussian(),\
+                                mean_function=GPflow.mean_functions.Constant())
         m3 = GPflow.svgp.SVGP(X, Y, GPflow.kernels.RBF(1),
                               likelihood=GPflow.likelihoods.Gaussian(),
-                              Z=X.copy(), q_diag=False)
+                              Z=X.copy(), q_diag=False,\
+                              mean_function=GPflow.mean_functions.Constant())
         m3.Z.fixed = True
         m4 = GPflow.svgp.SVGP(X, Y, GPflow.kernels.RBF(1),
                               likelihood=GPflow.likelihoods.Gaussian(),
-                              Z=X.copy(), q_diag=False, whiten=True)
+                              Z=X.copy(), q_diag=False, whiten=True,\
+                              mean_function=GPflow.mean_functions.Constant())
         m4.Z.fixed=True
         m5 = GPflow.sgpr.SGPR(X, Y, GPflow.kernels.RBF(1),
-                              Z=X.copy())
+                              Z=X.copy(),\
+                              mean_function=GPflow.mean_functions.Constant())
+                              
         m5.Z.fixed = True
-        m6 = GPflow.sgpr.GPRFITC(X, Y, GPflow.kernels.RBF(1), Z=X.copy())
+        m6 = GPflow.sgpr.GPRFITC(X, Y, GPflow.kernels.RBF(1), Z=X.copy(),\
+                              mean_function=GPflow.mean_functions.Constant())
         m6.Z.fixed = True
         self.models = [m1, m2, m3, m4, m5, m6]
         for m in self.models:
@@ -57,8 +64,8 @@ class TestEquivalence(unittest.TestCase):
                 variances.append(m.kern.variance.value)
                 lengthscales.append(m.kern.lengthscales.value)
         variances, lengthscales = np.array(variances), np.array(lengthscales)
-
-        self.failUnless(np.allclose(variances, variances[0], 1e-3))
+        
+        self.failUnless(np.allclose(variances, variances[0], 1e-3))            
         self.failUnless(np.allclose(lengthscales, lengthscales[0], 1e-3))
         mu0, var0 = self.models[0].predict_y(self.Xtest)
         for m in self.models[1:]:


### PR DESCRIPTION
Hi all.

I guess there is a bug in VGP related to mean_function.
The following in VGP.build_likelihood() may be wrong.
`f_mean = tf.matmul(K, self.q_alpha) + self.mean_function(self.X)`
`KL = 0.5 * (A_logdet + trAi - self.num_data * self.num_latent+ tf.reduce_sum(f_mean*self.q_alpha))`
Especially -> `f_mean*self.q_alpha`

I think this term should be like
`(f_mean - mean_function) K^{-1} (f_mean - mean_function)`
but the current implementation is equivalent to
`(f_mean) K^{-1} (f_mean - mean_function)`
This makes `VGP.optimize()` diverge.
 
I also modified test_method_equivalence.py to include mean_function.