### PR TITLE
Compatibility with next version of TensorFlow

### DIFF
--- a/GPflow/densities.py
+++ b/GPflow/densities.py
@@ -30,7 +30,7 @@ def lognormal(x, mu, var):
 
 
 def bernoulli(p, y):
-    return tf.log(tf.select(tf.equal(y, 1), p, 1-p))
+    return tf.log(tf.where(tf.equal(y, 1), p, 1-p))
 
 
 def poisson(lamb, y):

--- a/GPflow/ekernels.py
+++ b/GPflow/ekernels.py
@@ -264,8 +264,7 @@ class Add(kernels.Add):
 
         # transform points based on Gaussian parameters
         cholXcov = tf.cholesky(Xcov)  # NxDxD
-        Xt = tf.batch_matmul(cholXcov, tf.tile(xn[None, :, :], (N, 1, 1)),
-                             adj_y=True)  # NxDxH**D
+        Xt = tf.matmul(cholXcov, tf.tile(xn[None, :, :], (N, 1, 1)), transpose_b=True)  # NxDxH**D
 
         X = 2.0 ** 0.5 * Xt + tf.expand_dims(Xmu, 2)  # NxDxH**D
         Xr = tf.reshape(tf.transpose(X, [2, 0, 1]), (-1, self.input_dim))  # (H**D*N)xD

--- a/GPflow/ekernels.py
+++ b/GPflow/ekernels.py
@@ -61,10 +61,10 @@ class RBF(kernels.RBF):
         M = tf.shape(Z)[0]
         N = tf.shape(Xmu)[0] - 1
         D = tf.shape(Xmu)[1]
-        Xsigmb = tf.slice(Xcov, [0, 0, 0, 0], tf.pack([-1, N, -1, -1]))
+        Xsigmb = tf.slice(Xcov, [0, 0, 0, 0], tf.stack([-1, N, -1, -1]))
         Xsigm = Xsigmb[0, :, :, :]  # NxDxD
         Xsigmc = Xsigmb[1, :, :, :]  # NxDxD
-        Xmum = tf.slice(Xmu, [0, 0], tf.pack([N, -1]))
+        Xmum = tf.slice(Xmu, [0, 0], tf.stack([N, -1]))
         Xmup = Xmu[1:, :]
         lengthscales = self.lengthscales if self.ARD else tf.zeros((D,), dtype=float_type) + self.lengthscales
         scalemat = tf.expand_dims(tf.diag(lengthscales ** 2.0), 0) + Xsigm  # NxDxD
@@ -79,10 +79,10 @@ class RBF(kernels.RBF):
         smIvec = tf.matrix_solve(rsm, tf.expand_dims(vec, 3))[:, :, :, 0]  # NxMxDx1
         q = tf.reduce_sum(smIvec * vec, [2])  # NxM
 
-        addvec = tf.batch_matmul(
+        addvec = tf.matmul(
             tf.tile(tf.expand_dims(Xsigmc, 1), (1, M, 1, 1)),
             tf.expand_dims(smIvec, 3),
-            adj_x=True
+            transpose_a=True
         )[:, :, :, 0] + tf.expand_dims(Xmup, 1)  # NxMxD
 
         return self.variance * addvec * tf.reshape(det ** -0.5, (N, 1, 1)) * tf.expand_dims(tf.exp(-0.5 * q), 2)
@@ -132,7 +132,7 @@ class Linear(kernels.Linear):
             raise NotImplementedError
         # use only active dimensions
         Z, Xmu = self._slice(Z, Xmu)
-        return self.variance * tf.batch_matmul(Xmu, tf.transpose(Z))
+        return self.variance * tf.matmul(Xmu, tf.transpose(Z))
 
     def exKxz(self, Z, Xmu, Xcov):
         with tf.control_dependencies([
@@ -146,7 +146,7 @@ class Linear(kernels.Linear):
         Xmum = Xmu[:-1, :]
         Xmup = Xmu[1:, :]
         op = tf.expand_dims(Xmum, 2) * tf.expand_dims(Xmup, 1) + Xcov[1, :-1, :, :]  # NxDxD
-        return self.variance * tf.batch_matmul(tf.tile(tf.expand_dims(Z, 0), (N, 1, 1)), op)
+        return self.variance * tf.matmul(tf.tile(tf.expand_dims(Z, 0), (N, 1, 1)), op)
 
     def eKzxKxz(self, Z, Xmu, Xcov):
         """
@@ -162,7 +162,7 @@ class Linear(kernels.Linear):
         N = tf.shape(Xmu)[0]
         mom2 = tf.expand_dims(Xmu, 1) * tf.expand_dims(Xmu, 2) + Xcov  # NxDxD
         eZ = tf.tile(tf.expand_dims(Z, 0), (N, 1, 1))  # NxMxD
-        return self.variance ** 2.0 * tf.batch_matmul(tf.batch_matmul(eZ, mom2), eZ, adj_y=True)
+        return self.variance ** 2.0 * tf.matmul(tf.matmul(eZ, mom2), eZ, transpose_b=True)
 
 
 class Add(kernels.Add):
@@ -244,10 +244,10 @@ class Add(kernels.Add):
         vecplus = (Z[None, :, :, None] / lengthscales2[None, None, :, None] +
                    tf.matrix_solve(Xcov, Xmu[:, :, None])[:, None, :, :])  # NxMxDx1
         mean = tf.cholesky_solve(tcgm,
-                                 tf.batch_matmul(tf.tile(Xcov[:, None, :, :], [1, M, 1, 1]), vecplus)
+                                 tf.matmul(tf.tile(Xcov[:, None, :, :], [1, M, 1, 1]), vecplus)
                                  )[:, :, :, 0] * lengthscales2[None, None, :]  # NxMxD
-        a = tf.batch_matmul(tf.tile(Z[None, :, :], [N, 1, 1]),
-                            mean * exp[:, :, None] * det[:, None, None] * const, adj_y=True)
+        a = tf.matmul(tf.tile(Z[None, :, :], [N, 1, 1]),
+                            mean * exp[:, :, None] * det[:, None, None] * const, transpose_b=True)
         return a + tf.transpose(a, [0, 2, 1])
 
     def quad_eKzx1Kxz2(self, Ka, Kb, Z, Xmu, Xcov):

--- a/GPflow/gplvm.py
+++ b/GPflow/gplvm.py
@@ -179,11 +179,11 @@ class BayesianGPLVM(GPModel):
         if full_cov:
             var = self.kern.K(Xnew) + tf.matmul(tf.transpose(tmp2), tmp2) \
                   - tf.matmul(tf.transpose(tmp1), tmp1)
-            shape = tf.pack([1, 1, tf.shape(self.Y)[1]])
+            shape = tf.stack([1, 1, tf.shape(self.Y)[1]])
             var = tf.tile(tf.expand_dims(var, 2), shape)
         else:
             var = self.kern.Kdiag(Xnew) + tf.reduce_sum(tf.square(tmp2), 0) \
                   - tf.reduce_sum(tf.square(tmp1), 0)
-            shape = tf.pack([1, tf.shape(self.Y)[1]])
+            shape = tf.stack([1, tf.shape(self.Y)[1]])
             var = tf.tile(tf.expand_dims(var, 1), shape)
         return mean + self.mean_function(Xnew), var

--- a/GPflow/gpr.py
+++ b/GPflow/gpr.py
@@ -80,7 +80,7 @@ class GPR(GPModel):
         fmean = tf.matmul(tf.transpose(A), V) + self.mean_function(Xnew)
         if full_cov:
             fvar = self.kern.K(Xnew) - tf.matmul(tf.transpose(A), A)
-            shape = tf.pack([1, 1, tf.shape(self.Y)[1]])
+            shape = tf.stack([1, 1, tf.shape(self.Y)[1]])
             fvar = tf.tile(tf.expand_dims(fvar, 2), shape)
         else:
             fvar = self.kern.Kdiag(Xnew) - tf.reduce_sum(tf.square(A), 0)

--- a/GPflow/kullback_leiblers.py
+++ b/GPflow/kullback_leiblers.py
@@ -131,7 +131,7 @@ def gauss_kl(q_mu, q_sqrt, K):
     KL += -0.5 * tf.cast(tf.reduce_prod(tf.shape(q_sqrt)[1:]), float_type)  # constant term
     Lq = tf.matrix_band_part(tf.transpose(q_sqrt, (2, 0, 1)), -1, 0)  # force lower triangle
     KL += -0.5*tf.reduce_sum(tf.log(tf.square(tf.matrix_diag_part(Lq))))  # logdet
-    L_tiled = tf.tile(tf.expand_dims(L, 0), tf.pack([tf.shape(Lq)[0], 1, 1]))
+    L_tiled = tf.tile(tf.expand_dims(L, 0), tf.stack([tf.shape(Lq)[0], 1, 1]))
     LiLq = tf.matrix_triangular_solve(L_tiled, Lq, lower=True)
     KL += 0.5 * tf.reduce_sum(tf.square(LiLq))  # Trace term
     return KL

--- a/GPflow/likelihoods.py
+++ b/GPflow/likelihoods.py
@@ -423,7 +423,7 @@ class MultiClass(Likelihood):
             hits = tf.equal(tf.expand_dims(tf.argmax(F, 1), 1), Y)
             yes = tf.ones(tf.shape(Y), dtype=float_type) - self.invlink.epsilon
             no = tf.zeros(tf.shape(Y), dtype=float_type) + self.invlink._eps_K1
-            p = tf.select(hits, yes, no)
+            p = tf.where(hits, yes, no)
             return tf.log(p)
         else:
             raise NotImplementedError
@@ -439,10 +439,10 @@ class MultiClass(Likelihood):
     def predict_mean_and_var(self, Fmu, Fvar):
         if isinstance(self.invlink, RobustMax):
             # To compute this, we'll compute the density for each possible output
-            possible_outputs = [tf.fill(tf.pack([tf.shape(Fmu)[0], 1]), np.array(i, dtype=np.int64)) for i in
+            possible_outputs = [tf.fill(tf.stack([tf.shape(Fmu)[0], 1]), np.array(i, dtype=np.int64)) for i in
                                 range(self.num_classes)]
             ps = [self.predict_density(Fmu, Fvar, po) for po in possible_outputs]
-            ps = tf.transpose(tf.pack([tf.reshape(p, (-1,)) for p in ps]))
+            ps = tf.transpose(tf.stack([tf.reshape(p, (-1,)) for p in ps]))
             return ps, ps - tf.square(ps)
         else:
             raise NotImplementedError
@@ -515,8 +515,8 @@ class SwitchedLikelihood(Likelihood):
 
     def predict_mean_and_var(self, Fmu, Fvar):
         mu_list, var_list = zip(*[lik.predict_mean_and_var(Fmu, Fvar) for lik in self.likelihood_list])
-        mu = tf.concat(1, mu_list)
-        var = tf.concat(1, var_list)
+        mu = tf.concat_v2(mu_list, 1)
+        var = tf.concat_v2(var_list, 1)
         return mu, var
 
 
@@ -560,8 +560,8 @@ class Ordinal(Likelihood):
 
     def logp(self, F, Y):
         Y = tf.cast(Y, tf.int32)
-        scaled_bins_left = tf.concat(0, [self.bin_edges/self.sigma, np.array([np.inf])])
-        scaled_bins_right = tf.concat(0, [np.array([-np.inf]), self.bin_edges/self.sigma])
+        scaled_bins_left = tf.concat_v2([self.bin_edges/self.sigma, np.array([np.inf])], 0)
+        scaled_bins_right = tf.concat_v2([np.array([-np.inf]), self.bin_edges/self.sigma], 0)
         selected_bins_left = tf.gather(scaled_bins_left, Y)
         selected_bins_right = tf.gather(scaled_bins_right, Y)
 
@@ -576,8 +576,8 @@ class Ordinal(Likelihood):
 
         Note that a matrix of F values is flattened.
         """
-        scaled_bins_left = tf.concat(0, [self.bin_edges/self.sigma, np.array([np.inf])])
-        scaled_bins_right = tf.concat(0, [np.array([-np.inf]), self.bin_edges/self.sigma])
+        scaled_bins_left = tf.concat_v2([self.bin_edges/self.sigma, np.array([np.inf])], 0)
+        scaled_bins_right = tf.concat_v2([np.array([-np.inf]), self.bin_edges/self.sigma], 0)
         return probit(scaled_bins_left - tf.reshape(F, (-1, 1)) / self.sigma)\
             - probit(scaled_bins_right - tf.reshape(F, (-1, 1)) / self.sigma)
 

--- a/GPflow/mean_functions.py
+++ b/GPflow/mean_functions.py
@@ -45,7 +45,7 @@ class MeanFunction(Parameterized):
 
 class Zero(MeanFunction):
     def __call__(self, X):
-        return tf.zeros(tf.pack([tf.shape(X)[0], 1]), dtype=float_type)
+        return tf.zeros(tf.stack([tf.shape(X)[0], 1]), dtype=float_type)
 
 
 class Linear(MeanFunction):
@@ -80,7 +80,7 @@ class Constant(MeanFunction):
         self.c = Param(c)
 
     def __call__(self, X):
-        shape = tf.pack([tf.shape(X)[0], 1])
+        shape = tf.stack([tf.shape(X)[0], 1])
         return tf.tile(tf.reshape(self.c, (1, -1)), shape)
 
 

--- a/GPflow/model.py
+++ b/GPflow/model.py
@@ -128,8 +128,8 @@ class Model(Parameterized):
                 f = self.build_likelihood() + self.build_prior()
                 g, = tf.gradients(f, self._free_vars)
 
-            self._minusF = tf.neg(f, name='objective')
-            self._minusG = tf.neg(g, name='grad_objective')
+            self._minusF = tf.negative(f, name='objective')
+            self._minusG = tf.negative(g, name='grad_objective')
 
             # The optimiser needs to be part of the computational graph, and needs
             # to be initialised before tf.initialise_all_variables() is called.
@@ -384,10 +384,10 @@ class GPModel(Model):
         samples = []
         for i in range(self.num_latent):
             L = tf.cholesky(var[:, :, i] + jitter)
-            shape = tf.pack([tf.shape(L)[0], num_samples])
+            shape = tf.stack([tf.shape(L)[0], num_samples])
             V = tf.random_normal(shape, dtype=settings.dtypes.float_type)
             samples.append(mu[:, i:i + 1] + tf.matmul(L, V))
-        return tf.transpose(tf.pack(samples))
+        return tf.transpose(tf.stack(samples))
 
     @AutoFlow((float_type, [None, None]))
     def predict_y(self, Xnew):

--- a/GPflow/quadrature.py
+++ b/GPflow/quadrature.py
@@ -52,13 +52,12 @@ def mvnquad(f, means, covs, H, Din, Dout=()):
 
     # transform points based on Gaussian parameters
     cholXcov = tf.cholesky(covs)  # NxDxD
-    Xt = tf.batch_matmul(cholXcov, tf.tile(xn[None, :, :], (N, 1, 1)),
-                         adj_y=True)  # NxDxH**D
+    Xt = tf.matmul(cholXcov, tf.tile(xn[None, :, :], (N, 1, 1)), transpose_b=True)  # NxDxH**D
     X = 2.0 ** 0.5 * Xt + tf.expand_dims(means, 2)  # NxDxH**D
     Xr = tf.reshape(tf.transpose(X, [2, 0, 1]), (-1, Din))  # (H**D*N)xD
 
     # perform quadrature
     fX = tf.reshape(f(Xr), (H ** Din, N,) + Dout)
     wr = np.reshape(wn * np.pi ** (-Din * 0.5),
-                    (-1,) + (1,)*(1+len(Dout)))
+                    (-1,) + (1,) * (1 + len(Dout)))
     return tf.reduce_sum(fX * wr, 0)

--- a/GPflow/sgpr.py
+++ b/GPflow/sgpr.py
@@ -43,6 +43,7 @@ class SGPR(GPModel):
 
 
     """
+
     def __init__(self, X, Y, kern, Z, mean_function=Zero()):
         """
         X is a data matrix, size N x D
@@ -90,8 +91,8 @@ class SGPR(GPModel):
         bound = -0.5 * num_data * output_dim * np.log(2 * np.pi)
         bound += - output_dim * tf.reduce_sum(tf.log(tf.diag_part(LB)))
         bound -= 0.5 * num_data * output_dim * tf.log(self.likelihood.variance)
-        bound += -0.5*tf.reduce_sum(tf.square(err))/self.likelihood.variance
-        bound += 0.5*tf.reduce_sum(tf.square(c))
+        bound += -0.5 * tf.reduce_sum(tf.square(err)) / self.likelihood.variance
+        bound += 0.5 * tf.reduce_sum(tf.square(c))
         bound += -0.5 * output_dim * tf.reduce_sum(Kdiag) / self.likelihood.variance
         bound += 0.5 * output_dim * tf.reduce_sum(tf.diag_part(AAT))
 
@@ -119,20 +120,19 @@ class SGPR(GPModel):
         tmp2 = tf.matrix_triangular_solve(LB, tmp1, lower=True)
         mean = tf.matmul(tf.transpose(tmp2), c)
         if full_cov:
-            var = self.kern.K(Xnew) + tf.matmul(tf.transpose(tmp2), tmp2)\
-                - tf.matmul(tf.transpose(tmp1), tmp1)
-            shape = tf.pack([1, 1, tf.shape(self.Y)[1]])
+            var = self.kern.K(Xnew) + tf.matmul(tf.transpose(tmp2), tmp2) \
+                  - tf.matmul(tf.transpose(tmp1), tmp1)
+            shape = tf.stack([1, 1, tf.shape(self.Y)[1]])
             var = tf.tile(tf.expand_dims(var, 2), shape)
         else:
-            var = self.kern.Kdiag(Xnew) + tf.reduce_sum(tf.square(tmp2), 0)\
-                - tf.reduce_sum(tf.square(tmp1), 0)
-            shape = tf.pack([1, tf.shape(self.Y)[1]])
+            var = self.kern.Kdiag(Xnew) + tf.reduce_sum(tf.square(tmp2), 0) \
+                  - tf.reduce_sum(tf.square(tmp1), 0)
+            shape = tf.stack([1, tf.shape(self.Y)[1]])
             var = tf.tile(tf.expand_dims(var, 1), shape)
         return mean + self.mean_function(Xnew), var
 
 
 class GPRFITC(GPModel):
-
     def __init__(self, X, Y, kern, Z, mean_function=Zero()):
         """
         This implements GP regression with the FITC approximation.
@@ -214,8 +214,8 @@ class GPRFITC(GPModel):
 
         err, nu, Luu, L, alpha, beta, gamma = self.build_common_terms()
 
-        mahalanobisTerm = -0.5 * tf.reduce_sum(tf.square(err) / tf.expand_dims(nu, 1))\
-            + 0.5 * tf.reduce_sum(tf.square(gamma))
+        mahalanobisTerm = -0.5 * tf.reduce_sum(tf.square(err) / tf.expand_dims(nu, 1)) \
+                          + 0.5 * tf.reduce_sum(tf.square(gamma))
 
         # We need to compute the log normalizing term -N/2 \log 2 pi - 0.5 \log \det( K_fitc )
 
@@ -228,8 +228,8 @@ class GPRFITC(GPModel):
 
         constantTerm = -0.5 * self.num_data * tf.log(tf.constant(2. * np.pi, settings.dtypes.float_type))
         logDeterminantTerm = -0.5 * tf.reduce_sum(tf.log(nu)) - tf.reduce_sum(tf.log(tf.diag_part(L)))
-        logNormalizingTerm = constantTerm + logDeterminantTerm 
-        
+        logNormalizingTerm = constantTerm + logDeterminantTerm
+
         return mahalanobisTerm + logNormalizingTerm * self.num_latent
 
     def build_predict(self, Xnew, full_cov=False):
@@ -247,12 +247,12 @@ class GPRFITC(GPModel):
         intermediateA = tf.matrix_triangular_solve(L, w, lower=True)
 
         if full_cov:
-            var = self.kern.K(Xnew) - tf.matmul(tf.transpose(w), w)\
-                + tf.matmul(tf.transpose(intermediateA), intermediateA)
-            var = tf.tile(tf.expand_dims(var, 2), tf.pack([1, 1, tf.shape(self.Y)[1]]))
+            var = self.kern.K(Xnew) - tf.matmul(tf.transpose(w), w) \
+                  + tf.matmul(tf.transpose(intermediateA), intermediateA)
+            var = tf.tile(tf.expand_dims(var, 2), tf.stack([1, 1, tf.shape(self.Y)[1]]))
         else:
-            var = self.kern.Kdiag(Xnew) - tf.reduce_sum(tf.square(w), 0)\
-                + tf.reduce_sum(tf.square(intermediateA), 0)  # size Xnew,
-            var = tf.tile(tf.expand_dims(var, 1), tf.pack([1, tf.shape(self.Y)[1]]))
+            var = self.kern.Kdiag(Xnew) - tf.reduce_sum(tf.square(w), 0) \
+                  + tf.reduce_sum(tf.square(intermediateA), 0)  # size Xnew,
+            var = tf.tile(tf.expand_dims(var, 1), tf.stack([1, tf.shape(self.Y)[1]]))
 
         return mean, var

--- a/GPflow/tf_wraps.py
+++ b/GPflow/tf_wraps.py
@@ -19,6 +19,7 @@ A collection of wrappers and extensions for tensorflow.
 
 import os
 import tensorflow as tf
+from tensorflow.python.framework import ops
 from ._settings import settings
 
 
@@ -26,7 +27,7 @@ def eye(N):
     """
     An identitiy matrix
     """
-    return tf.diag(tf.ones(tf.pack([N, ]), dtype=settings.dtypes.float_type))
+    return tf.diag(tf.ones(tf.stack([N, ]), dtype=settings.dtypes.float_type))
 
 
 _custom_op_module = tf.load_op_library(os.path.join(os.path.dirname(__file__), 'tfops', 'matpackops.so'))
@@ -34,12 +35,12 @@ vec_to_tri = _custom_op_module.vec_to_tri
 tri_to_vec = _custom_op_module.tri_to_vec
 
 
-@tf.RegisterGradient("VecToTri")
+@ops.RegisterGradient("VecToTri")
 def _vec_to_tri_grad(op, grad):
     return [tri_to_vec(grad)]
 
 
-@tf.RegisterShape("VecToTri")
+@ops.RegisterShape("VecToTri")
 def _vec_to_tri_shape(op):
     in_shape = op.inputs[0].get_shape().with_rank(2)
     M = in_shape[1].value

--- a/GPflow/vgp.py
+++ b/GPflow/vgp.py
@@ -145,7 +145,7 @@ class VGP(GPModel):
         Kx_tiled = tf.tile(tf.expand_dims(Kx, 0), [self.num_latent, 1, 1])
         LiKx = tf.matrix_triangular_solve(L, Kx_tiled)
         if full_cov:
-            f_var = self.kern.K(Xnew) - tf.batch_matmul(LiKx, LiKx, adj_x=True)
+            f_var = self.kern.K(Xnew) - tf.matmul(LiKx, LiKx, transpose_a=True)
         else:
             f_var = self.kern.Kdiag(Xnew) - tf.reduce_sum(tf.square(LiKx), 1)
         return f_mean, tf.transpose(f_var)

--- a/testing/test_conditionals.py
+++ b/testing/test_conditionals.py
@@ -45,7 +45,7 @@ class DiagsTest(unittest.TestCase):
 
 
         #the chols are diagonal matrices, with the same entries as the diag representation.
-        self.chol = tf.pack([tf.diag(self.sqrt[:,i]) for i in range(self.num_latent)])
+        self.chol = tf.stack([tf.diag(self.sqrt[:,i]) for i in range(self.num_latent)])
         self.chol = tf.transpose(self.chol, perm=[1,2,0])
 
     def test_whiten(self):

--- a/testing/test_coregion.py
+++ b/testing/test_coregion.py
@@ -51,9 +51,9 @@ class TestEquivalence(unittest.TestCase):
                                    likelihood=lik,
                                    num_latent=2)
 
-        self.vgp0.optimize(display=False, max_iters=300)
-        self.vgp1.optimize(display=False, max_iters=300)
-        self.cvgp.optimize(display=False, max_iters=300)
+        self.vgp0.optimize(disp=False, maxiter=300)
+        self.vgp1.optimize(disp=False, maxiter=300)
+        self.cvgp.optimize(disp=False, maxiter=300)
 
     def test_all(self):
         # check variance

--- a/testing/test_ekerns.py
+++ b/testing/test_ekerns.py
@@ -44,11 +44,11 @@ class TriDiagonalBlockRep(object):
 
     def tf_forward(self, x):
         N, D = tf.shape(x)[0], tf.shape(x)[2]
-        xm = tf.slice(x, [0, 0, 0], tf.pack([N - 1, -1, -1]))
+        xm = tf.slice(x, [0, 0, 0], tf.stack([N - 1, -1, -1]))
         xp = x[1:, :, :]
-        diagblocks = tf.batch_matmul(x, x, adj_x=True)
-        offblocks = tf.concat(0, [tf.batch_matmul(xm, xp, adj_x=True), tf.zeros((1, D, D), dtype=tf.float64)])
-        return tf.pack([diagblocks, offblocks])
+        diagblocks = tf.matmul(x, x, transpose_a=True)
+        offblocks = tf.concat_v2([tf.matmul(xm, xp, transpose_a=True), tf.zeros((1, D, D), 0, dtype=tf.float64)])
+        return tf.stack([diagblocks, offblocks])
 
     def __str__(self):
         return "BlockTriDiagonal"

--- a/testing/test_transforms.py
+++ b/testing/test_transforms.py
@@ -56,7 +56,7 @@ class TransformTests(unittest.TestCase):
 
         # there is no jacobian: loop manually
         def jacobian(f):
-            return tf.pack([tf.gradients(f(self.x)[i], self.x)[0] for i in range(10)])
+            return tf.stack([tf.gradients(f(self.x)[i], self.x)[0] for i in range(10)])
 
         tf_jacs = [tf.log(tf.matrix_determinant(jacobian(t.tf_forward))) for t in self.transforms if
                    type(t) is not GPflow.transforms.LowerTriangular]


### PR DESCRIPTION
This PR makes GPflow compatible with the next version of TensorFlow, where a few functions get renamed, and old deprecated ones are removed.

This is also compatible with the current version of TensorFlow, so it can be merged now.