### PR TITLE
tearing down interactive session when finished

### DIFF
--- a/testing/test_custom_op.py
+++ b/testing/test_custom_op.py
@@ -24,6 +24,9 @@ class TestVecToTri(unittest.TestCase):
     def setUp(self):
         self.sess = tf.InteractiveSession()
 
+    def tearDown(self):
+        self.sess.close()
+
     def testVecToTri(self):
         mats = [
             np.arange(1, 4)[None, :],
@@ -49,6 +52,9 @@ class TestVecToTri(unittest.TestCase):
 class TestTriToVec(unittest.TestCase):
     def setUp(self):
         self.sess = tf.InteractiveSession()
+
+    def tearDown(self):
+        self.sess.close()
 
     def testTriToVec(self):
         mats = [


### PR DESCRIPTION
This fixes a minor issue where tensorflow spits out warnings along the lines of

```AssertionError: Nesting violated for default stack of <class 'weakref'> objects```

It turns out that this is because we were not closing interactive sessions during testing.