### PR TITLE
Better deduction of `input_dim` for `kernels.Combination`

### DIFF
--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -449,7 +449,7 @@ class Combination(Kern):
         for k in kern_list:
             assert isinstance(k, Kern), "can only add Kern instances"
 
-        input_dim = np.max([k.input_dim if type(k.active_dims) is slice else np.max(k.active_dims) for k in kern_list])
+        input_dim = np.max([k.input_dim if type(k.active_dims) is slice else np.max(k.active_dims) + 1 for k in kern_list])
         Kern.__init__(self, input_dim=input_dim)
 
         # add kernels to a list, flattening out instances of this class therein

--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -448,7 +448,9 @@ class Combination(Kern):
     def __init__(self, kern_list):
         for k in kern_list:
             assert isinstance(k, Kern), "can only add Kern instances"
-        Kern.__init__(self, input_dim=np.max([k.input_dim for k in kern_list]))
+
+        input_dim = np.max([k.input_dim if type(k.active_dims) is slice else np.max(k.active_dims) for k in kern_list])
+        Kern.__init__(self, input_dim=input_dim)
 
         # add kernels to a list, flattening out instances of this class therein
         self.kern_list = []


### PR DESCRIPTION
Deduces `input_dim` based on `input_dim` of a sub-kernel if a slice is used for `active_dims`, and the max of the `active_dims` otherwise.