### PR TITLE
Auto data flow

### DIFF
--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -3,6 +3,7 @@ from functools import reduce
 import tensorflow as tf
 import numpy as np
 from .param import Param, Parameterized, AutoFlow
+from .data_holders import DictData
 from . import transforms
 
 
@@ -42,11 +43,11 @@ class Kern(Parameterized):
     def __mul__(self, other):
         return Prod([self, other])
 
-    @AutoFlow((tf.float64, [None, None]), (tf.float64, [None, None]))
+    @AutoFlow(DictData, DictData)
     def compute_K(self, X, Z):
         return self.K(X, Z)
 
-    @AutoFlow((tf.float64, [None, None]))
+    @AutoFlow(DictData)
     def compute_K_symm(self, X):
         return self.K(X)
 

--- a/GPflow/model.py
+++ b/GPflow/model.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 from .param import Parameterized, AutoFlow
-from .data_holders import DictData
+from .data_holders import DictData, ScalarData
 from scipy.optimize import minimize, OptimizeResult
 import numpy as np
 import tensorflow as tf
@@ -326,7 +326,7 @@ class GPModel(Model):
     def build_predict(self):
         raise NotImplementedError
 
-    @AutoFlow((tf.float64, [None, None]))
+    @AutoFlow(DictData)
     def predict_f(self, Xnew):
         """
         Compute the mean and variance of the latent function(s) at the points
@@ -334,7 +334,7 @@ class GPModel(Model):
         """
         return self.build_predict(Xnew)
 
-    @AutoFlow((tf.float64, [None, None]))
+    @AutoFlow(DictData)
     def predict_f_full_cov(self, Xnew):
         """
         Compute the mean and covariance matrix of the latent function(s) at the
@@ -342,7 +342,7 @@ class GPModel(Model):
         """
         return self.build_predict(Xnew, full_cov=True)
 
-    @AutoFlow((tf.float64, [None, None]), (tf.int32, []))
+    @AutoFlow(DictData, ScalarData)
     def predict_f_samples(self, Xnew, num_samples):
         """
         Produce samples from the posterior latent function(s) at the points
@@ -358,7 +358,7 @@ class GPModel(Model):
             samples.append(mu[:, i:i + 1] + tf.matmul(L, V))
         return tf.transpose(tf.pack(samples))
 
-    @AutoFlow((tf.float64, [None, None]))
+    @AutoFlow(DictData)
     def predict_y(self, Xnew):
         """
         Compute the mean and variance of held-out data at the points Xnew
@@ -366,7 +366,7 @@ class GPModel(Model):
         pred_f_mean, pred_f_var = self.build_predict(Xnew)
         return self.likelihood.predict_mean_and_var(pred_f_mean, pred_f_var)
 
-    @AutoFlow((tf.float64, [None, None]), (tf.float64, [None, None]))
+    @AutoFlow(DictData, DictData)
     def predict_density(self, Xnew, Ynew):
         """
         Compute the (log) density of the data Ynew at the points Xnew

--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from functools import wraps
 from . import transforms
 from .tree_structure import Parentable
-from .data_holders import DataHolder
+from .data_holders import DataHolder, DictData, ScalarData, DataHolderList
 
 # when one of these attributes is set, notify a recompilation
 recompile_keys = ['prior', 'transform', 'fixed']
@@ -277,7 +277,7 @@ class AutoFlow:
 
     >>> class MyClass(Parameterized):
     >>>
-    >>>   @AutoFlow((tf.float64), (tf.float64))
+    >>>   @AutoFlow(DictData, DictData)
     >>>   def my_method(self, x, y):
     >>>       #compute something, returning a tf graph.
     >>>       return tf.foo(self.baz, x, y)
@@ -306,11 +306,10 @@ class AutoFlow:
     result in the graph being constructed only once.
 
     """
-
-    def __init__(self, *tf_arg_tuples):
+    def __init__(self, *data_classes):
         # NB. TF arg_tuples is a list of tuples, each of which can be used to
         # construct a tf placeholder.
-        self.tf_arg_tuples = tf_arg_tuples
+        self.data_classes= data_classes
 
     def __call__(self, tf_method):
         @wraps(tf_method)
@@ -323,19 +322,57 @@ class AutoFlow:
                 # the method needs to be compiled.
                 storage = {}  # an empty dict to keep things in
                 setattr(instance, storage_name, storage)
+                # storage dict_data for the arguments
+                storage['data_holder_list'] = DataHolderList()
+                for data_class, np_arg in zip(self.data_classes, np_args):
+                    storage['data_holder_list'].append(\
+                        self.get_a_data_holder(data_class, np_arg, instance))
+
                 storage['free_vars'] = tf.placeholder(tf.float64, [None])
                 instance.make_tf_array(storage['free_vars'])
-                storage['tf_args'] = [tf.placeholder(*a) for a in self.tf_arg_tuples]
+
+                # tf_array is passed to the tf_method
                 with instance.tf_mode():
-                    storage['tf_result'] = tf_method(instance, *storage['tf_args'])
+                    storage['tf_result'] = tf_method(instance, *storage['data_holder_list']._tf_array)
+
                 storage['session'] = tf.Session()
                 storage['session'].run(tf.initialize_all_variables(), feed_dict=instance.get_feed_dict())
-            feed_dict = dict(zip(storage['tf_args'], np_args))
+
+            # set array into dict_data
+            for d, np_arg in zip(storage['data_holder_list'], np_args):
+                self.set_to_data_holder(d, np_arg)
+
+            feed_dict = instance.get_feed_dict()
             feed_dict[storage['free_vars']] = instance.get_free_state()
-            feed_dict.update(instance.get_feed_dict())
+            feed_dict.update(storage['data_holder_list'].get_feed_dict())
             return storage['session'].run(storage['tf_result'], feed_dict=feed_dict)
 
         return runnable
+
+
+    def get_a_data_holder(self, data_class, np_arg, instance=None):
+        """
+        A method to create a DataHolder from data_class and np_arg.
+        data_class : an object that inherites from DataHolder.
+        np_array : an np.array (or a tuple of arguments) that will be passed
+                                                        to the DataHolder
+
+        instance : passed for the future extensions.
+        """
+        if data_class == DictData:
+            return DictData(np_arg, on_shape_change ='pass')
+        elif data_class == ScalarData:
+            return ScalarData(np_arg)
+        else:
+            raise Exception(str(data_class)+' is not implemented in AutoFlow.')
+
+
+    def set_to_data_holder(self, data_holder, np_arg):
+        """
+        A method to set array into data holder.
+        """
+        if isinstance(data_holder, (DictData, ScalarData)):
+            data_holder.set_data(np_arg)
 
 
 class Parameterized(Parentable):
@@ -435,7 +472,7 @@ class Parameterized(Parentable):
                     self.highest_parent._needs_recompile = True
 
             # if the existing atribute is a DataHolder, set the value of the data inside
-            if isinstance(p, DataHolder) and isinstance(value, np.ndarray):
+            if isinstance(p, DataHolder) and isinstance(value, (np.ndarray, list, tuple)):
                 p.set_data(value)
                 return  # don't call object.setattr or set the _parent value
 
@@ -456,7 +493,7 @@ class Parameterized(Parentable):
         required, this function recurses the structure removing all AutoFlow
         dicts. Subsequent calls to to those functions will casue AutoFlow to regenerate.
         """
-        for key in self.__dict__.keys():
+        for key in list(self.__dict__):
             if key[0] == '_' and key[-11:] == '_AF_storage':
                 delattr(self, key)
         [p._kill_autoflow() for p in self.sorted_params if isinstance(p, Parameterized)]

--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -364,7 +364,7 @@ class AutoFlow:
         elif data_class == ScalarData:
             return ScalarData(np_arg)
         else:
-            raise Exception(str(data_class)+' is not implemented in AutoFlow.')
+            raise TypeError(str(data_class)+' is not accepted by AutoFlow.')
 
 
     def set_to_data_holder(self, data_holder, np_arg):

--- a/testing/test_autoflow.py
+++ b/testing/test_autoflow.py
@@ -42,7 +42,7 @@ class TestNoArgs(unittest.TestCase):
 
         keys = [k for k in self.m.__dict__.keys() if k[-11:] == '_AF_storage']
         self.assertTrue(len(keys) == 0, msg="no AF storage should be present after recompile switch set.")
-        
+
 
 class AddModel(DumbModel):
     @GPflow.model.AutoFlow(GPflow.data_holders.DictData, GPflow.data_holders.DictData)
@@ -89,7 +89,7 @@ class MulModel(DumbModel):
     @GPflow.model.AutoFlow(GPflow.data_holders.DictData, GPflow.data_holders.ScalarData)
     def mul(self, x, y):
         return tf.mul(x, y)
-        
+
 class TestScalar(unittest.TestCase):
     def setUp(self):
         tf.reset_default_graph()
@@ -101,7 +101,26 @@ class TestScalar(unittest.TestCase):
 
     def test_scalar(self):
         self.assertTrue(np.allclose(self.x * self.y, self.m.mul(self.x, self.y)))
-        
+
+class RaiseModel(DumbModel):
+    # This raises error because it is not a default data class, DictData or ScalarData
+    @GPflow.model.AutoFlow(GPflow.data_holders.DictData, GPflow.data_holders.DataHolder)
+    def mul(self, x, y):
+        return tf.mul(x, y)
+
+class TestRaise(unittest.TestCase):
+    def setUp(self):
+        tf.reset_default_graph()
+        self.m = RaiseModel()
+        self.m._compile()
+        rng = np.random.RandomState(0)
+        self.x = rng.randn(10, 20)
+        self.y = 10.0
+
+    def test_scalar(self):
+        with self.assertRaises(TypeError):
+            self.m.mul(self.x, self.y)
+
 
 class TestGPmodel(unittest.TestCase):
     def setUp(self):

--- a/testing/test_autoflow.py
+++ b/testing/test_autoflow.py
@@ -42,10 +42,10 @@ class TestNoArgs(unittest.TestCase):
 
         keys = [k for k in self.m.__dict__.keys() if k[-11:] == '_AF_storage']
         self.assertTrue(len(keys) == 0, msg="no AF storage should be present after recompile switch set.")
-
+        
 
 class AddModel(DumbModel):
-    @GPflow.model.AutoFlow((tf.float64,), (tf.float64,))
+    @GPflow.model.AutoFlow(GPflow.data_holders.DictData, GPflow.data_holders.DictData)
     def add(self, x, y):
         return tf.add(x, y)
 
@@ -82,8 +82,26 @@ class TestAdd(unittest.TestCase):
         self.y = rng.randn(10, 20)
 
     def test_add(self):
-        self.failUnless(np.allclose(self.x + self.y, self.m.add(self.x, self.y)))
+        self.assertTrue(np.allclose(self.x + self.y, self.m.add(self.x, self.y)))
 
+
+class MulModel(DumbModel):
+    @GPflow.model.AutoFlow(GPflow.data_holders.DictData, GPflow.data_holders.ScalarData)
+    def mul(self, x, y):
+        return tf.mul(x, y)
+        
+class TestScalar(unittest.TestCase):
+    def setUp(self):
+        tf.reset_default_graph()
+        self.m = MulModel()
+        self.m._compile()
+        rng = np.random.RandomState(0)
+        self.x = rng.randn(10, 20)
+        self.y = 10.0
+
+    def test_scalar(self):
+        self.assertTrue(np.allclose(self.x * self.y, self.m.mul(self.x, self.y)))
+        
 
 class TestGPmodel(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Also related to #138 

This is PR for the review of my AutoFlow modification.

I want to use a DataHolder in AutoFlow rather than a simple placeholder, and make it possible to change the behavior of the AutoFlow in its child class.

The main purpose of this modification is to make it possible to pass an object other than tf.placeholder to the predictive method such as `model.predict_f()`.
In my coregionalized model implementation, I want to pass an object that include a coordinate vector, task index as well as some methods to sort, split and merge, in a child class of AutoFlow ([LabeledAutoFlow](https://github.com/GPflow/GPflow/blob/32590b7ea7963651de493ea5c5cd6e147ed9764c/GPflow/coregionalized/param.py) in #138).

I would be very great if anyone review this codes and comment if this change is acceptable or not.
If not, I will consider alternatives.