### PR TITLE
Improve test coverage for stochastic gradients with tf optimizer.

### DIFF
--- a/GPflow/minibatch.py
+++ b/GPflow/minibatch.py
@@ -28,19 +28,19 @@ class IndexManager(object):
         raise NotImplementedError
 
 class ReplacementSampling(IndexManager):
-	def nextIndeces(self):
-		return self.rng.randint(self.total_points, 
-		                        size=self.minibatch_size)
+    def nextIndeces(self):
+        return self.rng.randint(self.total_points, 
+                                size=self.minibatch_size)
 
 class NoReplacementSampling(IndexManager):
-	def __init__(self, minibatch_size, total_points, rng = None):
-	    assert(minibatch_size<=total_points,
-	           "replacement sampled minibatch size must be less than data size") 
-	    IndexManager.__init__(self, minibatch_size, total_points, rng)
-	
-	def nextIndeces(self):
-		permutation = self.rng.permutation(self.total_points)
-		return permutation[:self.minibatch_size]
+    def __init__(self, minibatch_size, total_points, rng = None):
+        assert(minibatch_size<=total_points,
+               "replacement sampled minibatch size must be less than data size") 
+        IndexManager.__init__(self, minibatch_size, total_points, rng)
+    
+    def nextIndeces(self):
+        permutation = self.rng.permutation(self.total_points)
+        return permutation[:self.minibatch_size]
 
 class SequenceIndeces(IndexManager):
     """
@@ -50,11 +50,11 @@ class SequenceIndeces(IndexManager):
     def __init__(self, minibatch_size, total_points, rng = None):
         self.counter = 0
         IndexManager.__init__(self, minibatch_size, total_points, rng)
-		
+        
     def nextIndeces(self):
         """
-		Written so that if total_points
-		changes this will still work
+        Written so that if total_points
+        changes this will still work
         """
         firstIndex = self.counter
         lastIndex = self.counter + self.minibatch_size
@@ -90,7 +90,7 @@ class MinibatchData(DataHolder):
                                    minibatch_size, 
                                    total_points,
                                    rng)
-        
+                                       
     def parseGenerationMethod(self, 
                               input_batch_manager, 
                               minibatch_size,
@@ -100,21 +100,21 @@ class MinibatchData(DataHolder):
         #When minibatch_size is a small fraction of total_point
         #ReplacementSampling should give similar results to 
         #NoReplacementSampling and the former can be much faster.
-		if input_batch_manager==None: 
-			fraction = float(minibatch_size) / float(total_points)
-			if fraction < 0.5:
-				self.index_manager = ReplacementSampling(minibatch_size,
-														 total_points,
-														 rng)
-			else:
-				self.index_manager = NoReplacementSampling(minibatch_size,
-														   total_points,
-	                                                       rng)
-		else: #Explicitly specified behaviour.
-			if input_batch_manager.__class__ not in IndexManager.__subclasses__():
-				raise NotImplementedError
-			self.index_manager = input_batch_manager
-			
-	def update_feed_dict(self, key_dict, feed_dict):
-		next_indeces = self.index_manager.nextIndeces()
-		feed_dict[key_dict[self]] = self._array[next_indeces]
+        if input_batch_manager==None: 
+            fraction = float(minibatch_size) / float(total_points)
+            if fraction < 0.5:
+                self.index_manager = ReplacementSampling(minibatch_size,
+                                                         total_points,
+                                                         rng)
+            else:
+                self.index_manager = NoReplacementSampling(minibatch_size,
+                                                           total_points,
+                                                           rng)
+        else: #Explicitly specified behaviour.
+            if input_batch_manager.__class__ not in IndexManager.__subclasses__():
+                raise NotImplementedError
+            self.index_manager = input_batch_manager
+            
+    def update_feed_dict(self, key_dict, feed_dict):
+        next_indeces = self.index_manager.nextIndeces()
+        feed_dict[key_dict[self]] = self._array[next_indeces]

--- a/GPflow/minibatch.py
+++ b/GPflow/minibatch.py
@@ -11,48 +11,53 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import numpy as np
 from .param import DataHolder
+
 
 class IndexManager(object):
     """
     Base clase for methods of batch indexing data.
     rng is an instance of np.random.RandomState, defaults to seed 0.
     """
-    def __init__(self, minibatch_size, total_points, rng = None):
+    def __init__(self, minibatch_size, total_points, rng=None):
         self.minibatch_size = minibatch_size
         self.total_points = total_points
         self.rng = rng or np.random.RandomState(0)
-        
-    def nextIndeces(self):
+
+    def nextIndices(self):
         raise NotImplementedError
 
+
 class ReplacementSampling(IndexManager):
-    def nextIndeces(self):
-        return self.rng.randint(self.total_points, 
+    def nextIndices(self):
+        return self.rng.randint(self.total_points,
                                 size=self.minibatch_size)
 
+
 class NoReplacementSampling(IndexManager):
-    def __init__(self, minibatch_size, total_points, rng = None):
-        #Can't sample without replacement is minibatch_size is larger 
-        #than total_points
-        assert(minibatch_size<=total_points) 
+    def __init__(self, minibatch_size, total_points, rng=None):
+        # Can't sample without replacement is minibatch_size is larger
+        # than total_points
+        assert(minibatch_size <= total_points)
         IndexManager.__init__(self, minibatch_size, total_points, rng)
-    
-    def nextIndeces(self):
+
+    def nextIndices(self):
         permutation = self.rng.permutation(self.total_points)
         return permutation[:self.minibatch_size]
 
-class SequenceIndeces(IndexManager):
+
+class SequenceIndices(IndexManager):
     """
-    A class that maintains the state necessary to manage 
+    A class that maintains the state necessary to manage
     sequential indexing of data holders.
     """
-    def __init__(self, minibatch_size, total_points, rng = None):
+    def __init__(self, minibatch_size, total_points, rng=None):
         self.counter = 0
         IndexManager.__init__(self, minibatch_size, total_points, rng)
-        
-    def nextIndeces(self):
+
+    def nextIndices(self):
         """
         Written so that if total_points
         changes this will still work
@@ -60,48 +65,46 @@ class SequenceIndeces(IndexManager):
         firstIndex = self.counter
         lastIndex = self.counter + self.minibatch_size
         self.counter = lastIndex % self.total_points
-        return np.arange(firstIndex,lastIndex) % self.total_points
+        return np.arange(firstIndex, lastIndex) % self.total_points
+
 
 class MinibatchData(DataHolder):
     """
-    A special DataHolder class which feeds a minibatch 
+    A special DataHolder class which feeds a minibatch
     to tensorflow via update_feed_dict().
     """
-    
-    #List of valid specifiers for generation methods.
-    _generation_methods = ['replace','noreplace','sequential']
-    
-    def __init__(self, array, 
-                       minibatch_size, 
-                       rng=None, 
-                       batch_manager=None):
+
+    # List of valid specifiers for generation methods.
+    _generation_methods = ['replace', 'noreplace', 'sequential']
+
+    def __init__(self, array, minibatch_size, rng=None, batch_manager=None):
         """
         array is a numpy array of data.
         minibatch_size (int) is the size of the minibatch
-        
-        batch_manager specified data sampling scheme and is a subclass 
+
+        batch_manager specified data sampling scheme and is a subclass
         of IndexManager.
-        
-        Note: you may want to randomize the order of the data 
+
+        Note: you may want to randomize the order of the data
         if using sequential generation.
         """
         DataHolder.__init__(self, array, on_shape_change='pass')
         total_points = self._array.shape[0]
-        self.parseGenerationMethod(batch_manager, 
-                                   minibatch_size, 
+        self.parseGenerationMethod(batch_manager,
+                                   minibatch_size,
                                    total_points,
                                    rng)
-                                       
-    def parseGenerationMethod(self, 
-                              input_batch_manager, 
+
+    def parseGenerationMethod(self,
+                              input_batch_manager,
                               minibatch_size,
                               total_points,
                               rng):
-        #Logic for default behaviour.
-        #When minibatch_size is a small fraction of total_point
-        #ReplacementSampling should give similar results to 
-        #NoReplacementSampling and the former can be much faster.
-        if input_batch_manager==None: 
+        # Logic for default behaviour.
+        # When minibatch_size is a small fraction of total_point
+        # ReplacementSampling should give similar results to
+        # NoReplacementSampling and the former can be much faster.
+        if input_batch_manager is None:
             fraction = float(minibatch_size) / float(total_points)
             if fraction < 0.5:
                 self.index_manager = ReplacementSampling(minibatch_size,
@@ -111,11 +114,11 @@ class MinibatchData(DataHolder):
                 self.index_manager = NoReplacementSampling(minibatch_size,
                                                            total_points,
                                                            rng)
-        else: #Explicitly specified behaviour.
+        else:  # Explicitly specified behaviour.
             if input_batch_manager.__class__ not in IndexManager.__subclasses__():
                 raise NotImplementedError
             self.index_manager = input_batch_manager
-            
+
     def update_feed_dict(self, key_dict, feed_dict):
-        next_indeces = self.index_manager.nextIndeces()
-        feed_dict[key_dict[self]] = self._array[next_indeces]
+        next_indices = self.index_manager.nextIndices()
+        feed_dict[key_dict[self]] = self._array[next_indices]

--- a/GPflow/minibatch.py
+++ b/GPflow/minibatch.py
@@ -34,8 +34,9 @@ class ReplacementSampling(IndexManager):
 
 class NoReplacementSampling(IndexManager):
     def __init__(self, minibatch_size, total_points, rng = None):
-        assert(minibatch_size<=total_points,
-               "replacement sampled minibatch size must be less than data size") 
+        #Can't sample without replacement is minibatch_size is larger 
+        #than total_points
+        assert(minibatch_size<=total_points) 
         IndexManager.__init__(self, minibatch_size, total_points, rng)
     
     def nextIndeces(self):

--- a/GPflow/minibatch.py
+++ b/GPflow/minibatch.py
@@ -1,0 +1,120 @@
+# Copyright 2016 James Hensman, Valentine Svensson, alexggmatthews, Mark van der Wilk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .param import DataHolder
+
+class IndexManager(object):
+    """
+    Base clase for methods of batch indexing data.
+    rng is an instance of np.random.RandomState, defaults to seed 0.
+    """
+    def __init__(self, minibatch_size, total_points, rng = None):
+        self.minibatch_size = minibatch_size
+        self.total_points = total_points
+        self.rng = rng or np.random.RandomState(0)
+        
+    def nextIndeces(self):
+        raise NotImplementedError
+
+class ReplacementSampling(IndexManager):
+	def nextIndeces(self):
+		return self.rng.randint(self.total_points, 
+		                        size=self.minibatch_size)
+
+class NoReplacementSampling(IndexManager):
+	def __init__(self, minibatch_size, total_points, rng = None):
+	    assert(minibatch_size<=total_points,
+	           "replacement sampled minibatch size must be less than data size") 
+	    IndexManager.__init__(self, minibatch_size, total_points, rng)
+	
+	def nextIndeces(self):
+		permutation = self.rng.permutation(self.total_points)
+		return permutation[:self.minibatch_size]
+
+class SequenceIndeces(IndexManager):
+    """
+    A class that maintains the state necessary to manage 
+    sequential indexing of data holders.
+    """
+    def __init__(self, minibatch_size, total_points, rng = None):
+        self.counter = 0
+        IndexManager.__init__(self, minibatch_size, total_points, rng)
+		
+    def nextIndeces(self):
+        """
+		Written so that if total_points
+		changes this will still work
+        """
+        firstIndex = self.counter
+        lastIndex = self.counter + self.minibatch_size
+        self.counter = lastIndex % self.total_points
+        return np.arange(firstIndex,lastIndex) % self.total_points
+
+class MinibatchData(DataHolder):
+    """
+    A special DataHolder class which feeds a minibatch 
+    to tensorflow via update_feed_dict().
+    """
+    
+    #List of valid specifiers for generation methods.
+    _generation_methods = ['replace','noreplace','sequential']
+    
+    def __init__(self, array, 
+                       minibatch_size, 
+                       rng=None, 
+                       batch_manager=None):
+        """
+        array is a numpy array of data.
+        minibatch_size (int) is the size of the minibatch
+        
+        batch_manager specified data sampling scheme and is a subclass 
+        of IndexManager.
+        
+        Note: you may want to randomize the order of the data 
+        if using sequential generation.
+        """
+        DataHolder.__init__(self, array, on_shape_change='pass')
+        total_points = self._array.shape[0]
+        self.parseGenerationMethod(batch_manager, 
+                                   minibatch_size, 
+                                   total_points,
+                                   rng)
+        
+    def parseGenerationMethod(self, 
+                              input_batch_manager, 
+                              minibatch_size,
+                              total_points,
+                              rng):
+        #Logic for default behaviour.
+        #When minibatch_size is a small fraction of total_point
+        #ReplacementSampling should give similar results to 
+        #NoReplacementSampling and the former can be much faster.
+        if input_batch_manager==None: 
+		    fraction = float(minibatch_size) / float(total_points)
+		    if fraction < 0.5:
+		        self.index_manager = ReplacementSampling(minibatch_size,
+		                                                 total_points,
+		                                                 rng)
+		    else:
+		        self.index_manager = NoReplacementSampling(minibatch_size,
+                                                           total_points,
+                                                           rng)
+        else: #Explicitly specified behaviour.
+		    if input_batch_manager.__class__ not in IndexManager.__subclasses__():
+			    raise NotImplementedError
+		    self.index_manager = input_batch_manager
+			
+    def update_feed_dict(self, key_dict, feed_dict):
+        next_indeces = self.index_manager.nextIndeces()
+        feed_dict[key_dict[self]] = self._array[next_indeces]

--- a/GPflow/minibatch.py
+++ b/GPflow/minibatch.py
@@ -100,21 +100,21 @@ class MinibatchData(DataHolder):
         #When minibatch_size is a small fraction of total_point
         #ReplacementSampling should give similar results to 
         #NoReplacementSampling and the former can be much faster.
-        if input_batch_manager==None: 
-		    fraction = float(minibatch_size) / float(total_points)
-		    if fraction < 0.5:
-		        self.index_manager = ReplacementSampling(minibatch_size,
-		                                                 total_points,
-		                                                 rng)
-		    else:
-		        self.index_manager = NoReplacementSampling(minibatch_size,
-                                                           total_points,
-                                                           rng)
-        else: #Explicitly specified behaviour.
-		    if input_batch_manager.__class__ not in IndexManager.__subclasses__():
-			    raise NotImplementedError
-		    self.index_manager = input_batch_manager
+		if input_batch_manager==None: 
+			fraction = float(minibatch_size) / float(total_points)
+			if fraction < 0.5:
+				self.index_manager = ReplacementSampling(minibatch_size,
+														 total_points,
+														 rng)
+			else:
+				self.index_manager = NoReplacementSampling(minibatch_size,
+														   total_points,
+	                                                       rng)
+		else: #Explicitly specified behaviour.
+			if input_batch_manager.__class__ not in IndexManager.__subclasses__():
+				raise NotImplementedError
+			self.index_manager = input_batch_manager
 			
-    def update_feed_dict(self, key_dict, feed_dict):
-        next_indeces = self.index_manager.nextIndeces()
-        feed_dict[key_dict[self]] = self._array[next_indeces]
+	def update_feed_dict(self, key_dict, feed_dict):
+		next_indeces = self.index_manager.nextIndeces()
+		feed_dict[key_dict[self]] = self._array[next_indeces]

--- a/GPflow/minibatch.py
+++ b/GPflow/minibatch.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import numpy as np
 from .param import DataHolder
 
 class IndexManager(object):

--- a/GPflow/svgp.py
+++ b/GPflow/svgp.py
@@ -111,7 +111,7 @@ class MinibatchData(DataHolder):
         #NoReplacementSampling and the former can be much faster.
         if input_batch_manager==None: 
 		    fraction = float(minibatch_size) / float(total_points)
-		    if fraction > 0.5:
+		    if fraction < 0.5:
 		        self.index_manager = ReplacementSampling(minibatch_size,
 		                                                 total_points,
 		                                                 rng)
@@ -160,7 +160,7 @@ class SVGP(GPModel):
         """
         # sort out the X, Y into MiniBatch objects.
         if minibatch_size is None:
-            minibatch_size = X.shape[0]
+            minibatch_size = X.shape[0]     
         self.num_data = X.shape[0]
         X = MinibatchData(X, minibatch_size, np.random.RandomState(0))
         Y = MinibatchData(Y, minibatch_size, np.random.RandomState(0))

--- a/GPflow/svgp.py
+++ b/GPflow/svgp.py
@@ -76,7 +76,7 @@ class MinibatchData(DataHolder):
         DataHolder.__init__(self, array, on_shape_change='pass')
         self.minibatch_size = minibatch_size
         self.rng = rng or np.random.RandomState(0)
-        parseGenerationMethod(generation_method)
+        self.parseGenerationMethod(generation_method)
         
     def parseGenerationMethod(self, input_generation_method):
         if input_generation_method==None: #Default behaviour.

--- a/GPflow/svgp.py
+++ b/GPflow/svgp.py
@@ -44,7 +44,7 @@ class ReplacementSampling(IndexManager):
 class NoReplacementSampling(IndexManager):
 	def nextIndeces(self):
 		permutation = self.rng.permutation(self.total_points)
-		return permuatation[:self.minibatch_size]
+		return permutation[:self.minibatch_size]
 
 class SequenceIndeces(IndexManager):
     """

--- a/GPflow/svgp.py
+++ b/GPflow/svgp.py
@@ -22,6 +22,7 @@ from . import transforms, conditionals, kullback_leiblers
 from .mean_functions import Zero
 from .tf_wraps import eye
 from ._settings import settings
+from IPython import embed
 
 class SequenceIndexManager:
     """
@@ -41,7 +42,7 @@ class SequenceIndexManager:
         
         firstIndex = self.counter
         lastIndex = self.counter + self.minibatch_size
-        self.counter = (lastIndex+1) % total_points
+        self.counter = lastIndex % total_points
         return np.arange(firstIndex,lastIndex) % total_points
 
 class MinibatchData(DataHolder):

--- a/GPflow/svgp.py
+++ b/GPflow/svgp.py
@@ -22,7 +22,6 @@ from . import transforms, conditionals, kullback_leiblers
 from .mean_functions import Zero
 from .tf_wraps import eye
 from ._settings import settings
-from IPython import embed
 
 class SequenceIndexManager:
     """

--- a/GPflow/svgp.py
+++ b/GPflow/svgp.py
@@ -42,6 +42,11 @@ class ReplacementSampling(IndexManager):
 		                        size=self.minibatch_size)
 
 class NoReplacementSampling(IndexManager):
+	def __init__(self, minibatch_size, total_points, rng = None):
+	    assert(minibatch_size<=total_points,
+	           "replacement sampled minibatch size must be less than data size") 
+	    IndexManager.__init__(self, minibatch_size, total_points, rng)
+	
 	def nextIndeces(self):
 		permutation = self.rng.permutation(self.total_points)
 		return permutation[:self.minibatch_size]

--- a/testing/test_methods.py
+++ b/testing/test_methods.py
@@ -17,7 +17,6 @@ from GPflow.svgp import SequenceIndeces
 import numpy as np
 import unittest
 import tensorflow as tf
-from IPython import embed
 
 class TestMethods(unittest.TestCase):
     def setUp(self):
@@ -194,7 +193,7 @@ class TestStochasticGradients(unittest.TestCase):
         return model		
         		
     def getTfOptimizer(self):
-        learning_rate = 1.
+        learning_rate = .1
         opt = tf.train.GradientDescentOptimizer(learning_rate, 
                                                 use_locking=True)
         return opt
@@ -214,7 +213,10 @@ class TestStochasticGradients(unittest.TestCase):
                 return False
         return True
     
-    def compareTwoModels(self,indecesOne,indecesTwo,batchOne,batchTwo):
+    def compareTwoModels(self,indecesOne,indecesTwo,
+                              batchOne,batchTwo,
+                              maxiter,
+                              checkSame=True):
         modelOne = self.getIndexedModel(self.XAB,
                                         self.YAB,
                                         self.sharedZ,
@@ -225,27 +227,34 @@ class TestStochasticGradients(unittest.TestCase):
                                         self.sharedZ,
                                         batchTwo,
                                         indecesTwo)
-        modelOne.optimize(method=self.getTfOptimizer(),maxiter=1)
-        modelTwo.optimize(method=self.getTfOptimizer(),maxiter=1)
-        self.assertTrue(self.checkModelsClose(modelOne,modelTwo))        
+        modelOne.optimize(method=self.getTfOptimizer(),maxiter=maxiter)
+        modelTwo.optimize(method=self.getTfOptimizer(),maxiter=maxiter)
+        if checkSame:
+			self.assertTrue(self.checkModelsClose(modelOne,modelTwo))        
+        else:
+			self.assertFalse(self.checkModelsClose(modelOne,modelTwo)) 			
         
     def testOne(self):	
         self.compareTwoModels([self.indexA,self.indexB],
                               [self.indexB,self.indexA],
                               2,
-                              2)
+                              2,
+                              3)
                               
     def testTwo(self):
         self.compareTwoModels([self.indexA,self.indexB],
                               [self.indexA,self.indexA],
                               1,
-                              2)        
-			
-    def testThree(self):	
-        self.compareTwoModels([self.indexB,self.indexA],
-                              [self.indexB,self.indexB],
+                              2,
+                              1)        
+			                              
+    def testThree(self):
+        self.compareTwoModels([self.indexA,self.indexA],
+                              [self.indexA,self.indexB],
                               1,
-                              2)          
+                              1,
+                              2,
+                              False)		          
 
 class TestSparseMCMC(unittest.TestCase):
     """

--- a/testing/test_methods.py
+++ b/testing/test_methods.py
@@ -155,6 +155,41 @@ class TestSVGP(unittest.TestCase):
         m1._compile()
 
 
+	def getModel(self,X,Y,Z,minibatch_size):
+		model = GPflow.svgp.SVGP(X,
+		                         Y,
+		                         kern = GPflow.kernels.RBF(1),
+								 likelihood = GPflow.likelihoods.Gaussian(),
+								 Z = Z)
+		
+		return model
+
+    def test_stochastic_gradients(self):
+        """
+        In response to bug #281, we need to make sure stochastic update
+        happens correctly in tf optimizer mode.
+        To do this compare stochastic updates with deterministic updates
+        that should be equivalent.
+        """		
+        X = np.atleast_2d(np.array([0.,1.])).T
+        Y = np.atleast_2d(np.array([-1.,3.])).T
+        sharedZ = np.atleast_2d(np.array([0.5]) )
+        nDataPoints = X.shape[0]
+        nOptimizerIterations = 1
+        
+        
+        Xs = []
+        Ys = []
+        models = []
+        
+        for index in range(nDataPoints):
+			Xs.append(np.vstack( [ X[index,:] for i in range(nDataPoints) ] ))
+			Ys.append(np.vstack( [ Y[index,:] for i in range(nDataPoints) ] ))
+		    
+		for repeatIndex in range(nDataPoints):
+		
+			
+        
 class TestSparseMCMC(unittest.TestCase):
     """
     This test makes sure that when the inducing points are the same as the data

--- a/testing/test_methods.py
+++ b/testing/test_methods.py
@@ -13,7 +13,7 @@
 # limitations under the License.from __future__ import print_function
 
 import GPflow
-from GPflow.minibatch import SequenceIndeces
+from GPflow.minibatch import SequenceIndices
 import numpy as np
 import unittest
 import tensorflow as tf
@@ -188,8 +188,8 @@ class TestStochasticGradients(unittest.TestCase):
                                  Z = Z,
                                  minibatch_size=minibatch_size)
         #This step changes the batch indeces to cycle.
-        model.X.index_manager = SequenceIndeces(minibatch_size,X.shape[0])
-        model.Y.index_manager = SequenceIndeces(minibatch_size,X.shape[0])
+        model.X.index_manager = SequenceIndices(minibatch_size,X.shape[0])
+        model.Y.index_manager = SequenceIndices(minibatch_size,X.shape[0])
         return model        
                 
     def getTfOptimizer(self):

--- a/testing/test_methods.py
+++ b/testing/test_methods.py
@@ -168,7 +168,7 @@ class TestStochasticGradients(unittest.TestCase):
     In this test we substitute a deterministic analogue of the batchs
     sampler for which we can predict the effects of different updates.
     """
-    def setUp(self):		
+    def setUp(self):        
         self.XAB = np.atleast_2d(np.array([0.,1.])).T
         self.YAB = np.atleast_2d(np.array([-1.,3.])).T
         self.sharedZ = np.atleast_2d(np.array([0.5]) )
@@ -179,25 +179,25 @@ class TestStochasticGradients(unittest.TestCase):
         newX = baseX[indeces]
         newY = baseY[indeces]
         return newX, newY
-			
+            
     def getModel(self,X,Y,Z,minibatch_size):
         model = GPflow.svgp.SVGP(X,
-		                         Y,
-		                         kern = GPflow.kernels.RBF(1),
-								 likelihood = GPflow.likelihoods.Gaussian(),
-								 Z = Z,
+                                 Y,
+                                 kern = GPflow.kernels.RBF(1),
+                                 likelihood = GPflow.likelihoods.Gaussian(),
+                                 Z = Z,
                                  minibatch_size=minibatch_size)
         #This step changes the batch indeces to cycle.
         model.X.index_manager = SequenceIndeces(minibatch_size,X.shape[0])
         model.Y.index_manager = SequenceIndeces(minibatch_size,X.shape[0])
-        return model		
-        		
+        return model        
+                
     def getTfOptimizer(self):
         learning_rate = .1
         opt = tf.train.GradientDescentOptimizer(learning_rate, 
                                                 use_locking=True)
         return opt
-        		
+                
     def getIndexedModel(self,X,Y,Z,minibatch_size,indeces):
         Xindeces,Yindeces = self.getIndexedData(X,Y,indeces)
         indexedModel = self.getModel(Xindeces,Yindeces,Z,minibatch_size)
@@ -230,11 +230,11 @@ class TestStochasticGradients(unittest.TestCase):
         modelOne.optimize(method=self.getTfOptimizer(),maxiter=maxiter)
         modelTwo.optimize(method=self.getTfOptimizer(),maxiter=maxiter)
         if checkSame:
-			self.assertTrue(self.checkModelsClose(modelOne,modelTwo))        
+            self.assertTrue(self.checkModelsClose(modelOne,modelTwo))        
         else:
-			self.assertFalse(self.checkModelsClose(modelOne,modelTwo)) 			
+            self.assertFalse(self.checkModelsClose(modelOne,modelTwo))          
         
-    def testOne(self):	
+    def testOne(self):  
         self.compareTwoModels([self.indexA,self.indexB],
                               [self.indexB,self.indexA],
                               2,
@@ -247,14 +247,14 @@ class TestStochasticGradients(unittest.TestCase):
                               1,
                               2,
                               1)        
-			                              
+                                          
     def testThree(self):
         self.compareTwoModels([self.indexA,self.indexA],
                               [self.indexA,self.indexB],
                               1,
                               1,
                               2,
-                              False)		          
+                              False)                  
 
 class TestSparseMCMC(unittest.TestCase):
     """

--- a/testing/test_methods.py
+++ b/testing/test_methods.py
@@ -13,7 +13,7 @@
 # limitations under the License.from __future__ import print_function
 
 import GPflow
-from GPflow.svgp import SequenceIndeces
+from GPflow.minibatch import SequenceIndeces
 import numpy as np
 import unittest
 import tensorflow as tf

--- a/testing/test_minibatch_data.py
+++ b/testing/test_minibatch_data.py
@@ -30,17 +30,22 @@ class TestSequentialManager(unittest.TestCase):
 		self.assertTrue((indecesA==np.arange(0,minibatch_size)).all())
 
 		indecesB = sequenceManager.nextIndeces(total_points)
-		self.assertTrue((indecesB==np.array([4,0,1 ])).all())
+		self.assertTrue((indecesB==np.array([3,4,0 ])).all())
 	
     def testB(self):
 		minibatch_size = 5
 		total_points = 2
 		sequenceManager = SequenceIndexManager(minibatch_size)
 		
-		indeces = sequenceManager.nextIndeces(total_points)
-		targetIndeces = np.array([0,1,0,1,0])
+		indecesA = sequenceManager.nextIndeces(total_points)
+		targetIndecesA = np.array([0,1,0,1,0])
 			
-		self.assertTrue((indeces==targetIndeces).all())
+		self.assertTrue((indecesA==targetIndecesA).all())
+
+		indecesB = sequenceManager.nextIndeces(total_points)
+		targetIndecesB = np.array([1,0,1,0,1])
+			
+		self.assertTrue((indecesB==targetIndecesB).all())
 	
 if __name__ == "__main__":
     unittest.main()

--- a/testing/test_minibatch_data.py
+++ b/testing/test_minibatch_data.py
@@ -15,8 +15,8 @@
 import tensorflow as tf
 import numpy as np
 import unittest
-from GPflow.svgp import SequenceIndeces, MinibatchData
-from GPflow.svgp import ReplacementSampling, NoReplacementSampling
+from GPflow.minibatch import SequenceIndeces, MinibatchData
+from GPflow.minibatch import ReplacementSampling, NoReplacementSampling
 
 class TestSequentialManager(unittest.TestCase):
     def setUp(self):

--- a/testing/test_minibatch_data.py
+++ b/testing/test_minibatch_data.py
@@ -75,13 +75,13 @@ class TestRandomIndexManagers(unittest.TestCase):
         data_size_err = 3
         constructor = lambda : NoReplacementSampling(mini_size_err,
                                                      data_size_err)
-        self.assertRaises(constructor)
+        self.assertRaises(AssertionError,constructor)
         
         mini_size = 3
         data_size = 3
         nrs = NoReplacementSampling(mini_size,data_size)
         indeces = np.sort(nrs.nextIndeces()).tolist()
-        self.assertEqual(indeces,range(data_size))
+        self.assertEqual(indeces,[0,1,2])
 
         one = 1     
         nrsb = NoReplacementSampling(one,data_size)

--- a/testing/test_minibatch_data.py
+++ b/testing/test_minibatch_data.py
@@ -120,6 +120,19 @@ class TestMinibatchData(unittest.TestCase):
         test_dict = {output_string : test_out_array }                     
         self.assertEqual(feed_dict.keys(),test_dict.keys())
         self.assertTrue((feed_dict[output_string]==test_out_array).all())
-        
+
+    def testC(self):
+        #Test the manager selection logic.
+        md = MinibatchData(self.dummyArray, 
+                           self.minibatch_size, 
+                           rng=None)        
+        self.assertEqual(md.index_manager.__class__, ReplacementSampling)                  
+
+
+        md = MinibatchData(self.dummyArray, 
+                           self.minibatch_size*2, 
+                           rng=None)        
+        self.assertEqual(md.index_manager.__class__, NoReplacementSampling)          
+ 
 if __name__ == "__main__":
     unittest.main()

--- a/testing/test_minibatch_data.py
+++ b/testing/test_minibatch_data.py
@@ -15,7 +15,7 @@
 import tensorflow as tf
 import numpy as np
 import unittest
-from GPflow.svgp import SequenceIndexManager, MinibatchData
+from GPflow.svgp import SequenceIndeces, MinibatchData
 
 class TestSequentialManager(unittest.TestCase):
     def setUp(self):
@@ -24,25 +24,25 @@ class TestSequentialManager(unittest.TestCase):
     def testA(self):
 		minibatch_size = 3
 		total_points = 5
-		sequenceManager = SequenceIndexManager(minibatch_size)
+		sequenceManager = SequenceIndeces(minibatch_size,total_points)
 		
-		indecesA = sequenceManager.nextIndeces(total_points)
+		indecesA = sequenceManager.nextIndeces()
 		self.assertTrue((indecesA==np.arange(0,minibatch_size)).all())
 
-		indecesB = sequenceManager.nextIndeces(total_points)
+		indecesB = sequenceManager.nextIndeces()
 		self.assertTrue((indecesB==np.array([3,4,0 ])).all())
 	
     def testB(self):
 		minibatch_size = 5
 		total_points = 2
-		sequenceManager = SequenceIndexManager(minibatch_size)
+		sequenceManager = SequenceIndeces(minibatch_size,total_points)
 		
-		indecesA = sequenceManager.nextIndeces(total_points)
+		indecesA = sequenceManager.nextIndeces()
 		targetIndecesA = np.array([0,1,0,1,0])
 			
 		self.assertTrue((indecesA==targetIndecesA).all())
 
-		indecesB = sequenceManager.nextIndeces(total_points)
+		indecesB = sequenceManager.nextIndeces()
 		targetIndecesB = np.array([1,0,1,0,1])
 			
 		self.assertTrue((indecesB==targetIndecesB).all())
@@ -52,16 +52,29 @@ class TestMinibatchData(unittest.TestCase):
 		tf.reset_default_graph()
 		self.nDataPoints = 10
 		self.minibatch_size = 4
-		self.dummyArray = np.zeros((self.nDataPoints,1))
-		
-		
+		self.dummyArray = np.atleast_2d(np.arange(self.nDataPoints)).T
+				
 	def testA(self):
-		fake = 'sdfnkj'
 		constructor = lambda : MinibatchData(self.dummyArray, 
                                          self.minibatch_size, 
                                          rng=None, 
-                                         generation_method=fake)
+                                         batch_manager=[])
 		self.assertRaises(NotImplementedError,constructor)
+
+	def testB(self):
+		sm = SequenceIndeces(self.minibatch_size, self.nDataPoints)
+		md = MinibatchData(self.dummyArray, 
+                           self.minibatch_size, 
+                           rng=None, 
+                           batch_manager=sm)
+		output_string = 'test_out'
+		key_dict = {md: output_string}
+		feed_dict = {} 
+		md.update_feed_dict( key_dict, feed_dict )
+		test_out_array = np.atleast_2d(np.arange(self.minibatch_size)).T
+		test_dict = {output_string : test_out_array }                     
+		self.assertEqual(feed_dict.keys(),test_dict.keys())
+		self.assertTrue((feed_dict[output_string]==test_out_array).all())
 		
 if __name__ == "__main__":
     unittest.main()

--- a/testing/test_minibatch_data.py
+++ b/testing/test_minibatch_data.py
@@ -46,6 +46,22 @@ class TestSequentialManager(unittest.TestCase):
 		targetIndecesB = np.array([1,0,1,0,1])
 			
 		self.assertTrue((indecesB==targetIndecesB).all())
-	
+
+class TestMinibatchData(unittest.TestCase):
+	def setUp(self):
+		tf.reset_default_graph()
+		self.nDataPoints = 10
+		self.minibatch_size = 4
+		self.dummyArray = np.zeros((self.nDataPoints,1))
+		
+		
+	def testA(self):
+		fake = 'sdfnkj'
+		constructor = lambda : MinibatchData(self.dummyArray, 
+                                         self.minibatch_size, 
+                                         rng=None, 
+                                         generation_method=fake)
+		self.assertRaises(NotImplementedError,constructor)
+		
 if __name__ == "__main__":
     unittest.main()

--- a/testing/test_minibatch_data.py
+++ b/testing/test_minibatch_data.py
@@ -15,7 +15,7 @@
 import tensorflow as tf
 import numpy as np
 import unittest
-from GPflow.minibatch import SequenceIndeces, MinibatchData
+from GPflow.minibatch import SequenceIndices, MinibatchData
 from GPflow.minibatch import ReplacementSampling, NoReplacementSampling
 
 class TestSequentialManager(unittest.TestCase):
@@ -25,28 +25,28 @@ class TestSequentialManager(unittest.TestCase):
     def testA(self):
         minibatch_size = 3
         total_points = 5
-        sequenceManager = SequenceIndeces(minibatch_size,total_points)
+        sequenceManager = SequenceIndices(minibatch_size,total_points)
         
-        indecesA = sequenceManager.nextIndeces()
+        indecesA = sequenceManager.nextIndices()
         self.assertTrue((indecesA==np.arange(0,minibatch_size)).all())
 
-        indecesB = sequenceManager.nextIndeces()
+        indecesB = sequenceManager.nextIndices()
         self.assertTrue((indecesB==np.array([3,4,0 ])).all())
     
     def testB(self):
         minibatch_size = 5
         total_points = 2
-        sequenceManager = SequenceIndeces(minibatch_size,total_points)
+        sequenceManager = SequenceIndices(minibatch_size,total_points)
         
-        indecesA = sequenceManager.nextIndeces()
-        targetIndecesA = np.array([0,1,0,1,0])
+        indecesA = sequenceManager.nextIndices()
+        targetIndicesA = np.array([0,1,0,1,0])
             
-        self.assertTrue((indecesA==targetIndecesA).all())
+        self.assertTrue((indecesA==targetIndicesA).all())
 
-        indecesB = sequenceManager.nextIndeces()
-        targetIndecesB = np.array([1,0,1,0,1])
+        indecesB = sequenceManager.nextIndices()
+        targetIndicesB = np.array([1,0,1,0,1])
             
-        self.assertTrue((indecesB==targetIndecesB).all())
+        self.assertTrue((indecesB==targetIndicesB).all())
 
 class TestRandomIndexManagers(unittest.TestCase):
     def setUp(self):
@@ -67,7 +67,7 @@ class TestRandomIndexManagers(unittest.TestCase):
         data_size = 3
         tolerance = 1e-2
         rs = ReplacementSampling(minibatch_size,data_size)
-        indeces = rs.nextIndeces().tolist()
+        indeces = rs.nextIndices().tolist()
         self.assertTrue(self.checkUniformDist(indeces,data_size))
                     
     def testNoReplacement(self):
@@ -80,7 +80,7 @@ class TestRandomIndexManagers(unittest.TestCase):
         mini_size = 3
         data_size = 3
         nrs = NoReplacementSampling(mini_size,data_size)
-        indeces = np.sort(nrs.nextIndeces()).tolist()
+        indeces = np.sort(nrs.nextIndices()).tolist()
         self.assertEqual(indeces,[0,1,2])
 
         one = 1     
@@ -88,7 +88,7 @@ class TestRandomIndexManagers(unittest.TestCase):
         
         indecesOverall = []
         for repeatIndex in range(3000):
-            indeces = nrsb.nextIndeces().tolist()
+            indeces = nrsb.nextIndices().tolist()
             indecesOverall = indecesOverall + indeces
         self.assertTrue(self.checkUniformDist(indecesOverall,data_size))
             
@@ -107,7 +107,7 @@ class TestMinibatchData(unittest.TestCase):
         self.assertRaises(NotImplementedError,constructor)
 
     def testB(self):
-        sm = SequenceIndeces(self.minibatch_size, self.nDataPoints)
+        sm = SequenceIndices(self.minibatch_size, self.nDataPoints)
         md = MinibatchData(self.dummyArray, 
                            self.minibatch_size, 
                            rng=None, 

--- a/testing/test_minibatch_data.py
+++ b/testing/test_minibatch_data.py
@@ -1,0 +1,46 @@
+# Copyright 2016 alexggmatthews
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+import numpy as np
+import unittest
+from GPflow.svgp import SequenceIndexManager, MinibatchData
+
+class TestSequentialManager(unittest.TestCase):
+    def setUp(self):
+        tf.reset_default_graph()
+     
+    def testA(self):
+		minibatch_size = 3
+		total_points = 5
+		sequenceManager = SequenceIndexManager(minibatch_size)
+		
+		indecesA = sequenceManager.nextIndeces(total_points)
+		self.assertTrue((indecesA==np.arange(0,minibatch_size)).all())
+
+		indecesB = sequenceManager.nextIndeces(total_points)
+		self.assertTrue((indecesB==np.array([4,0,1 ])).all())
+	
+    def testB(self):
+		minibatch_size = 5
+		total_points = 2
+		sequenceManager = SequenceIndexManager(minibatch_size)
+		
+		indeces = sequenceManager.nextIndeces(total_points)
+		targetIndeces = np.array([0,1,0,1,0])
+			
+		self.assertTrue((indeces==targetIndeces).all())
+	
+if __name__ == "__main__":
+    unittest.main()

--- a/testing/test_minibatch_data.py
+++ b/testing/test_minibatch_data.py
@@ -23,30 +23,30 @@ class TestSequentialManager(unittest.TestCase):
         tf.reset_default_graph()
      
     def testA(self):
-		minibatch_size = 3
-		total_points = 5
-		sequenceManager = SequenceIndeces(minibatch_size,total_points)
-		
-		indecesA = sequenceManager.nextIndeces()
-		self.assertTrue((indecesA==np.arange(0,minibatch_size)).all())
+        minibatch_size = 3
+        total_points = 5
+        sequenceManager = SequenceIndeces(minibatch_size,total_points)
+        
+        indecesA = sequenceManager.nextIndeces()
+        self.assertTrue((indecesA==np.arange(0,minibatch_size)).all())
 
-		indecesB = sequenceManager.nextIndeces()
-		self.assertTrue((indecesB==np.array([3,4,0 ])).all())
-	
+        indecesB = sequenceManager.nextIndeces()
+        self.assertTrue((indecesB==np.array([3,4,0 ])).all())
+    
     def testB(self):
-		minibatch_size = 5
-		total_points = 2
-		sequenceManager = SequenceIndeces(minibatch_size,total_points)
-		
-		indecesA = sequenceManager.nextIndeces()
-		targetIndecesA = np.array([0,1,0,1,0])
-			
-		self.assertTrue((indecesA==targetIndecesA).all())
+        minibatch_size = 5
+        total_points = 2
+        sequenceManager = SequenceIndeces(minibatch_size,total_points)
+        
+        indecesA = sequenceManager.nextIndeces()
+        targetIndecesA = np.array([0,1,0,1,0])
+            
+        self.assertTrue((indecesA==targetIndecesA).all())
 
-		indecesB = sequenceManager.nextIndeces()
-		targetIndecesB = np.array([1,0,1,0,1])
-			
-		self.assertTrue((indecesB==targetIndecesB).all())
+        indecesB = sequenceManager.nextIndeces()
+        targetIndecesB = np.array([1,0,1,0,1])
+            
+        self.assertTrue((indecesB==targetIndecesB).all())
 
 class TestRandomIndexManagers(unittest.TestCase):
     def setUp(self):
@@ -56,70 +56,70 @@ class TestRandomIndexManagers(unittest.TestCase):
         fTotalPoints = float(len(indeces))
         tolerance = 1e-2
         for possibleIndex in range(nChoices):
-			empirical = indeces.count(possibleIndex) / fTotalPoints
-			error = np.abs(empirical - 1./nChoices)        
-			if error > tolerance:
-				return False
+            empirical = indeces.count(possibleIndex) / fTotalPoints
+            error = np.abs(empirical - 1./nChoices)        
+            if error > tolerance:
+                return False
         return True
         
     def testReplacement(self):
-		minibatch_size = 1000
-		data_size = 3
-		tolerance = 1e-2
-		rs = ReplacementSampling(minibatch_size,data_size)
-		indeces = rs.nextIndeces().tolist()
-		self.assertTrue(self.checkUniformDist(indeces,data_size))
-					
+        minibatch_size = 1000
+        data_size = 3
+        tolerance = 1e-2
+        rs = ReplacementSampling(minibatch_size,data_size)
+        indeces = rs.nextIndeces().tolist()
+        self.assertTrue(self.checkUniformDist(indeces,data_size))
+                    
     def testNoReplacement(self):
-		mini_size_err = 5
-		data_size_err = 3
-		constructor = lambda : NoReplacementSampling(mini_size_err,
-		                                             data_size_err)
-		self.assertRaises(constructor)
-		
-		mini_size = 3
-		data_size = 3
-		nrs = NoReplacementSampling(mini_size,data_size)
-		indeces = np.sort(nrs.nextIndeces()).tolist()
-		self.assertEqual(indeces,range(data_size))
+        mini_size_err = 5
+        data_size_err = 3
+        constructor = lambda : NoReplacementSampling(mini_size_err,
+                                                     data_size_err)
+        self.assertRaises(constructor)
+        
+        mini_size = 3
+        data_size = 3
+        nrs = NoReplacementSampling(mini_size,data_size)
+        indeces = np.sort(nrs.nextIndeces()).tolist()
+        self.assertEqual(indeces,range(data_size))
 
-		one = 1		
-		nrsb = NoReplacementSampling(one,data_size)
-		
-		indecesOverall = []
-		for repeatIndex in range(3000):
-			indeces = nrsb.nextIndeces().tolist()
-			indecesOverall = indecesOverall + indeces
-		self.assertTrue(self.checkUniformDist(indecesOverall,data_size))
-			
+        one = 1     
+        nrsb = NoReplacementSampling(one,data_size)
+        
+        indecesOverall = []
+        for repeatIndex in range(3000):
+            indeces = nrsb.nextIndeces().tolist()
+            indecesOverall = indecesOverall + indeces
+        self.assertTrue(self.checkUniformDist(indecesOverall,data_size))
+            
 class TestMinibatchData(unittest.TestCase):
-	def setUp(self):
-		tf.reset_default_graph()
-		self.nDataPoints = 10
-		self.minibatch_size = 4
-		self.dummyArray = np.atleast_2d(np.arange(self.nDataPoints)).T
-				
-	def testA(self):
-		constructor = lambda : MinibatchData(self.dummyArray, 
+    def setUp(self):
+        tf.reset_default_graph()
+        self.nDataPoints = 10
+        self.minibatch_size = 4
+        self.dummyArray = np.atleast_2d(np.arange(self.nDataPoints)).T
+                
+    def testA(self):
+        constructor = lambda : MinibatchData(self.dummyArray, 
                                          self.minibatch_size, 
                                          rng=None, 
                                          batch_manager=[])
-		self.assertRaises(NotImplementedError,constructor)
+        self.assertRaises(NotImplementedError,constructor)
 
-	def testB(self):
-		sm = SequenceIndeces(self.minibatch_size, self.nDataPoints)
-		md = MinibatchData(self.dummyArray, 
+    def testB(self):
+        sm = SequenceIndeces(self.minibatch_size, self.nDataPoints)
+        md = MinibatchData(self.dummyArray, 
                            self.minibatch_size, 
                            rng=None, 
                            batch_manager=sm)
-		output_string = 'test_out'
-		key_dict = {md: output_string}
-		feed_dict = {} 
-		md.update_feed_dict( key_dict, feed_dict )
-		test_out_array = np.atleast_2d(np.arange(self.minibatch_size)).T
-		test_dict = {output_string : test_out_array }                     
-		self.assertEqual(feed_dict.keys(),test_dict.keys())
-		self.assertTrue((feed_dict[output_string]==test_out_array).all())
-		
+        output_string = 'test_out'
+        key_dict = {md: output_string}
+        feed_dict = {} 
+        md.update_feed_dict( key_dict, feed_dict )
+        test_out_array = np.atleast_2d(np.arange(self.minibatch_size)).T
+        test_dict = {output_string : test_out_array }                     
+        self.assertEqual(feed_dict.keys(),test_dict.keys())
+        self.assertTrue((feed_dict[output_string]==test_out_array).all())
+        
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #284 
Includes regression test for #281 
This one will need squash merging, please.

I've pulled out a lot of the minibatch functionality, tidied it and added unit tests. I've also added a deterministic minibatcher that cycles through the data.

The cyclic minibatcher enabled me to give much more precise tests of the expected behaviour of SVGP. It could also be useful in general but the interface is not intuitive. I suggest we keep it as an expert feature. 

