### PR TITLE
LowerTriangularTransform now also takes matrix, not just array of matrices

### DIFF
--- a/GPflow/likelihoods.py
+++ b/GPflow/likelihoods.py
@@ -18,8 +18,8 @@ import tensorflow as tf
 import numpy as np
 from .param import Parameterized, Param
 from . import transforms
-hermgauss = np.polynomial.hermite.hermgauss
 
+hermgauss = np.polynomial.hermite.hermgauss
 
 
 class Likelihood(Parameterized):
@@ -97,8 +97,8 @@ class Likelihood(Parameterized):
         E_y = tf.reshape(tf.matmul(self.conditional_mean(X), gh_w), shape)
 
         # here's the quadrature for the variance
-        integrand = self.conditional_variance(X)\
-            + tf.square(self.conditional_mean(X))
+        integrand = self.conditional_variance(X) \
+                    + tf.square(self.conditional_mean(X))
         V_y = tf.reshape(tf.matmul(integrand, gh_w), shape) - tf.square(E_y)
 
         return E_y, V_y
@@ -124,7 +124,7 @@ class Likelihood(Parameterized):
         """
         gh_x, gh_w = hermgauss(self.num_gauss_hermite_points)
 
-        gh_w = gh_w.reshape(-1, 1)/np.sqrt(np.pi)
+        gh_w = gh_w.reshape(-1, 1) / np.sqrt(np.pi)
         shape = tf.shape(Fmu)
         Fmu, Fvar, Y = [tf.reshape(e, (-1, 1)) for e in (Fmu, Fvar, Y)]
         X = gh_x[None, :] * tf.sqrt(2.0 * Fvar) + Fmu
@@ -157,7 +157,7 @@ class Likelihood(Parameterized):
 
         gh_x, gh_w = hermgauss(self.num_gauss_hermite_points)
         gh_x = gh_x.reshape(1, -1)
-        gh_w = gh_w.reshape(-1, 1)/np.sqrt(np.pi)
+        gh_w = gh_w.reshape(-1, 1) / np.sqrt(np.pi)
         shape = tf.shape(Fmu)
         Fmu, Fvar, Y = [tf.reshape(e, (-1, 1)) for e in (Fmu, Fvar, Y)]
         X = gh_x * tf.sqrt(2.0 * Fvar) + Fmu
@@ -188,8 +188,8 @@ class Gaussian(Likelihood):
         return densities.gaussian(Fmu, Y, Fvar + self.variance)
 
     def variational_expectations(self, Fmu, Fvar, Y):
-        return -0.5*np.log(2*np.pi) - 0.5*tf.log(self.variance)\
-            - 0.5*(tf.square(Y - Fmu) + Fvar)/self.variance
+        return -0.5 * np.log(2 * np.pi) - 0.5 * tf.log(self.variance) \
+               - 0.5 * (tf.square(Y - Fmu) + Fvar) / self.variance
 
 
 class Poisson(Likelihood):
@@ -208,7 +208,7 @@ class Poisson(Likelihood):
 
     def variational_expectations(self, Fmu, Fvar, Y):
         if self.invlink is tf.exp:
-            return Y*Fmu - tf.exp(Fmu + Fvar/2) - tf.lgamma(Y+1)
+            return Y * Fmu - tf.exp(Fmu + Fvar / 2) - tf.lgamma(Y + 1)
         else:
             return Likelihood.variational_expectations(self, Fmu, Fvar, Y)
 
@@ -229,7 +229,7 @@ class Exponential(Likelihood):
 
     def variational_expectations(self, Fmu, Fvar, Y):
         if self.invlink is tf.exp:
-            return -tf.exp(-Fmu + Fvar/2) * Y - Fmu
+            return -tf.exp(-Fmu + Fvar / 2) * Y - Fmu
         else:
             return Likelihood.variational_expectations(self, Fmu, Fvar, Y)
 
@@ -247,11 +247,11 @@ class StudentT(Likelihood):
         return tf.identity(F)
 
     def conditional_variance(self, F):
-        return F*0.0 + (self.deg_free / (self.deg_free - 2.0))
+        return F * 0.0 + (self.deg_free / (self.deg_free - 2.0))
 
 
 def probit(x):
-    return 0.5*(1.0+tf.erf(x/np.sqrt(2.0))) * (1-2e-3) + 1e-3
+    return 0.5 * (1.0 + tf.erf(x / np.sqrt(2.0))) * (1 - 2e-3) + 1e-3
 
 
 class Bernoulli(Likelihood):
@@ -265,7 +265,7 @@ class Bernoulli(Likelihood):
     def predict_mean_and_var(self, Fmu, Fvar):
         if self.invlink is probit:
             p = probit(Fmu / tf.sqrt(1 + Fvar))
-            return p,  p - tf.square(p)
+            return p, p - tf.square(p)
         else:
             # for other invlink, use quadrature
             return Likelihood.predict_mean_and_var(self, Fmu, Fvar)
@@ -286,6 +286,7 @@ class Gamma(Likelihood):
     """
     Use the transformed GP to give the *scale* (inverse rate) of the Gamma
     """
+
     def __init__(self, invlink=tf.exp):
         Likelihood.__init__(self)
         self.invlink = invlink
@@ -303,8 +304,8 @@ class Gamma(Likelihood):
 
     def variational_expectations(self, Fmu, Fvar, Y):
         if self.invlink is tf.exp:
-            return -self.shape * Fmu - tf.lgamma(self.shape)\
-                + (self.shape - 1.) * tf.log(Y) - Y * tf.exp(-Fmu + Fvar/2.)
+            return -self.shape * Fmu - tf.lgamma(self.shape) \
+                   + (self.shape - 1.) * tf.log(Y) - Y * tf.exp(-Fmu + Fvar / 2.)
         else:
             return Likelihood.variational_expectations(self, Fmu, Fvar, Y)
 
@@ -325,6 +326,7 @@ class Beta(Likelihood):
         alpha = scale * m
         beta  = scale * (1-m)
     """
+
     def __init__(self, invlink=probit, scale=1.0):
         Likelihood.__init__(self)
         self.scale = Param(scale, transforms.positive)
@@ -358,14 +360,15 @@ class RobustMax(object):
 
 
     """
+
     def __init__(self, num_classes, epsilon=1e-3):
         self.epsilon = epsilon
         self.num_classes = num_classes
-        self._eps_K1 = self.epsilon/(self.num_classes-1)
+        self._eps_K1 = self.epsilon / (self.num_classes - 1)
 
     def __call__(self, F):
         i = tf.argmax(F, 1)
-        return tf.one_hot(i, self.num_classes, 1.-self.epsilon, self._eps_K1)
+        return tf.one_hot(i, self.num_classes, 1. - self.epsilon, self._eps_K1)
 
     def prob_is_largest(self, Y, mu, var, gh_x, gh_w):
         # work out what the mean and variance is of the indicated latent function.
@@ -374,20 +377,22 @@ class RobustMax(object):
         var_selected = tf.reduce_sum(oh_on * var, 1)
 
         # generate Gauss Hermite grid
-        X = tf.reshape(mu_selected, (-1, 1)) + gh_x * tf.reshape(tf.sqrt(tf.clip_by_value(2. * var_selected, 1e-10, np.inf)), (-1, 1))
+        X = tf.reshape(mu_selected, (-1, 1)) + gh_x * tf.reshape(
+            tf.sqrt(tf.clip_by_value(2. * var_selected, 1e-10, np.inf)), (-1, 1))
 
         # compute the CDF of the Gaussian between the latent functions and the grid (including the selected function)
-        dist = (tf.expand_dims(X, 1) - tf.expand_dims(mu, 2)) / tf.expand_dims(tf.sqrt(tf.clip_by_value(var, 1e-10, np.inf)), 2)
-        cdfs = 0.5 * (1.0 + tf.erf(dist/np.sqrt(2.0)))
+        dist = (tf.expand_dims(X, 1) - tf.expand_dims(mu, 2)) / tf.expand_dims(
+            tf.sqrt(tf.clip_by_value(var, 1e-10, np.inf)), 2)
+        cdfs = 0.5 * (1.0 + tf.erf(dist / np.sqrt(2.0)))
 
-        cdfs = cdfs * (1-2e-4) + 1e-4
+        cdfs = cdfs * (1 - 2e-4) + 1e-4
 
         # blank out all the distances on the selected latent function
         oh_off = tf.cast(tf.one_hot(tf.reshape(Y, (-1,)), self.num_classes, 0., 1.), tf.float64)
         cdfs = cdfs * tf.expand_dims(oh_off, 2) + tf.expand_dims(oh_on, 2)
 
         # take the product over the latent functions, and the sum over the GH grid.
-        return tf.matmul(tf.reduce_prod(cdfs, reduction_indices=[1]), tf.reshape(gh_w/np.sqrt(np.pi), (-1, 1)))
+        return tf.matmul(tf.reduce_prod(cdfs, reduction_indices=[1]), tf.reshape(gh_w / np.sqrt(np.pi), (-1, 1)))
 
 
 class MultiClass(Likelihood):
@@ -402,8 +407,8 @@ class MultiClass(Likelihood):
         if invlink is None:
             invlink = RobustMax(self.num_classes)
             self.invlink = invlink
-        elif not isinstance(invlink,RobustMax):
-            raise NotImplementedError        
+        elif not isinstance(invlink, RobustMax):
+            raise NotImplementedError
 
     def logp(self, F, Y):
         if isinstance(self.invlink, RobustMax):
@@ -419,14 +424,15 @@ class MultiClass(Likelihood):
         if isinstance(self.invlink, RobustMax):
             gh_x, gh_w = hermgauss(self.num_gauss_hermite_points)
             p = self.invlink.prob_is_largest(Y, Fmu, Fvar, gh_x, gh_w)
-            return p * np.log(1-self.invlink.epsilon) + (1.-p) * np.log(self.invlink._eps_K1)
+            return p * np.log(1 - self.invlink.epsilon) + (1. - p) * np.log(self.invlink._eps_K1)
         else:
             raise NotImplementedError
 
     def predict_mean_and_var(self, Fmu, Fvar):
         if isinstance(self.invlink, RobustMax):
             # To compute this, we'll compute the density for each possible output
-            possible_outputs = [tf.fill(tf.pack([tf.shape(Fmu)[0], 1]), np.array(i, dtype=np.int64)) for i in range(self.num_classes)]
+            possible_outputs = [tf.fill(tf.pack([tf.shape(Fmu)[0], 1]), np.array(i, dtype=np.int64)) for i in
+                                range(self.num_classes)]
             ps = [self.predict_density(Fmu, Fvar, po) for po in possible_outputs]
             ps = tf.transpose(tf.pack([tf.reshape(p, (-1,)) for p in ps]))
             return ps, ps - tf.square(ps)

--- a/GPflow/transforms.py
+++ b/GPflow/transforms.py
@@ -184,8 +184,9 @@ class LowerTriangular(Transform):
     (N x N x D).
     """
 
-    def __init__(self, num_matrices=1):
+    def __init__(self, num_matrices=1, squeeze=False):
         self.num_matrices = num_matrices  # We need to store this for reconstruction.
+        self.squeeze = squeeze
 
     def _validate_vector_length(self, length):
         """
@@ -219,7 +220,7 @@ class LowerTriangular(Transform):
         for i in range(self.num_matrices):
             indices = np.tril_indices(matsize, 0)
             var[indices + (np.zeros(len(indices[0])).astype(int) + i,)] = xr[i, :]
-        return var
+        return var.squeeze() if self.squeeze else var
 
     def backward(self, y):
         """
@@ -230,23 +231,26 @@ class LowerTriangular(Transform):
         Returns:
             Free state.
         """
-        N = int((y.size / self.num_matrices)**0.5)
+        N = int((y.size / self.num_matrices) ** 0.5)
         y = np.reshape(y, (N, N, self.num_matrices))
         return y[np.tril_indices(len(y), 0)].T.flatten()
 
     def tf_forward(self, x):
-        return tf.transpose(tfh.vec_to_tri(tf.reshape(x, (self.num_matrices, -1))), [1, 2, 0])
+        fwd = tf.transpose(tfh.vec_to_tri(tf.reshape(x, (self.num_matrices, -1))), [1, 2, 0])
+        return tf.squeeze(fwd) if self.squeeze else fwd
 
     def tf_log_jacobian(self, x):
         return tf.zeros((1,), tf.float64) - np.inf
 
     def free_state_size(self, variable_shape):
-        if variable_shape[2] != self.num_matrices:
+        matrix_batch = len(variable_shape) > 2
+        if ((not matrix_batch and self.num_matrices != 1) or
+           (matrix_batch and variable_shape[2] != self.num_matrices)):
             raise ValueError("Number of matrices must be consistent with what was passed to the constructor.")
         if variable_shape[0] != variable_shape[1]:
             raise ValueError("Matrices passed must be square.")
         N = variable_shape[0]
-        return int(0.5 * N * (N + 1)) * variable_shape[2]
+        return int(0.5 * N * (N + 1)) * (variable_shape[2] if matrix_batch else 1)
 
     def __str__(self):
         return "LoTri->vec"

--- a/GPflow/transforms.py
+++ b/GPflow/transforms.py
@@ -185,6 +185,12 @@ class LowerTriangular(Transform):
     """
 
     def __init__(self, num_matrices=1, squeeze=False):
+        """
+        Create an instance of LowerTriangular transform.
+        Args:
+            num_matrices: Number of matrices to be stored.
+            squeeze: If num_matrices == 1, drop the redundant axis.
+        """
         self.num_matrices = num_matrices  # We need to store this for reconstruction.
         self.squeeze = squeeze
 


### PR DESCRIPTION
A small fix to the `LowerTriangular` transform, so that it now also takes MxM matrices, rather than NxMxM arrays of matrices. This is sometimes required and just makes it a bit nicer to work with.

Additionally, in case of any questions about `likelihoods.py`, my IDE automatically enforces PEP8 style, which caused all the changes. I decided to add them anyway, but feel free to remove if you think it causes clutter.