### PR TITLE
added test for multiple Y columns. Fix in SGPR and GPRFITC

### DIFF
--- a/GPflow/sgpr.py
+++ b/GPflow/sgpr.py
@@ -92,8 +92,8 @@ class SGPR(GPModel):
         bound -= 0.5 * num_data * output_dim * tf.log(self.likelihood.variance)
         bound += -0.5*tf.reduce_sum(tf.square(err))/self.likelihood.variance
         bound += 0.5*tf.reduce_sum(tf.square(c))
-        bound += -0.5 * tf.reduce_sum(Kdiag) / self.likelihood.variance
-        bound += 0.5 * tf.reduce_sum(tf.diag_part(AAT))
+        bound += -0.5 * output_dim * tf.reduce_sum(Kdiag) / self.likelihood.variance
+        bound += 0.5 * output_dim * tf.reduce_sum(tf.diag_part(AAT))
 
         return bound
 
@@ -228,9 +228,9 @@ class GPRFITC(GPModel):
 
         constantTerm = -0.5 * self.num_data * tf.log(tf.constant(2. * np.pi, settings.dtypes.float_type))
         logDeterminantTerm = -0.5 * tf.reduce_sum(tf.log(nu)) - tf.reduce_sum(tf.log(tf.diag_part(L)))
-        logNormalizingTerm = constantTerm + logDeterminantTerm
-
-        return mahalanobisTerm + logNormalizingTerm
+        logNormalizingTerm = constantTerm + logDeterminantTerm 
+        
+        return mahalanobisTerm + logNormalizingTerm * self.num_latent
 
     def build_predict(self, Xnew, full_cov=False):
         """

--- a/testing/test_method_equivalence.py
+++ b/testing/test_method_equivalence.py
@@ -41,6 +41,7 @@ class TestEquivalence(unittest.TestCase):
         rng = np.random.RandomState(0)
         X = rng.rand(20, 1)*10
         Y = np.sin(X) + 0.9 * np.cos(X*1.6) + rng.randn(*X.shape) * 0.8
+        Y = np.tile(Y, 2) # two identical columns
         self.Xtest = rng.rand(10, 1)*10
 
         m1 = GPflow.gpr.GPR(X, Y, kern=GPflow.kernels.RBF(1),


### PR DESCRIPTION
response to #280 

Turns out there was also an error in FITC . 

I modified the method equivalence test to have two identical columns of Y. When I tried generating different columns (and higher dimensional inputs) the tests (sometimes) failed at the current tolerances. 