### PR TITLE
DataHolderList

### DIFF
--- a/GPflow/data_holders.py
+++ b/GPflow/data_holders.py
@@ -223,16 +223,22 @@ class DataHolderList(DataHolder):
     def append(self, data_holder):
         """
         method to append a data holder
+        :param DatHolder data_holder: a data_holder to be stored.
         """
         self._data_holders.append(data_holder)
 
 
-    def set_data(self, arrays):
+    def set_data(self, array_list):
         """
-        Set the data into data_holders.
+        Set the a array_list into each data_holder.
+        :param list array_list: list of np.array. The length of the list
+            must match to self._data_holders
         """
-        assert(len(self._data_holders) == len(arrays))
-        for (data_holder, array) in zip(self._data_holders, arrays):
+        # TODO If length changes, better to raise recompile flag?
+        if len(self._data_holders) != len(array_list):
+            raise IndexError("length of array_list must match")
+
+        for (data_holder, array) in zip(self._data_holders, array_list):
             data_holder.set_data(array)
 
 
@@ -261,11 +267,7 @@ class DataHolderList(DataHolder):
         """
         Don't overload __getstate___ from DictData
         """
-        d = Parentable.__getstate__(self)
-
-    def __setstate__(self, d):
-        for d in self._data_holders:
-            d.__setstate__(self, d)
+        return Parentable.__getstate__(self)
 
     def __str__(self, prepend='Data:'):
         # TODO what should be demanded for __str__ for DataHolderList?

--- a/GPflow/data_holders.py
+++ b/GPflow/data_holders.py
@@ -167,7 +167,7 @@ class ScalarData(DataHolder):
     """
     def __init__(self, scalar):
         DataHolder.__init__(self)
-        self.value = scalar
+        self._scalar = scalar
 
         # manual guess for dtype. It may not a very good solution
         if isinstance(scalar, int):
@@ -187,11 +187,15 @@ class ScalarData(DataHolder):
 
     def __setstate__(self, d):
         DataHolder.__setstate__(self, d)
-        tf_array = tf.placeholder(self.value, name=self.name)
+        tf_array = tf.placeholder(self._scalar, name=self.name)
         self._tf_array = tf_array
 
     def get_feed_dict(self):
         return {self._tf_array: self.value}
+
+    @property
+    def value(self):
+        return self._scalar
 
 
 class DataHolderList(DataHolder):

--- a/testing/test_data_object.py
+++ b/testing/test_data_object.py
@@ -62,6 +62,23 @@ class TestScalarData(unittest.TestCase):
             value = tf.Session().run(self.model.X*self.model.Y, feed_dict=feed_dict)
         self.assertTrue(np.allclose(self.model.X.value*self.model.Y.value, value))
 
+    def test_type(self):
+        X = ScalarData(1)
+        feed_dict = X.get_feed_dict()
+        self.assertTrue(X._tf_array.dtype, tf.int32)
+        Y = ScalarData(1.0)
+        feed_dict = X.get_feed_dict()
+        self.assertTrue(X._tf_array.dtype, tf.float64)
+
+    def test_pickle(self):
+        s = pickle.dumps(self.model)
+        pickle.loads(s)
+
+    def test_set_data(self):
+        self.model.X.set_data(1.0)
+        self.assertTrue(self.model.X.value == 1.0)
+
+
 class TestDataHolderList(unittest.TestCase):
     def setUp(self):
         self.model = GPflow.param.Parameterized()


### PR DESCRIPTION
Hi.

Related #138 
I added DataHolderList to data_holders.py, which handles multiple DataHolders as a list.
append, __iter__, __getitem__ methods are prepared just like a normal list.
ScalarData is a simple DataHolder to handle a scalar, not np.array.

This PR is a part of #138, and meant for the easier review.