### PR TITLE
make sure log jacobian is computed even for fixed variables

### DIFF
--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -225,6 +225,8 @@ class Param(Parentable):
             self._tf_array = tf.placeholder(dtype=float_type,
                                             shape=self._array.shape,
                                             name=self.name)
+            # do not consider log jacobian for parameters that are fixed.
+            self._log_jacobian = 0.0
             return 0
         free_size = self.transform.free_state_size(self.shape)
         x_free = free_array[:free_size]

--- a/testing/test_param.py
+++ b/testing/test_param.py
@@ -456,6 +456,22 @@ class TestDictSVGP(unittest.TestCase):
         self.assertTrue(np.allclose(loglik1, loglik3))
 
 
+class TestFixWithPrior(unittest.TestCase):
+    """
+    This tests that models with a fixed parameter which has a prior continue to work
+    """
+
+    def test(self):
+        m = GPflow.model.Model()
+        m.p = GPflow.param.Param(1.0, GPflow.transforms.positive)
+        m.pp = GPflow.param.Param(1.0, GPflow.transforms.positive)
+        m.p.prior = GPflow.priors.Gamma(1, 1)
+        m.pp.prior = GPflow.priors.Gamma(1, 1)
+        m.p.fixed = True
+        m.build_likelihood = lambda: tf.zeros([1], tf.float64)
+        m.optimize(disp=1, maxiter=10)
+
+
 class TestScopes(unittest.TestCase):
     def setUp(self):
         rng = np.random.RandomState(0)


### PR DESCRIPTION
Currently, if a model has a prior *and* is fixed, we get an error, because the log_jacobian correction is requested for the fixed variable, and it hasn't been computed. 

This PR fixes that: now parameters with `fixed=True` and a prior will have a log_jacobian of 0. A regression test is included. 