### PR TITLE
fix minor bug in MultiClass likelihood when passing invlink

### DIFF
--- a/GPflow/likelihoods.py
+++ b/GPflow/likelihoods.py
@@ -414,9 +414,9 @@ class MultiClass(Likelihood):
         self.num_classes = num_classes
         if invlink is None:
             invlink = RobustMax(self.num_classes)
-            self.invlink = invlink
         elif not isinstance(invlink, RobustMax):
             raise NotImplementedError
+        self.invlink = invlink
 
     def logp(self, F, Y):
         if isinstance(self.invlink, RobustMax):


### PR DESCRIPTION
The `MultiClass` likelihood allows you to pass in an `invlink` explicitly, as long as it's a `RobustMax`. But if you did that, it wouldn't actually set `self.invlink` and the object would be broken.

I doubt anyone was likely to do that, but it might as well work.