### PR TITLE
add Apache license headers (fix #135)

### DIFF
--- a/GPflow/__init__.py
+++ b/GPflow/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 # flake8: noqa
 from . import likelihoods, kernels, param, model, gpmc, sgpmc, priors, gpr, svgp, vgp, sgpr
 from ._version import __version__

--- a/GPflow/_version.py
+++ b/GPflow/_version.py
@@ -1,1 +1,15 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 __version__ = "0.2.0"

--- a/GPflow/conditionals.py
+++ b/GPflow/conditionals.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 from .tf_hacks import eye
 import tensorflow as tf
 

--- a/GPflow/densities.py
+++ b/GPflow/densities.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import tensorflow as tf
 import numpy as np
 

--- a/GPflow/gpmc.py
+++ b/GPflow/gpmc.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import numpy as np
 import tensorflow as tf
 from .model import GPModel

--- a/GPflow/gpr.py
+++ b/GPflow/gpr.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import tensorflow as tf
 from .model import GPModel
 from .densities import multivariate_normal

--- a/GPflow/hmc.py
+++ b/GPflow/hmc.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 from __future__ import division, print_function
 import numpy as np
 

--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 from __future__ import print_function
 from functools import reduce
 

--- a/GPflow/kullback_leiblers.py
+++ b/GPflow/kullback_leiblers.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import tensorflow as tf
 from .tf_hacks import eye
 

--- a/GPflow/likelihoods.py
+++ b/GPflow/likelihoods.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 from . import densities
 import tensorflow as tf
 import numpy as np

--- a/GPflow/mean_functions.py
+++ b/GPflow/mean_functions.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import tensorflow as tf
 import numpy as np
 from .param import Param, Parameterized

--- a/GPflow/model.py
+++ b/GPflow/model.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 from __future__ import print_function
 from .param import Parameterized, AutoFlow, DataHolder
 from scipy.optimize import minimize, OptimizeResult

--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import numpy as np
 import pandas as pd
 import tensorflow as tf

--- a/GPflow/priors.py
+++ b/GPflow/priors.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 from . import densities
 import tensorflow as tf
 import numpy as np

--- a/GPflow/sgpmc.py
+++ b/GPflow/sgpmc.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import numpy as np
 import tensorflow as tf
 from .model import GPModel

--- a/GPflow/sgpr.py
+++ b/GPflow/sgpr.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import tensorflow as tf
 import numpy as np
 from .model import GPModel

--- a/GPflow/svgp.py
+++ b/GPflow/svgp.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import tensorflow as tf
 import numpy as np
 from .param import Param, DataHolder

--- a/GPflow/tf_hacks.py
+++ b/GPflow/tf_hacks.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 """
 A collection of hacks for tensorflow.
 

--- a/GPflow/transforms.py
+++ b/GPflow/transforms.py
@@ -1,3 +1,17 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import numpy as np
 import tensorflow as tf
 

--- a/GPflow/vgp.py
+++ b/GPflow/vgp.py
@@ -1,3 +1,31 @@
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# Copyright 2016 James Hensman
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
 import tensorflow as tf
 import numpy as np
 from .param import Param, DataHolder


### PR DESCRIPTION
I've added headers to everything in the `GPflow` directory.  The headers now say `Copyright 2016 $AUTHORS`, where `$AUTHORS` is pulled from the git blame file.

For example, `GPflow/vgp.py` credits `James Hensman, Valentine Svensson, alexggmatthews, fujiisoup`. I didn't worry about adding grammatically correct conjunctions and comma placement, or about translating git names to legal names, although that should be straightforward if desired.

Let me know if you'd like any tweaks to the headers or if you'd like them added to other files as well. Hope this is useful.