### PR TITLE
removing potential for circular import

### DIFF
--- a/GPflow/transforms.py
+++ b/GPflow/transforms.py
@@ -15,7 +15,7 @@
 
 import numpy as np
 import tensorflow as tf
-import GPflow.tf_hacks as tfh
+from . import tf_hacks as tfh
 
 
 class Transform(object):


### PR DESCRIPTION
Small fix: we should use relative import where possible. importing 'from' GPflow inside GPflow could lead to circular dependence in the future. 