### PR TITLE
Track logprobs

### DIFF
--- a/GPflow/model.py
+++ b/GPflow/model.py
@@ -152,7 +152,7 @@ class Model(Parameterized):
     def compute_log_likelihood(self):
         return self.build_likelihood()
 
-    def sample(self, num_samples, Lmax=20, epsilon=0.01, verbose=False):
+    def sample(self, num_samples, Lmax=20, epsilon=0.01, verbose=False, return_logprobs=False, RNG=np.random.RandomState(0)):
         """
         Use Hamiltonian Monte Carlo to draw samples from the model posterior.
         """
@@ -160,7 +160,8 @@ class Model(Parameterized):
             self._compile()
         return hmc.sample_HMC(self._objective, num_samples,
                               Lmax, epsilon,
-                              x0=self.get_free_state(), verbose=verbose)
+                              x0=self.get_free_state(), verbose=verbose,
+                              return_logprobs=return_logprobs, RNG=RNG)
 
     def optimize(self, method='L-BFGS-B', tol=None, callback=None,
                  max_iters=1000, **kw):

--- a/testing/test_hmc.py
+++ b/testing/test_hmc.py
@@ -45,6 +45,16 @@ class SampleGaussianTest(unittest.TestCase):
         self.failUnless(samples.shape == (100, 3))
         self.failIf(np.all(samples[0] == self.x0))
 
+    def test_return_logprobs(self):
+        _ = GPflow.hmc.sample_HMC(self.f, num_samples=100, Lmax=20, epsilon=0.05,
+                                  x0=self.x0, verbose=False, thin=1, burn=10,
+                                  RNG=np.random.RandomState(11))
+        _, logps = GPflow.hmc.sample_HMC(self.f, num_samples=100, Lmax=20, epsilon=0.05,
+                                         x0=self.x0, verbose=False, thin=1, burn=10,
+                                         RNG=np.random.RandomState(11), return_logprobs=True)
+
+
+
 
 class SampleModelTest(unittest.TestCase):
     """

--- a/testing/test_hmc.py
+++ b/testing/test_hmc.py
@@ -46,10 +46,7 @@ class SampleGaussianTest(unittest.TestCase):
         self.failIf(np.all(samples[0] == self.x0))
 
     def test_return_logprobs(self):
-        _ = GPflow.hmc.sample_HMC(self.f, num_samples=100, Lmax=20, epsilon=0.05,
-                                  x0=self.x0, verbose=False, thin=1, burn=10,
-                                  RNG=np.random.RandomState(11))
-        _, logps = GPflow.hmc.sample_HMC(self.f, num_samples=100, Lmax=20, epsilon=0.05,
+        s, logps = GPflow.hmc.sample_HMC(self.f, num_samples=100, Lmax=20, epsilon=0.05,
                                          x0=self.x0, verbose=False, thin=1, burn=10,
                                          RNG=np.random.RandomState(11), return_logprobs=True)
 
@@ -74,10 +71,13 @@ class SampleModelTest(unittest.TestCase):
         self.m = Quadratic()
 
     def test_mean(self):
-        samples = self.m.sample(num_samples=200, Lmax=20, epsilon=0.05)
+        samples = self.m.sample(num_samples=400, Lmax=20, epsilon=0.05)
 
-        self.failUnless(samples.shape == (200, 2))
+        self.failUnless(samples.shape == (400, 2))
         self.failUnless(np.allclose(samples.mean(0), np.zeros(2), 1e-1, 1e-1))
+
+    def test_return_logprobs(self):
+        s, logps = self.m.sample(num_samples=200, Lmax=20, epsilon=0.05, return_logprobs=True)
 
 
 class SamplesDictTest(unittest.TestCase):


### PR DESCRIPTION
Adding a simple boolean that returns the log-densities alongside the samples during HMC. these are useful for some diagnostics and model comparison (e.g. DIC). 