### PR TITLE
Get tests working with Python 3

### DIFF
--- a/testing/test_autoflow.py
+++ b/testing/test_autoflow.py
@@ -26,7 +26,7 @@ class TestNoArgs(unittest.TestCase):
         self.m._compile()
 
     def test_return(self):
-        self.failUnless(np.allclose(self.m.function(), 3.))
+        self.assertTrue(np.allclose(self.m.function(), 3.))
 
     def test_kill(self):
         # make sure autoflow dicts are removed when _needs_recompile is set.
@@ -82,7 +82,7 @@ class TestAdd(unittest.TestCase):
         self.y = rng.randn(10, 20)
 
     def test_add(self):
-        self.failUnless(np.allclose(self.x + self.y, self.m.add(self.x, self.y)))
+        self.assertTrue(np.allclose(self.x + self.y, self.m.add(self.x, self.y)))
 
 
 class TestGPmodel(unittest.TestCase):

--- a/testing/test_conditionals.py
+++ b/testing/test_conditionals.py
@@ -53,8 +53,8 @@ class DiagsTest(unittest.TestCase):
         mean_diff = tf.Session().run(Fstar_mean_1 - Fstar_mean_2, feed_dict=self.feed_dict)
         var_diff = tf.Session().run(Fstar_var_1 - Fstar_var_2, feed_dict=self.feed_dict)
 
-        self.failUnless(np.allclose(mean_diff, 0))
-        self.failUnless(np.allclose(var_diff, 0))
+        self.assertTrue(np.allclose(mean_diff, 0))
+        self.assertTrue(np.allclose(var_diff, 0))
 
 
     def test_nonwhiten(self):
@@ -65,8 +65,8 @@ class DiagsTest(unittest.TestCase):
         mean_diff = tf.Session().run(Fstar_mean_1 - Fstar_mean_2, feed_dict=self.feed_dict)
         var_diff = tf.Session().run(Fstar_var_1 - Fstar_var_2, feed_dict=self.feed_dict)
 
-        self.failUnless(np.allclose(mean_diff, 0))
-        self.failUnless(np.allclose(var_diff, 0))
+        self.assertTrue(np.allclose(mean_diff, 0))
+        self.assertTrue(np.allclose(var_diff, 0))
 
 
 class WhitenTest(unittest.TestCase):
@@ -114,8 +114,8 @@ class WhitenTest(unittest.TestCase):
         mean1, var1 = tf.Session().run([Fstar_w_mean, Fstar_w_var], feed_dict=self.feed_dict)
         mean2, var2 = tf.Session().run([Fstar_mean, Fstar_var], feed_dict=self.feed_dict)
 
-        self.failUnless(np.allclose(mean1, mean2))
-        self.failUnless(np.allclose(var1, var2))
+        self.assertTrue(np.allclose(mean1, mean2))
+        self.assertTrue(np.allclose(var1, var2))
 
 
 class WhitenTestGaussian(WhitenTest):
@@ -145,8 +145,8 @@ class WhitenTestGaussian(WhitenTest):
         mean_difference = tf.Session().run(Fstar_w_mean - Fstar_mean, feed_dict=self.feed_dict)
         var_difference = tf.Session().run(Fstar_w_var - Fstar_var, feed_dict=self.feed_dict)
 
-        self.failUnless(np.all(np.abs(mean_difference) < 1e-4))
-        self.failUnless(np.all(np.abs(var_difference) < 1e-4))
+        self.assertTrue(np.all(np.abs(mean_difference) < 1e-4))
+        self.assertTrue(np.all(np.abs(var_difference) < 1e-4))
 
        
 

--- a/testing/test_hmc.py
+++ b/testing/test_hmc.py
@@ -15,8 +15,8 @@ class SampleGaussianTest(unittest.TestCase):
                                         x0=self.x0, verbose=False, thin=10, burn=0)
         mean = samples.mean(0)
         cov = np.cov(samples.T)
-        self.failUnless(np.allclose(mean, np.zeros(3), 1e-1, 1e-1))
-        self.failUnless(np.allclose(cov, np.eye(3), 1e-1, 1e-1))
+        self.assertTrue(np.allclose(mean, np.zeros(3), 1e-1, 1e-1))
+        self.assertTrue(np.allclose(cov, np.eye(3), 1e-1, 1e-1))
 
     def test_rng(self):
         """
@@ -34,16 +34,16 @@ class SampleGaussianTest(unittest.TestCase):
                                          x0=self.x0, verbose=False, thin=10, burn=0,
                                          RNG=np.random.RandomState(11))
 
-        self.failUnless(np.all(samples1 == samples2))
-        self.failIf(np.all(samples1 == samples3))
+        self.assertTrue(np.all(samples1 == samples2))
+        self.assertFalse(np.all(samples1 == samples3))
 
     def test_burn(self):
         samples = GPflow.hmc.sample_HMC(self.f, num_samples=100, Lmax=20, epsilon=0.05,
                                         x0=self.x0, verbose=False, thin=1, burn=10,
                                         RNG=np.random.RandomState(11))
 
-        self.failUnless(samples.shape == (100, 3))
-        self.failIf(np.all(samples[0] == self.x0))
+        self.assertTrue(samples.shape == (100, 3))
+        self.assertFalse(np.all(samples[0] == self.x0))
 
     def test_return_logprobs(self):
         s, logps = GPflow.hmc.sample_HMC(self.f, num_samples=100, Lmax=20, epsilon=0.05,
@@ -73,8 +73,8 @@ class SampleModelTest(unittest.TestCase):
     def test_mean(self):
         samples = self.m.sample(num_samples=400, Lmax=20, epsilon=0.05)
 
-        self.failUnless(samples.shape == (400, 2))
-        self.failUnless(np.allclose(samples.mean(0), np.zeros(2), 1e-1, 1e-1))
+        self.assertTrue(samples.shape == (400, 2))
+        self.assertTrue(np.allclose(samples.mean(0), np.zeros(2), 1e-1, 1e-1))
 
     def test_return_logprobs(self):
         s, logps = self.m.sample(num_samples=200, Lmax=20, epsilon=0.05, return_logprobs=True)

--- a/testing/test_kerns.py
+++ b/testing/test_kerns.py
@@ -2,7 +2,7 @@ import GPflow
 import tensorflow as tf
 import numpy as np
 import unittest
-from reference import referenceRbfKernel, referencePeriodicKernel
+from .reference import referenceRbfKernel, referencePeriodicKernel
 
 
 class TestRbf(unittest.TestCase):
@@ -22,7 +22,7 @@ class TestRbf(unittest.TestCase):
 
         with kernel.tf_mode():
             gram_matrix = tf.Session().run(kernel.K(X), feed_dict={x_free: kernel.get_free_state(), X: X_data})
-        self.failUnless(np.allclose(gram_matrix-reference_gram_matrix, 0))
+        self.assertTrue(np.allclose(gram_matrix-reference_gram_matrix, 0))
 
 
 class TestPeriodic(unittest.TestCase):
@@ -37,7 +37,7 @@ class TestPeriodic(unittest.TestCase):
         with kernel.tf_mode():
             gram_matrix = tf.Session().run(kernel.K(X),
                                            feed_dict={x_free: kernel.get_free_state(), X: X_data})
-        self.failUnless(np.allclose(gram_matrix-reference_gram_matrix, 0))
+        self.assertTrue(np.allclose(gram_matrix-reference_gram_matrix, 0))
 
     def test_1d(self):
         D = 1
@@ -76,7 +76,7 @@ class TestKernSymmetry(unittest.TestCase):
             with k.tf_mode():
                 Errors = tf.Session().run(k.K(X) - k.K(X, X),
                                           feed_dict={x_free: k.get_free_state(), X: X_data})
-                self.failUnless(np.allclose(Errors, 0))
+                self.assertTrue(np.allclose(Errors, 0))
 
     def test_5d(self):
         kernels = [K(5) for K in self.kernels]
@@ -88,7 +88,7 @@ class TestKernSymmetry(unittest.TestCase):
             with k.tf_mode():
                 Errors = tf.Session().run(k.K(X) - k.K(X, X),
                                           feed_dict={x_free: k.get_free_state(), X: X_data})
-                self.failUnless(np.allclose(Errors, 0))
+                self.assertTrue(np.allclose(Errors, 0))
 
 
 class TestKernDiags(unittest.TestCase):
@@ -116,7 +116,7 @@ class TestKernDiags(unittest.TestCase):
                 k2 = tf.diag_part(k.K(self.X))
                 k1, k2 = tf.Session().run([k1, k2],
                                           feed_dict={self.x_free: k.get_free_state(), self.X: self.X_data})
-            self.failUnless(np.allclose(k1, k2))
+            self.assertTrue(np.allclose(k1, k2))
 
 
 class TestAdd(unittest.TestCase):
@@ -140,7 +140,7 @@ class TestAdd(unittest.TestCase):
             with k.tf_mode():
                 k._K = tf.Session().run(k.K(X), feed_dict={x_free: k.get_free_state(), X: X_data})
 
-        self.failUnless(np.allclose(self.rbf._K + self.lin._K, self.k._K))
+        self.assertTrue(np.allclose(self.rbf._K + self.lin._K, self.k._K))
 
     def test_asym(self):
         x_free = tf.placeholder('float64')
@@ -153,7 +153,7 @@ class TestAdd(unittest.TestCase):
             with k.tf_mode():
                 k._K = tf.Session().run(k.K(X), feed_dict={x_free: k.get_free_state(), X: X_data, Z: Z_data})
 
-        self.failUnless(np.allclose(self.rbf._K + self.lin._K, self.k._K))
+        self.assertTrue(np.allclose(self.rbf._K + self.lin._K, self.k._K))
 
 
 class TestWhite(unittest.TestCase):
@@ -175,7 +175,7 @@ class TestWhite(unittest.TestCase):
             K_sym = tf.Session().run(self.k.K(X), feed_dict={x_free: self.k.get_free_state(), X: X_data})
             K_asym = tf.Session().run(self.k.K(X, X), feed_dict={x_free: self.k.get_free_state(), X: X_data})
 
-        self.failIf(np.allclose(K_sym, K_asym))
+        self.assertFalse(np.allclose(K_sym, K_asym))
 
 
 class TestSlice(unittest.TestCase):
@@ -197,16 +197,16 @@ class TestSlice(unittest.TestCase):
         K2 = self.k2.compute_K_symm(self.X)
         K3 = self.k3.compute_K_symm(self.X[:, :1])
         K4 = self.k3.compute_K_symm(self.X[:, 1:])
-        self.failUnless(np.allclose(K1, K3))
-        self.failUnless(np.allclose(K2, K4))
+        self.assertTrue(np.allclose(K1, K3))
+        self.assertTrue(np.allclose(K2, K4))
 
     def test_asymm(self):
         K1 = self.k1.compute_K(self.X, self.Z)
         K2 = self.k2.compute_K(self.X, self.Z)
         K3 = self.k3.compute_K(self.X[:, :1], self.Z[:, :1])
         K4 = self.k3.compute_K(self.X[:, 1:], self.Z[:, 1:])
-        self.failUnless(np.allclose(K1, K3))
-        self.failUnless(np.allclose(K2, K4))
+        self.assertTrue(np.allclose(K1, K3))
+        self.assertTrue(np.allclose(K2, K4))
 
 
 class TestProd(unittest.TestCase):
@@ -235,7 +235,7 @@ class TestProd(unittest.TestCase):
                     self.k3.make_tf_array(self.x_free)
                     K3 = self.k3.K(self.X)
                     K3 = tf.Session().run(K3, feed_dict={self.X: self.X_data, self.x_free: self.k3.get_free_state()})
-        self.failUnless(np.allclose(K1 * K2, K3))
+        self.assertTrue(np.allclose(K1 * K2, K3))
 
 
 class TestARDActiveProd(unittest.TestCase):
@@ -267,7 +267,7 @@ class TestARDActiveProd(unittest.TestCase):
                 K1 = tf.Session().run(K1, feed_dict={self.X: self.X_data, self.x_free: self.k3.get_free_state()})
                 K2 = tf.Session().run(K2, feed_dict={self.X: self.X_data, self.x_free: self.k3a.get_free_state()})
 
-        self.failUnless(np.allclose(K1, K2))
+        self.assertTrue(np.allclose(K1, K2))
 
 
 class TestKernNaming(unittest.TestCase):
@@ -277,9 +277,9 @@ class TestKernNaming(unittest.TestCase):
         k3 = k1 + k2
         k4 = GPflow.kernels.Matern32(1)
         k5 = k3 + k4
-        self.failUnless(k5.rbf is k1)
-        self.failUnless(k5.linear is k2)
-        self.failUnless(k5.matern32 is k4)
+        self.assertTrue(k5.rbf is k1)
+        self.assertTrue(k5.linear is k2)
+        self.assertTrue(k5.matern32 is k4)
 
     def test_no_nesting_2(self):
         k1 = GPflow.kernels.RBF(1) + GPflow.kernels.Linear(2)
@@ -287,33 +287,33 @@ class TestKernNaming(unittest.TestCase):
         k2 = GPflow.kernels.Matern32(1) + GPflow.kernels.Matern52(2)
 
         k = k1 + k2
-        self.failUnless(hasattr(k, 'rbf'))
-        self.failUnless(hasattr(k, 'linear'))
-        self.failUnless(hasattr(k, 'matern32'))
-        self.failUnless(hasattr(k, 'matern52'))
+        self.assertTrue(hasattr(k, 'rbf'))
+        self.assertTrue(hasattr(k, 'linear'))
+        self.assertTrue(hasattr(k, 'matern32'))
+        self.assertTrue(hasattr(k, 'matern52'))
 
     def test_simple(self):
         k1 = GPflow.kernels.RBF(1)
         k2 = GPflow.kernels.Linear(2)
         k = k1 + k2
-        self.failUnless(k.rbf is k1)
-        self.failUnless(k.linear is k2)
+        self.assertTrue(k.rbf is k1)
+        self.assertTrue(k.linear is k2)
 
     def test_duplicates_1(self):
         k1 = GPflow.kernels.Matern32(1)
         k2 = GPflow.kernels.Matern32(43)
         k = k1 + k2
-        self.failUnless(k.matern32_1 is k1)
-        self.failUnless(k.matern32_2 is k2)
+        self.assertTrue(k.matern32_1 is k1)
+        self.assertTrue(k.matern32_2 is k2)
 
     def test_duplicates_2(self):
         k1 = GPflow.kernels.Matern32(1)
         k2 = GPflow.kernels.Matern32(2)
         k3 = GPflow.kernels.Matern32(3)
         k = k1 + k2 + k3
-        self.failUnless(k.matern32_1 is k1)
-        self.failUnless(k.matern32_2 is k2)
-        self.failUnless(k.matern32_3 is k3)
+        self.assertTrue(k.matern32_1 is k1)
+        self.assertTrue(k.matern32_2 is k2)
+        self.assertTrue(k.matern32_3 is k3)
 
 
 class TestKernNamingProduct(unittest.TestCase):
@@ -323,9 +323,9 @@ class TestKernNamingProduct(unittest.TestCase):
         k3 = k1 * k2
         k4 = GPflow.kernels.Matern32(1)
         k5 = k3 * k4
-        self.failUnless(k5.rbf is k1)
-        self.failUnless(k5.linear is k2)
-        self.failUnless(k5.matern32 is k4)
+        self.assertTrue(k5.rbf is k1)
+        self.assertTrue(k5.linear is k2)
+        self.assertTrue(k5.matern32 is k4)
 
     def test_no_nesting_2(self):
         k1 = GPflow.kernels.RBF(1) * GPflow.kernels.Linear(2)
@@ -333,33 +333,33 @@ class TestKernNamingProduct(unittest.TestCase):
         k2 = GPflow.kernels.Matern32(1) * GPflow.kernels.Matern52(2)
 
         k = k1 * k2
-        self.failUnless(hasattr(k, 'rbf'))
-        self.failUnless(hasattr(k, 'linear'))
-        self.failUnless(hasattr(k, 'matern32'))
-        self.failUnless(hasattr(k, 'matern52'))
+        self.assertTrue(hasattr(k, 'rbf'))
+        self.assertTrue(hasattr(k, 'linear'))
+        self.assertTrue(hasattr(k, 'matern32'))
+        self.assertTrue(hasattr(k, 'matern52'))
 
     def test_simple(self):
         k1 = GPflow.kernels.RBF(1)
         k2 = GPflow.kernels.Linear(2)
         k = k1 * k2
-        self.failUnless(k.rbf is k1)
-        self.failUnless(k.linear is k2)
+        self.assertTrue(k.rbf is k1)
+        self.assertTrue(k.linear is k2)
 
     def test_duplicates_1(self):
         k1 = GPflow.kernels.Matern32(1)
         k2 = GPflow.kernels.Matern32(43)
         k = k1 * k2
-        self.failUnless(k.matern32_1 is k1)
-        self.failUnless(k.matern32_2 is k2)
+        self.assertTrue(k.matern32_1 is k1)
+        self.assertTrue(k.matern32_2 is k2)
 
     def test_duplicates_2(self):
         k1 = GPflow.kernels.Matern32(1)
         k2 = GPflow.kernels.Matern32(2)
         k3 = GPflow.kernels.Matern32(3)
         k = k1 * k2 * k3
-        self.failUnless(k.matern32_1 is k1)
-        self.failUnless(k.matern32_2 is k2)
-        self.failUnless(k.matern32_3 is k3)
+        self.assertTrue(k.matern32_1 is k1)
+        self.assertTrue(k.matern32_2 is k2)
+        self.assertTrue(k.matern32_3 is k3)
 
 
 class TestARDInit(unittest.TestCase):

--- a/testing/test_likelihoods.py
+++ b/testing/test_likelihoods.py
@@ -56,7 +56,7 @@ class TestPredictConditional(unittest.TestCase):
             with l.tf_mode():
                 mu1 = tf.Session().run(l.conditional_mean(self.F), feed_dict={self.x: l.get_free_state(), self.F:self.F_data})
                 mu2, _ = tf.Session().run(l.predict_mean_and_var(self.F, self.F * 0), feed_dict={self.x: l.get_free_state(), self.F:self.F_data})
-            self.failUnless(np.allclose(mu1, mu2, test_setup.tolerance, test_setup.tolerance))
+            self.assertTrue(np.allclose(mu1, mu2, test_setup.tolerance, test_setup.tolerance))
 
     def test_variance(self):
         for test_setup in self.test_setups:
@@ -64,7 +64,7 @@ class TestPredictConditional(unittest.TestCase):
             with l.tf_mode():
                 v1 = tf.Session().run(l.conditional_variance(self.F), feed_dict={self.x: l.get_free_state(), self.F:self.F_data})
                 v2 = tf.Session().run(l.predict_mean_and_var(self.F, self.F * 0)[1], feed_dict={self.x: l.get_free_state(), self.F:self.F_data})   
-            self.failUnless(np.allclose(v1, v2, test_setup.tolerance, test_setup.tolerance))
+            self.assertTrue(np.allclose(v1, v2, test_setup.tolerance, test_setup.tolerance))
 
     def test_var_exp(self):
         """
@@ -77,7 +77,7 @@ class TestPredictConditional(unittest.TestCase):
             with l.tf_mode():
                 r1 = tf.Session().run(l.logp(self.F, y), feed_dict={self.x: l.get_free_state(), self.F:self.F_data})
                 r2 = tf.Session().run(l.variational_expectations(self.F, self.F * 0,test_setup.Y), feed_dict={self.x: l.get_free_state(), self.F:self.F_data})   
-            self.failUnless(np.allclose(r1, r2, test_setup.tolerance, test_setup.tolerance))
+            self.assertTrue(np.allclose(r1, r2, test_setup.tolerance, test_setup.tolerance))
 
 class TestQuadrature(unittest.TestCase):
     """
@@ -110,7 +110,7 @@ class TestQuadrature(unittest.TestCase):
             #compile and run the functions:
             F1 = tf.Session().run(F1, feed_dict={x: x_data})
             F2 = tf.Session().run(F2, feed_dict={x: x_data})
-            self.failUnless(np.allclose(F1, F2, test_setup.tolerance, test_setup.tolerance))
+            self.assertTrue(np.allclose(F1, F2, test_setup.tolerance, test_setup.tolerance))
 
     def test_pred_density(self):
         #get all the likelihoods where predict_density  has been overwritten.
@@ -131,7 +131,7 @@ class TestQuadrature(unittest.TestCase):
             #compile and run the functions:
             F1 = tf.Session().run(F1, feed_dict={x: x_data})
             F2 = tf.Session().run(F2, feed_dict={x: x_data})
-            self.failUnless(np.allclose(F1, F2, test_setup.tolerance, test_setup.tolerance))
+            self.assertTrue(np.allclose(F1, F2, test_setup.tolerance, test_setup.tolerance))
 
 class TestRobustMaxMulticlass(unittest.TestCase):
     """
@@ -160,10 +160,10 @@ class TestRobustMaxMulticlass(unittest.TestCase):
             mu, _ = tf.Session().run(l.predict_mean_and_var(F,F), feed_dict={x: l.get_free_state(), F:F_data})  
             pred = tf.Session().run(l.predict_density(F,F,Y), feed_dict={x: l.get_free_state(), F:F_data})  
             variational_expectations = tf.Session().run(l.variational_expectations(F,F,Y), feed_dict={x: l.get_free_state(), F:F_data}) 
-        self.failUnless( np.allclose( mu , np.ones((nPoints,nClasses))/nClasses, tolerance, tolerance ) )
-        self.failUnless( np.allclose( pred , np.ones((nPoints,1))/nClasses, tolerance, tolerance ) )
+        self.assertTrue( np.allclose( mu , np.ones((nPoints,nClasses))/nClasses, tolerance, tolerance ) )
+        self.assertTrue( np.allclose( pred , np.ones((nPoints,1))/nClasses, tolerance, tolerance ) )
         validation_variational_expectation = 1./nClasses * np.log( 1.- epsilon ) + (1. - 1./nClasses ) * np.log( epsilon / (nClasses - 1) )
-        self.failUnless( np.allclose( variational_expectations , np.ones((nPoints,1))*validation_variational_expectation, tolerance, tolerance ) )
+        self.assertTrue( np.allclose( variational_expectations , np.ones((nPoints,1))*validation_variational_expectation, tolerance, tolerance ) )
             
 if __name__ == "__main__":
     unittest.main()

--- a/testing/test_mean_functions.py
+++ b/testing/test_mean_functions.py
@@ -39,17 +39,17 @@ class TestMeanFuncs(unittest.TestCase):
         for mf in self.mfs:
             with mf.tf_mode():
                 Y = tf.Session().run(mf(self.X), feed_dict={self.x: mf.get_free_state(), self.X: self.X_data})
-            self.failUnless(Y.shape in [(self.N, self.output_dim), (self.N, 1)])
+            self.assertTrue(Y.shape in [(self.N, self.output_dim), (self.N, 1)])
 
     def test_composition_output_shape(self):
         for comp_mf in self.composition_mfs:
             with comp_mf.tf_mode():
                 Y = tf.Session().run(comp_mf(self.X), feed_dict={self.x: comp_mf.get_free_state(), self.X: self.X_data})
-            self.failUnless(Y.shape in [(self.N, self.output_dim), (self.N, 1)])
+            self.assertTrue(Y.shape in [(self.N, self.output_dim), (self.N, 1)])
 
     def test_combination_types(self):
-        self.failUnless(all(isinstance(mfAdd, GPflow.mean_functions.Additive) for mfAdd in self.composition_mfs_add))
-        self.failUnless(all(isinstance(mfMult, GPflow.mean_functions.Product) for mfMult in self.composition_mfs_mult))
+        self.assertTrue(all(isinstance(mfAdd, GPflow.mean_functions.Additive) for mfAdd in self.composition_mfs_add))
+        self.assertTrue(all(isinstance(mfMult, GPflow.mean_functions.Product) for mfMult in self.composition_mfs_mult))
 
 
 class TestModelCompositionOperations(unittest.TestCase):
@@ -130,11 +130,11 @@ class TestModelCompositionOperations(unittest.TestCase):
         mu1_const, v1_const = self.m_const_set1.predict_f(self.Xtest)
         mu2_const, v2_const = self.m_const_set2.predict_f(self.Xtest)
 
-        self.failUnless(np.all(np.isclose(v1_lin, v1_lin)))
-        self.failUnless(np.all(np.isclose(mu1_lin, mu2_lin)))
+        self.assertTrue(np.all(np.isclose(v1_lin, v1_lin)))
+        self.assertTrue(np.all(np.isclose(mu1_lin, mu2_lin)))
 
-        self.failUnless(np.all(np.isclose(v1_const, v2_const)))
-        self.failUnless(np.all(np.isclose(mu1_const, mu2_const)))
+        self.assertTrue(np.all(np.isclose(v1_const, v2_const)))
+        self.assertTrue(np.all(np.isclose(mu1_const, mu2_const)))
 
     def test_inverse_operations(self):
         mu1_lin_min_lin, v1_lin_min_lin = self.m_linear_min_linear.predict_f(self.Xtest)
@@ -146,12 +146,12 @@ class TestModelCompositionOperations(unittest.TestCase):
         mu_const, _ = self.m_constituent.predict_f(self.Xtest)
         mu_zero, v_zero = self.m_zero.predict_f(self.Xtest)
 
-        self.failUnless(np.all(np.isclose(mu1_lin_min_lin, mu_zero)))
-        self.failUnless(np.all(np.isclose(mu1_const_min_const, mu_zero)))
+        self.assertTrue(np.all(np.isclose(mu1_lin_min_lin, mu_zero)))
+        self.assertTrue(np.all(np.isclose(mu1_const_min_const, mu_zero)))
 
-        self.failUnless(np.all(np.isclose(mu1_comp_min_constituent1, mu_const)))
-        self.failUnless(np.all(np.isclose(mu1_comp_min_constituent2, mu_const)))
-        self.failUnless(np.all(np.isclose(mu1_comp_min_constituent1, mu1_comp_min_constituent2)))
+        self.assertTrue(np.all(np.isclose(mu1_comp_min_constituent1, mu_const)))
+        self.assertTrue(np.all(np.isclose(mu1_comp_min_constituent2, mu_const)))
+        self.assertTrue(np.all(np.isclose(mu1_comp_min_constituent1, mu1_comp_min_constituent2)))
 
 
 class TestModelsWithMeanFuncs(unittest.TestCase):
@@ -198,8 +198,8 @@ class TestModelsWithMeanFuncs(unittest.TestCase):
         for m_with, m_without in zip(self.models_with, self.models_without):
             mu1, v1 = m_with.predict_f(self.Xtest)
             mu2, v2 = m_without.predict_f(self.Xtest)
-            self.failUnless(np.all(v1 == v2))
-            self.failIf(np.all(mu1 == mu2))
+            self.assertTrue(np.all(v1 == v2))
+            self.assertFalse(np.all(mu1 == mu2))
 
 if __name__ == "__main__":
     unittest.main()

--- a/testing/test_method_equivalence.py
+++ b/testing/test_method_equivalence.py
@@ -54,7 +54,7 @@ class TestEquivalence(unittest.TestCase):
 
     def test_all(self):
         likelihoods = np.array([-m._objective(m.get_free_state())[0].squeeze() for m in self.models])
-        self.failUnless(np.allclose(likelihoods, likelihoods[0], 1e-2))
+        self.assertTrue(np.allclose(likelihoods, likelihoods[0], 1e-2))
         variances, lengthscales = [], []
         for m in self.models:
             if hasattr(m.kern, 'rbf'):
@@ -65,13 +65,13 @@ class TestEquivalence(unittest.TestCase):
                 lengthscales.append(m.kern.lengthscales.value)
         variances, lengthscales = np.array(variances), np.array(lengthscales)
         
-        self.failUnless(np.allclose(variances, variances[0], 1e-3))            
-        self.failUnless(np.allclose(lengthscales, lengthscales[0], 1e-3))
+        self.assertTrue(np.allclose(variances, variances[0], 1e-3))
+        self.assertTrue(np.allclose(lengthscales, lengthscales[0], 1e-3))
         mu0, var0 = self.models[0].predict_y(self.Xtest)
         for m in self.models[1:]:
             mu, var = m.predict_y(self.Xtest)
-            self.failUnless(np.allclose(mu, mu0, 1e-2))
-            self.failUnless(np.allclose(var, var0, 1e-2))
+            self.assertTrue(np.allclose(mu, mu0, 1e-2))
+            self.assertTrue(np.allclose(var, var0, 1e-2))
 
 
 

--- a/testing/test_methods.py
+++ b/testing/test_methods.py
@@ -31,28 +31,28 @@ class TestMethods(unittest.TestCase):
         for m in self.ms:
             m._compile()
             f, g = m._objective(m.get_free_state())
-            self.failUnless(f.size == 1)
-            self.failUnless(g.size == m.get_free_state().size)
+            self.assertTrue(f.size == 1)
+            self.assertTrue(g.size == m.get_free_state().size)
 
     def test_predict_f(self):    
         for m in self.ms:
             mf, vf = m.predict_f(self.Xs)
-            self.failUnless(mf.shape == vf.shape)
-            self.failUnless(mf.shape == (10, 1))
-            self.failUnless(np.all(vf >= 0.0))
+            self.assertTrue(mf.shape == vf.shape)
+            self.assertTrue(mf.shape == (10, 1))
+            self.assertTrue(np.all(vf >= 0.0))
 
     def test_predict_y(self):    
         for m in self.ms:
             mf, vf = m.predict_y(self.Xs)
-            self.failUnless(mf.shape == vf.shape)
-            self.failUnless(mf.shape == (10, 1))
-            self.failUnless(np.all(vf >= 0.0))
+            self.assertTrue(mf.shape == vf.shape)
+            self.assertTrue(mf.shape == (10, 1))
+            self.assertTrue(np.all(vf >= 0.0))
 
     def test_predict_density(self):
         self.Ys = self.rng.randn(10, 1)
         for m in self.ms:
             d = m.predict_density(self.Xs, self.Ys)
-            self.failUnless(d.shape == (10, 1))
+            self.assertTrue(d.shape == (10, 1))
 
 
 class TestSVGP(unittest.TestCase):
@@ -89,7 +89,7 @@ class TestSVGP(unittest.TestCase):
         m2.q_sqrt = np.array([np.diag(qsqrt[:, 0]),
                               np.diag(qsqrt[:, 1])]).swapaxes(0, 2)
         m2.q_mu = qmean
-        self.failUnless(np.allclose(m1._objective(m1.get_free_state())[0],
+        self.assertTrue(np.allclose(m1._objective(m1.get_free_state())[0],
                                     m2._objective(m2.get_free_state())[0]))
 
     def test_notwhite(self):
@@ -118,7 +118,7 @@ class TestSVGP(unittest.TestCase):
         m1.q_mu = qmean
         m2.q_sqrt = np.array([np.diag(qsqrt[:, 0]), np.diag(qsqrt[:, 1])]).swapaxes(0, 2)
         m2.q_mu = qmean
-        self.failUnless(np.allclose(m1._objective(m1.get_free_state())[0],
+        self.assertTrue(np.allclose(m1._objective(m1.get_free_state())[0],
                                     m2._objective(m2.get_free_state())[0]))
 
     def test_q_sqrt_fixing(self):
@@ -162,14 +162,14 @@ class TestSparseMCMC(unittest.TestCase):
     def test_likelihoods_and_gradients(self):
         f1, _ = self.m1._objective(self.m1.get_free_state())
         f2, _ = self.m2._objective(self.m2.get_free_state())
-        self.failUnless(np.allclose(f1, f2))
+        self.assertTrue(np.allclose(f1, f2))
         # the parameters might not be in the same order, so
         # sort the gradients before checking they're the same
         _, g1 = self.m1._objective(self.m1.get_free_state())
         _, g2 = self.m2._objective(self.m2.get_free_state())
         g1 = np.sort(g1)
         g2 = np.sort(g2)
-        self.failUnless(np.allclose(g1, g2, 1e-4))
+        self.assertTrue(np.allclose(g1, g2, 1e-4))
 
 
 if __name__ == "__main__":

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -22,11 +22,11 @@ class TestOptimize(unittest.TestCase):
     def test_adam(self):
         o = tf.train.AdamOptimizer()
         self.m.optimize(o, max_iters=5000)
-        self.failUnless(self.m.x.value.max() < 1e-2)
+        self.assertTrue(self.m.x.value.max() < 1e-2)
 
     def test_lbfgsb(self):
         self.m.optimize(display=False)
-        self.failUnless(self.m.x.value.max() < 1e-6)
+        self.assertTrue(self.m.x.value.max() < 1e-6)
 
 
 class TestNeedsRecompile(unittest.TestCase):
@@ -37,23 +37,23 @@ class TestNeedsRecompile(unittest.TestCase):
     def test_fix(self):
         self.m._needs_recompile = False
         self.m.p.fixed = True
-        self.failUnless(self.m._needs_recompile)
+        self.assertTrue(self.m._needs_recompile)
 
     def test_replace_param(self):
         self.m._needs_recompile = False
         new_p = GPflow.param.Param(3.0)
         self.m.p = new_p
-        self.failUnless(self.m._needs_recompile)
+        self.assertTrue(self.m._needs_recompile)
 
     def test_set_prior(self):
         self.m._needs_recompile = False
         self.m.p.prior = GPflow.priors.Gaussian(0, 1)
-        self.failUnless(self.m._needs_recompile)
+        self.assertTrue(self.m._needs_recompile)
 
     def test_set_transform(self):
         self.m._needs_recompile = False
         self.m.p.transform = GPflow.transforms.Identity()
-        self.failUnless(self.m._needs_recompile)
+        self.assertTrue(self.m._needs_recompile)
 
 
 class KeyboardRaiser:
@@ -85,7 +85,7 @@ class TestKeyboardCatching(unittest.TestCase):
         self.m._objective = KeyboardRaiser(15, self.m._objective)
         self.m.optimize(display=0, max_iters=10000, ftol=0, gtol=0)
         x1 = self.m.get_free_state()
-        self.failIf(np.allclose(x0, x1))
+        self.assertFalse(np.allclose(x0, x1))
 
     def test_optimize_tf(self):
         x0 = self.m.get_free_state()
@@ -93,7 +93,7 @@ class TestKeyboardCatching(unittest.TestCase):
         o = tf.train.AdamOptimizer()
         self.m.optimize(o, max_iters=15, callback=callback)
         x1 = self.m.get_free_state()
-        self.failIf(np.allclose(x0, x1))
+        self.assertFalse(np.allclose(x0, x1))
 
 
 class TestLikelihoodAutoflow(unittest.TestCase):
@@ -111,9 +111,9 @@ class TestLikelihoodAutoflow(unittest.TestCase):
         l1 = self.m.compute_log_likelihood()
         p1 = self.m.compute_log_prior()
 
-        self.failUnless(p0 == 0.0)
-        self.failIf(p0 == p1)
-        self.failUnless(l0 == l1)
+        self.assertTrue(p0 == 0.0)
+        self.assertFalse(p0 == p1)
+        self.assertTrue(l0 == l1)
 
 
 class TestName(unittest.TestCase):

--- a/testing/test_param.py
+++ b/testing/test_param.py
@@ -243,8 +243,8 @@ class ParamTestsWider(unittest.TestCase):
         fs = self.m.get_free_state()
         for p in [self.m.foo, self.m.bar, self.m.baz]:
             index, found = self.m.get_param_index(p)
-            self.failUnless(found)
-            self.failUnless(fs[index] == p.get_free_state()[0])
+            self.assertTrue(found)
+            self.assertTrue(fs[index] == p.get_free_state()[0])
         
     def testFixed(self):
         self.m.foo.fixed = True

--- a/testing/test_predict.py
+++ b/testing/test_predict.py
@@ -21,15 +21,15 @@ class TestGaussian(unittest.TestCase):
         mu_f, var_f = self.m.predict_f(self.Xtest)
         mu_y, var_y = self.m.predict_y(self.Xtest)
 
-        self.failUnless(np.allclose(mu_f, mu_y))
-        self.failUnless(np.allclose(var_f, var_y - 1.))
+        self.assertTrue(np.allclose(mu_f, mu_y))
+        self.assertTrue(np.allclose(var_f, var_y - 1.))
 
     def test_density(self):
         mu_y, var_y = self.m.predict_y(self.Xtest)
         density = self.m.predict_density(self.Xtest, self.Ytest)
 
         density_hand = -0.5*np.log(2*np.pi) - 0.5*np.log(var_y) - 0.5*np.square(mu_y - self.Ytest)/var_y
-        self.failUnless(np.allclose(density_hand, density))
+        self.assertTrue(np.allclose(density_hand, density))
 
     def test_recompile(self):
         mu_f, var_f = self.m.predict_f(self.Xtest)
@@ -75,15 +75,15 @@ class TestFullCov(unittest.TestCase):
     def test_cov(self):
         mu1, var = self.model.predict_f(self.Xtest)
         mu2, covar = self.model.predict_f_full_cov(self.Xtest)
-        self.failUnless(np.all(mu1 == mu2))
-        self.failUnless(covar.shape == self.covar_shape)
-        self.failUnless(var.shape == (self.Ntest, self.output_dim))
+        self.assertTrue(np.all(mu1 == mu2))
+        self.assertTrue(covar.shape == self.covar_shape)
+        self.assertTrue(var.shape == (self.Ntest, self.output_dim))
         for i in range(self.output_dim):
-            self.failUnless(np.allclose(var[:, i], np.diag(covar[:, :, i])))
+            self.assertTrue(np.allclose(var[:, i], np.diag(covar[:, :, i])))
 
     def test_samples(self):
         samples = self.model.predict_f_samples(self.Xtest, self.num_samples)
-        self.failUnless(samples.shape == self.samples_shape)
+        self.assertTrue(samples.shape == self.samples_shape)
 
 
 class TestFullCovSGPR(TestFullCov):

--- a/testing/test_priors.py
+++ b/testing/test_priors.py
@@ -23,7 +23,7 @@ class PriorModeTests(unittest.TestCase):
         self.m.optimize(display=0)
 
         xmax = self.m.get_free_state()
-        self.failUnless(np.allclose(xmax, 3))
+        self.assertTrue(np.allclose(xmax, 3))
 
     def testGaussianModeMatrix(self):
         self.m.x = GPflow.param.Param(np.random.randn(4, 4))
@@ -31,7 +31,7 @@ class PriorModeTests(unittest.TestCase):
         self.m.optimize(display=0)
 
         xmax = self.m.get_free_state()
-        self.failUnless(np.allclose(xmax, -1))
+        self.assertTrue(np.allclose(xmax, -1))
 
     def testGammaMode(self):
         self.m.x = GPflow.param.Param(1.0)
@@ -40,7 +40,7 @@ class PriorModeTests(unittest.TestCase):
         self.m.optimize(display=0)
 
         true_mode = (shape - 1.) * scale
-        self.failUnless(np.allclose(self.m.x.value, true_mode, 1e-3))
+        self.assertTrue(np.allclose(self.m.x.value, true_mode, 1e-3))
 
     def testLaplaceMode(self):
         self.m.x = GPflow.param.Param(1.0)
@@ -48,7 +48,7 @@ class PriorModeTests(unittest.TestCase):
         self.m.optimize(display=0)
 
         xmax = self.m.get_free_state()
-        self.failUnless(np.allclose(xmax, 3))
+        self.assertTrue(np.allclose(xmax, 3))
 
     def testLogNormalMode(self):
         self.m.x = GPflow.param.Param(1.0)
@@ -57,7 +57,7 @@ class PriorModeTests(unittest.TestCase):
         self.m.optimize(display=0)
 
         xmax = self.m.get_free_state()
-        self.failUnless(np.allclose(xmax, 3))
+        self.assertTrue(np.allclose(xmax, 3))
 
 
 

--- a/testing/test_transforms.py
+++ b/testing/test_transforms.py
@@ -21,13 +21,13 @@ class TransformTests(unittest.TestCase):
         ys_tf = [self.session.run(y, feed_dict={self.x: self.x_np}) for y in ys]
         ys_np = [t.forward(self.x_np) for t in self.transforms]
         for y1, y2 in zip(ys_tf, ys_np):
-            self.failUnless(np.allclose(y1, y2))
+            self.assertTrue(np.allclose(y1, y2))
 
     def test_forward_backward(self):
         ys_np = [t.forward(self.x_np) for t in self.transforms]
         xs_np = [t.backward(y) for t, y in zip(self.transforms, ys_np)]
         for x in xs_np:
-            self.failUnless(np.allclose(x, self.x_np))
+            self.assertTrue(np.allclose(x, self.x_np))
 
     def test_logjac(self):
         """
@@ -41,7 +41,7 @@ class TransformTests(unittest.TestCase):
         hand_jacs = [t.tf_log_jacobian(self.x) for t in self.transforms]
 
         for j1, j2 in zip(tf_jacs, hand_jacs):
-            self.failUnless(np.allclose(self.session.run(j1, feed_dict={self.x: self.x_np}),
+            self.assertTrue(np.allclose(self.session.run(j1, feed_dict={self.x: self.x_np}),
                                         self.session.run(j2, feed_dict={self.x: self.x_np})))
 
 

--- a/testing/test_variational.py
+++ b/testing/test_variational.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 from GPflow.tf_hacks import eye
 import numpy as np
 import unittest
-from reference import *
+from .reference import *
 
 def referenceUnivariateLogMarginalLikelihood( y, K, noiseVariance ):
     return -0.5 * y * y / ( K + noiseVariance ) - 0.5 * np.log( K + noiseVariance ) - 0.5 * np.log( np.pi * 2. )
@@ -79,7 +79,7 @@ class VariationalUnivariateTest(unittest.TestCase):
                 with model.tf_mode():
                     prior_KL_function = model.build_prior_KL()
                 test_prior_KL = prior_KL_function.eval( session = model._session, feed_dict = {model._free_vars: model.get_free_state() } ) 
-                self.failUnless( np.abs( referenceKL - test_prior_KL ) < 1e-4 )
+                self.assertTrue( np.abs( referenceKL - test_prior_KL ) < 1e-4 )
         
     def test_build_likelihood(self):
         #reference marginal likelihood
@@ -89,7 +89,7 @@ class VariationalUnivariateTest(unittest.TestCase):
             for is_whitened in [True,False]:
                 model = self.get_model( is_diagonal, is_whitened )
                 model_likelihood = model.compute_log_likelihood()
-                self.failUnless( np.abs( model_likelihood - log_marginal_likelihood ) < 1e-4 )
+                self.assertTrue( np.abs( model_likelihood - log_marginal_likelihood ) < 1e-4 )
 
     def testUnivariateConditionals(self):
         for is_diagonal in [True,False]:
@@ -102,8 +102,8 @@ class VariationalUnivariateTest(unittest.TestCase):
                         fmean_func, fvar_func = GPflow.conditionals.gaussian_gp_predict(self.X, self.Z, model.kern, model.q_mu, model.q_sqrt, self.oneLatentFunction)  
                 mean_value = fmean_func.eval( session = model._session, feed_dict = {model._free_vars: model.get_free_state() } )[0,0] 
                 var_value = fvar_func.eval( session = model._session, feed_dict = {model._free_vars: model.get_free_state() } )[0,0] 
-                self.failUnless( np.abs( mean_value - self.posteriorMean ) < 1e-4 )
-                self.failUnless( np.abs( var_value - self.posteriorVariance ) < 1e-4 )
+                self.assertTrue( np.abs( mean_value - self.posteriorMean ) < 1e-4 )
+                self.assertTrue( np.abs( var_value - self.posteriorVariance ) < 1e-4 )
 
 class VariationalMultivariateTest(unittest.TestCase):
     def setUp( self ):
@@ -142,7 +142,7 @@ class VariationalMultivariateTest(unittest.TestCase):
         pCov = rng.rand()
         univariate_KL = referenceUnivariatePriorKL( qMean, pMean, qCov, pCov )
         multivariate_KL = referenceMultivariatePriorKL( np.array( [[qMean]] ), np.array( [[qCov]]), np.array( [[pMean]] ), np.array( [[pCov]] ) )  
-        self.failUnless( np.abs( univariate_KL - multivariate_KL ) < 1e-4 )  
+        self.assertTrue( np.abs( univariate_KL - multivariate_KL ) < 1e-4 )
         
     def test_prior_KL_fullQ( self ):
         covQ = np.dot( self.q_sqrt_full, self.q_sqrt_full.T )
@@ -162,7 +162,7 @@ class VariationalMultivariateTest(unittest.TestCase):
             with model.tf_mode():
                 prior_KL_function = model.build_prior_KL()
             test_prior_KL = prior_KL_function.eval( session = model._session, feed_dict = {model._free_vars: model.get_free_state() } ) 
-            self.failUnless( np.abs( referenceKL - test_prior_KL ) < 1e-4 )        
+            self.assertTrue( np.abs( referenceKL - test_prior_KL ) < 1e-4 )
         
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- `reference` is now imported using `.reference`, which fixes a failure in Python 3
- All instances of `failUnless` and `failIf` are now replaced by `assertTrue` and `assertFalse`. The former are depreciated, and were giving me annoying warnings. Not too big a deal, but it would have needed to be changed eventually.