### PR TITLE
active_dims fix in Kdiag

### DIFF
--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -21,6 +21,7 @@ import numpy as np
 from .param import Param, Parameterized, AutoFlow
 from . import transforms
 from ._settings import settings
+
 float_type = settings.dtypes.float_type
 np_float_type = np.float32 if float_type is tf.float32 else np.float64
 
@@ -89,6 +90,7 @@ class Static(Kern):
     Kernels who don't depend on the value of the inputs are 'Static'.  The only
     parameter is a variance.
     """
+
     def __init__(self, input_dim, variance=1.0, active_dims=None):
         Kern.__init__(self, input_dim, active_dims)
         self.variance = Param(variance, transforms.positive)
@@ -101,6 +103,7 @@ class White(Static):
     """
     The White kernel
     """
+
     def K(self, X, X2=None):
         if X2 is None:
             d = tf.fill(tf.pack([tf.shape(X)[0]]), tf.squeeze(self.variance))
@@ -114,6 +117,7 @@ class Constant(Static):
     """
     The Constant (aka Bias) kernel
     """
+
     def K(self, X, X2=None):
         if X2 is None:
             shape = tf.pack([tf.shape(X)[0], tf.shape(X)[0]])
@@ -139,6 +143,7 @@ class Stationary(Kern):
     Determination'. This means that the kernel has one lengthscale per
     dimension, otherwise the kernel is isotropic (has a single lengthscale).
     """
+
     def __init__(self, input_dim, variance=1.0, lengthscales=None,
                  active_dims=None, ARD=False):
         """
@@ -169,16 +174,16 @@ class Stationary(Kern):
             self.ARD = False
 
     def square_dist(self, X, X2):
-        X = X/self.lengthscales
+        X = X / self.lengthscales
         Xs = tf.reduce_sum(tf.square(X), 1)
         if X2 is None:
-            return -2*tf.matmul(X, tf.transpose(X)) +\
-                tf.reshape(Xs, (-1, 1)) + tf.reshape(Xs, (1, -1))
+            return -2 * tf.matmul(X, tf.transpose(X)) + \
+                   tf.reshape(Xs, (-1, 1)) + tf.reshape(Xs, (1, -1))
         else:
             X2 = X2 / self.lengthscales
             X2s = tf.reduce_sum(tf.square(X2), 1)
-            return -2*tf.matmul(X, tf.transpose(X2)) +\
-                tf.reshape(Xs, (-1, 1)) + tf.reshape(X2s, (1, -1))
+            return -2 * tf.matmul(X, tf.transpose(X2)) + \
+                   tf.reshape(Xs, (-1, 1)) + tf.reshape(X2s, (1, -1))
 
     def euclid_dist(self, X, X2):
         r2 = self.square_dist(X, X2)
@@ -192,15 +197,17 @@ class RBF(Stationary):
     """
     The radial basis function (RBF) or squared exponential kernel
     """
+
     def K(self, X, X2=None):
         X, X2 = self._slice(X, X2)
-        return self.variance * tf.exp(-self.square_dist(X, X2)/2)
+        return self.variance * tf.exp(-self.square_dist(X, X2) / 2)
 
 
 class Linear(Kern):
     """
     The linear kernel
     """
+
     def __init__(self, input_dim, variance=1.0, active_dims=None, ARD=False):
         """
         - input_dim is the dimension of the input to the kernel
@@ -213,7 +220,7 @@ class Linear(Kern):
         self.ARD = ARD
         if ARD:
             # accept float or array:
-            variance = np.ones(self.input_dim)*variance
+            variance = np.ones(self.input_dim) * variance
             self.variance = Param(variance, transforms.positive)
         else:
             self.variance = Param(variance, transforms.positive)
@@ -227,6 +234,7 @@ class Linear(Kern):
             return tf.matmul(X * self.variance, tf.transpose(X2))
 
     def Kdiag(self, X):
+        X, _ = self._slice(X, None)
         return tf.reduce_sum(tf.square(X) * self.variance, 1)
 
 
@@ -260,6 +268,7 @@ class Exponential(Stationary):
     """
     The Exponential kernel
     """
+
     def K(self, X, X2=None):
         X, X2 = self._slice(X, X2)
         r = self.euclid_dist(X, X2)
@@ -270,6 +279,7 @@ class Matern12(Stationary):
     """
     The Matern 1/2 kernel
     """
+
     def K(self, X, X2=None):
         X, X2 = self._slice(X, X2)
         r = self.euclid_dist(X, X2)
@@ -280,28 +290,31 @@ class Matern32(Stationary):
     """
     The Matern 3/2 kernel
     """
+
     def K(self, X, X2=None):
         X, X2 = self._slice(X, X2)
         r = self.euclid_dist(X, X2)
-        return self.variance * (1. + np.sqrt(3.) * r) *\
-            tf.exp(-np.sqrt(3.) * r)
+        return self.variance * (1. + np.sqrt(3.) * r) * \
+               tf.exp(-np.sqrt(3.) * r)
 
 
 class Matern52(Stationary):
     """
     The Matern 5/2 kernel
     """
+
     def K(self, X, X2=None):
         X, X2 = self._slice(X, X2)
         r = self.euclid_dist(X, X2)
-        return self.variance*(1.0 + np.sqrt(5.) * r + 5./3. * tf.square(r))\
-            * tf.exp(-np.sqrt(5.) * r)
+        return self.variance * (1.0 + np.sqrt(5.) * r + 5. / 3. * tf.square(r)) \
+               * tf.exp(-np.sqrt(5.) * r)
 
 
 class Cosine(Stationary):
     """
     The Cosine kernel
     """
+
     def K(self, X, X2=None):
         X, X2 = self._slice(X, X2)
         r = self.euclid_dist(X, X2)
@@ -317,6 +330,7 @@ class PeriodicKernel(Kern):
 
     Derived using the mapping u=(cos(x), sin(x)) on the inputs.
     """
+
     def __init__(self, input_dim, period=1.0, variance=1.0,
                  lengthscales=1.0, active_dims=None):
         # No ARD support for lengthscale or period yet
@@ -338,8 +352,8 @@ class PeriodicKernel(Kern):
         f = tf.expand_dims(X, 1)  # now N x 1 x D
         f2 = tf.expand_dims(X2, 0)  # now 1 x M x D
 
-        r = np.pi * (f-f2) / self.period
-        r = tf.reduce_sum(tf.square(tf.sin(r)/self.lengthscales), 2)
+        r = np.pi * (f - f2) / self.period
+        r = tf.reduce_sum(tf.square(tf.sin(r) / self.lengthscales), 2)
 
         return self.variance * tf.exp(-0.5 * r)
 
@@ -429,6 +443,7 @@ class Combination(Kern):
     The names of the kernels to be combined are generated from their class
     names.
     """
+
     def __init__(self, kern_list):
         for k in kern_list:
             assert isinstance(k, Kern), "can only add Kern instances"

--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -53,6 +53,7 @@ class Kern(Parameterized):
             self.active_dims = slice(input_dim)
         else:
             self.active_dims = np.array(active_dims, dtype=np.int32)
+            assert len(active_dims) == input_dim
 
     def _slice(self, X, X2):
         if isinstance(self.active_dims, slice):

--- a/testing/test_kerns.py
+++ b/testing/test_kerns.py
@@ -3,7 +3,7 @@ import GPflow
 import tensorflow as tf
 import numpy as np
 import unittest
-from testing.reference import referenceRbfKernel, referencePeriodicKernel
+from .reference import referenceRbfKernel, referencePeriodicKernel
 
 
 class TestRbf(unittest.TestCase):
@@ -231,8 +231,8 @@ class TestSlice(unittest.TestCase):
                                                                 GPflow.kernels.Polynomial]
         self.kernels = []
         for kernclass in kernels:
-            k1 = kernclass(self.X.shape[1], active_dims=[0])
-            k2 = kernclass(self.X.shape[1], active_dims=[1])
+            k1 = kernclass(1, active_dims=[0])
+            k2 = kernclass(1, active_dims=[1])
             k3 = kernclass(1)
             self.kernels.append([k1, k2, k3])
 


### PR DESCRIPTION
Linear and Polynomial kernels did not respect active_dims properly in Kdiag.

- Added slice call to Linear.Kdiag
- Fixed TestSlice to test more kernels.
- Fixed TestSlice to have the correct inputdim.

@jameshensman: I just want to double-check, I also think I fixed an existing bug in `TestSlice`, where all the `input_dim`s passed to the kernels was 1. Where actually, `input_dim` should be the number of inputs passed into the kernel, rather than the number actually used, right?
