### PR TITLE
Block kernels, covarying GPs and gradient/Hessian observations for stationary kernels

### DIFF
--- a/GPflow/gradkern.py
+++ b/GPflow/gradkern.py
@@ -1,0 +1,240 @@
+import numpy as np
+import tensorflow as tf
+import GPflow
+from GPflow.param import Param
+from GPflow import transforms
+import pdb
+
+import matplotlib.pyplot as plt
+
+from functools import partial
+
+from multikernel import BlockKernel
+
+from GPflow._settings import settings
+float_type = settings.dtypes.float_type
+
+
+def find_partitions(collection):
+    '''Take an iterable `collection` and return a generator which produces
+    all unique partitions as lists-of-lists with every object being a member of
+    one set per partition.
+    alexis @ http://stackoverflow.com/questions/19368375/set-partitions-in-python
+    '''
+    if len(collection) == 1:
+        yield [ collection ]
+        return
+
+    first = collection[0]
+    for smaller in find_partitions(collection[1:]):
+        # insert `first` in each of the subpartition's subsets
+        for n, subset in enumerate(smaller):
+            yield smaller[:n] + [[ first ] + subset]  + smaller[n+1:]
+        # put `first` in its own subset
+        yield [ [ first ] ] + smaller
+
+class StationaryGradKernel(BlockKernel):
+    ''' Abstract kernel class which allows arbitrary derivative observations for
+    any differentiable stationary kernel. Computes each kernel matrix as a
+    composition of block matrices and automatically generates appropriate kernel
+    functions if given derivatives of the kernel matrix wrt squared distance.
+
+    To extend, inherit and replace `derivative_base` attribute with list of
+    the 0th, 1st, and 2nd derivative of desired kernel k(tau) with respect to squared
+    distance tau. Defaults to RBF/squared exponential.
+    '''
+    def __init__(self, input_dim, active_dims = None):
+        groups = input_dim
+        BlockKernel.__init__(self, input_dim, groups, active_dims)
+        self.variance = GPflow.param.Param(0.1, transforms.positive)
+        self.lengthscales = GPflow.param.Param(1.*np.ones(input_dim-1), transforms.positive)
+
+        self.derivative_base = [lambda tau: self.variance*tf.exp(-0.5*tau), lambda tau: -0.5*self.variance*tf.exp(-0.5*tau), lambda tau: 0.25*self.variance*tf.exp(-0.5*tau)]
+        self.kerns = [[self._kernel_factory(i,j) for j in range(groups)] for i in range(groups)]
+
+    def subK(self, index, X, X2 = None):
+        i, j = index
+        if X2 is None:
+            X2 = X
+        return self.kerns[i][j](X, X2)
+
+    def subKdiag(self, index, X):
+        K  = self.subK((index, index), X, X)
+        return tf.diag_part(K)
+
+    def square_dist(self, X, X2):
+        '''Function `squared_dist` identical to method in `Stationary`.'''
+        X = X / self.lengthscales
+        Xs = tf.reduce_sum(tf.square(X), 1)
+        if X2 is None:
+            return -2 * tf.matmul(X, tf.transpose(X)) + \
+                   tf.reshape(Xs, (-1, 1)) + tf.reshape(Xs, (1, -1))
+        else:
+            X2 = X2 / self.lengthscales
+            X2s = tf.reduce_sum(tf.square(X2), 1)
+            return -2 * tf.matmul(X, tf.transpose(X2)) + \
+                   tf.reshape(Xs, (-1, 1)) + tf.reshape(X2s, (1, -1))
+
+    def square_dist_d(self, X, X2, diff_x=(), diff_y=()):
+        '''Take derivative of square_dist(x,y) wrt dimensions `diff_x` of first
+        argument and `diff_y` of second argument.
+
+        Parameters:
+        - `X` and `X2`: arguments for `square_dist`.
+        - `diff_x`: Tuple of integers. Dimensions to differentiate with respect
+            to in the first argument of `square_dist(x,y)`.
+        - `diff_y`: Tuple of integers. Dimensions to differentiate with respect
+            to in the second argument of `square_dist(x,y)`.
+
+        Return:
+        - Appropriate derivative as a Tensorflow Tensor.
+        '''
+        x_order = len(diff_x)
+        y_order = len(diff_y)
+        diff_order = x_order + y_order
+        dx = diff_x + diff_y
+
+        Zero =  tf.zeros((tf.shape(X)[0], tf.shape(X)[0] if X2 is None else tf.shape(X2)[0]), dtype=float_type)
+        One = tf.ones((tf.shape(X)[0], tf.shape(X)[0] if X2 is None else tf.shape(X2)[0]), dtype=float_type)
+
+        if diff_order > 2:
+            #higher derivatives vanish
+            return Zero
+        elif diff_order == 0:
+            #if we don't take the derivative, return the function
+            return self.square_dist(X, X2)
+        elif diff_order == 1:
+
+            X = X / self.lengthscales ** 2
+            if X2 is None:
+                X2 = X
+            else:
+                X2 = X2 / self.lengthscales ** 2
+            delta = tf.expand_dims(X[:,dx[0]], 1) - tf.expand_dims(X2[:,dx[0]], 0)
+            #sign-flip if y derivative
+            if x_order > 0:
+                return 2.*delta
+            elif y_order > 0:
+                return -2.*delta
+
+        elif diff_order == 2:
+            #only equal-index dimension pairs are non-zero
+            i, j = dx
+            if i == j:
+                k = One*(2./self.lengthscales[i]**2.)
+                if x_order == y_order:
+                    return -k
+                else:
+                    return k
+            else:
+                return Zero
+        raise RuntimeError
+
+    def ind2dx(self, index):
+        '''Convert a linear index into a tuple of integers to differentiate with respect to.'''
+        return () if index == 0 else (index-1,)
+
+    def kernel_derivative(self, X, X2, diff_x=(), diff_y=()):
+        '''Calculates derivative of stationary kernel by decomposing into
+        derivatives of the kernel wrt the distance and derivatives of the distance
+        wrt the inputs. Procedurally generates each term of the derivative by
+        iterating over all possible products of mixed derivatives.
+
+        Parameters:
+        - `X` and `X2`: Numpy/TF array. Inputs over which the kernel is evaluated.
+        - `diff_x` and `diff_y`: Tuples of
+
+        Return:
+        - `result` -
+        '''
+        dist_d = partial(self.square_dist_d, X=X, X2=X2)
+        dx = [(x,'x') for x in diff_x] + [(y,'y') for y in diff_y]
+        x_order = len(diff_x)
+        y_order = len(diff_y)
+        diff_order = len(dx)
+        if diff_order == 0:
+            return self.derivative_base[0](self.square_dist(X, X2))
+        dx_combinations = find_partitions(dx)
+        order_factor = [self.derivative_base[order](self.square_dist(X, X2))
+                        for order in range(diff_order+1)]
+        terms = []
+        for partition in dx_combinations:
+            order = len(partition)
+            derivatives = [dist_d(diff_x=tuple(i for i, key in elem if key is 'x'),
+                                  diff_y=tuple(j for j, key in elem if key is 'y'))
+                           for elem in partition]
+            terms.append(order_factor[order]*tf.foldl(tf.multiply, derivatives))
+        result = tf.foldl(tf.add, terms)
+        return result
+
+    def _kernel_factory(self, i, j):
+        '''Return a function that calculates proper sub-kernel'''
+        diff_x = self.ind2dx(i)
+        diff_y = self.ind2dx(j)
+        def f(X, X2):
+            return self.kernel_derivative(X, X2, diff_x=diff_x, diff_y=diff_y)
+        return f
+
+class StationaryHessianKernel(StationaryGradKernel):
+    '''Generalizes StationaryGradKernel to second deriatives'''
+    def __init__(self, input_dim, active_dims = None):
+        ndim = input_dim-1
+        groups = 1 + ndim + ((ndim)*(ndim+1))//2
+        BlockKernel.__init__(self, input_dim, groups, active_dims)
+        self.variance = GPflow.param.Param(0.1, transforms.positive)
+        self.lengthscales = GPflow.param.Param(1.*np.ones(input_dim-1), transforms.positive)
+        self.tril_indices = np.column_stack(np.tril_indices(ndim))
+        self.derivative_base = [lambda tau: self.variance*tf.exp(-0.5*tau), lambda tau: -0.5*self.variance*tf.exp(-0.5*tau), lambda tau: 0.25*self.variance*tf.exp(-0.5*tau),
+        lambda tau: -0.125*self.variance*tf.exp(-0.5*tau), lambda tau: 0.0625*self.variance*tf.exp(-0.5*tau)]
+        #self.derivative_base = [lambda tau: self.variance*(-0.5)**n*tf.exp(-0.5*tau) for n in range(5)]
+        self.kerns = [[self._kernel_factory(i,j) for j in range(groups)] for i in range(groups)]
+
+
+    def ind2dx(self, i):
+        if i == 0:
+            return ()
+        elif i<self.input_dim:
+            return (i-1,)
+        else:
+            return tuple(self.tril_indices[i-self.input_dim,:])
+
+
+d = 1
+groups = 3
+Ns = [10,5,0]
+
+ind = np.vstack([n*np.ones((Ns[n],1)) for n in range(3)])
+N = np.sum(Ns)
+#np.random.shuffle(ind)
+val = np.vstack([np.linspace(0,1,n).reshape((-1,1)) for n in Ns])
+X = np.concatenate([ind, val],1)
+f = lambda x: np.exp(-x)
+fp = lambda x: -np.exp(-x)
+fpp = lambda x: np.exp(-x)
+y = np.vstack([fun(val[ind == i]).reshape((-1,1)) for fun, i in zip([f,fp,fpp], range(groups))])
+
+
+k = StationaryHessianKernel(d+1)
+kg = StationaryGradKernel(d+1)
+m = GPflow.gpr.GPR(X, y, k)
+mg = GPflow.gpr.GPR(X, y, kg)
+m.likelihood.variance = 0.1
+mg.likelihood.variance = 0.1
+
+K = k.compute_K(X, X)
+Kg = kg.compute_K(X, X)
+#m.optimize()
+#mg.optimize()
+res = 100
+x = np.column_stack([np.linspace(-1,1, res),np.zeros(res)])
+predlevel = lambda i: m.predict_f(np.column_stack([i*np.ones(res),x]))
+mu, var = predlevel(0)
+mug, varg = predlevel(1)
+mug2, varg = predlevel(2)
+
+plt.plot(x[:,0],mu,label='Function')
+plt.plot(x[:,0],mug,label='Derivative')
+plt.plot(x[:,0],mug2,label='Derivative2')
+
+plt.hlines(0, -1, 1)
+plt.legend()

--- a/GPflow/multikernel.py
+++ b/GPflow/multikernel.py
@@ -83,7 +83,7 @@ class MultiKernel(GPflow.kernels.Kern):
 
     def reconstruct(self, K, splitnum, goback):
         '''uses quantities from splitback to invert a dynamic_partition'''
-        tmp = tf.split_v(K, splitnum, split_dim=0) #split
+        tmp = tf.split(K, splitnum, axis=0) #split
         return tf.dynamic_stitch(goback, tmp) #stitch
 
 class HeteroscedasticWhite(GPflow.kernels.Kern):
@@ -147,8 +147,8 @@ class RecursiveKernel(MultiKernel):
 
         for index, (data1, data2) in enumerate(XandX2):
             #add incoming data
-            D = tf.concat(0, [data1, D])
-            D2 = tf.concat(0, [data2, D2])
+            D = tf.concat([data1, D], 0)
+            D2 = tf.concat([data2, D2], 0)
 
             #look up shape of the new kernel
             nshape = XandX2shapes[index,:]
@@ -168,7 +168,7 @@ class RecursiveKernel(MultiKernel):
         Kd = tf.zeros((0), dtype=tf.float64)
         D = tf.zeros((0, self.input_dim-1), dtype=tf.float64)
         for index, data in enumerate(datarev):
-            D = tf.concat(0, [data, D])
+            D = tf.concat([data, D], 0)
             sizediff = Xshapes[index]-tf.shape(Kd)[0]
             Kd = tf.pad(Kd,[[sizediff,0]])  +  self.subKdiag(index, D)
         return Kd
@@ -192,8 +192,8 @@ class BlockKernel(MultiKernel):
             row_i = []
             for j in range(self.groups):
                 row_i.append(self.subK((i, j), Xparts[i], X2parts[j]))
-            rows.append(tf.concat(1, row_i))
-        return tf.concat(0, rows)
+            rows.append(tf.concat(row_i, 1))
+        return tf.concat(rows, 0)
 
     def multidiag(self, Xparts):
         Kd = tf.zeros((0), dtype=tf.float64)
@@ -201,7 +201,7 @@ class BlockKernel(MultiKernel):
         subdiags = []
         for index, data in enumerate(Xparts):
             subdiags.append(self.subKdiag(index, Xparts[index]))
-        return tf.concat(0, subdiags)
+        return tf.concat(subdiags, 0)
 
 
 class KernelList(GPflow.param.Parameterized):

--- a/GPflow/multikernel.py
+++ b/GPflow/multikernel.py
@@ -1,0 +1,283 @@
+import numpy as np
+import tensorflow as tf
+import GPflow
+
+from GPflow._settings import settings
+float_type = settings.dtypes.float_type
+np_float_type = np.float32 if float_type is tf.float32 else np.float64
+
+from itertools import chain
+import pdb
+
+import matplotlib.pyplot as plt
+
+def embedsubmat(A, shape):
+    '''Embeds A in a zero matrix with shape `shape` in the lower-right corner.'''
+    sizediff = tf.expand_dims(shape - tf.shape(A), 1)
+    paddings = tf.pad(sizediff, [[0, 0], [0, 1]])
+    return tf.pad(A, paddings)
+
+
+class MultiKernel(GPflow.kernels.Kern):
+    '''this abstract kernel assumes input X where the first column is a series of integer indices and the
+    remaining dimensions are unconstrained. Multikernels are designed to handle outputs from different
+    Gaussian processes, specifically in the case where they are not independent and where they can be
+    observed independently. This abstract class implements the functionality necessary to split
+    the observations into different cases and reorder the final kernel matrix appropriately.'''
+    def __init__(self, input_dim, groups, active_dims=None):
+        GPflow.kernels.Kern.__init__(self, input_dim, active_dims)
+        assert(input_dim > 1)
+        self.groups = groups
+
+    def multikernel(self, Xparts, X2parts):
+        '''this method computes the kernel matrix for a sorted and partitioned dataset'''
+        return NotImplementedError
+
+    def multidiag(self, Xparts, X2parts):
+        '''this method computes the diagonal of the kernel matrix
+        for a sorted and partitioned dataset'''
+        return NotImplementedError
+
+    def K(self, X, X2=None):
+        X, X2 = self._slice(X, X2)
+        Xindex = tf.cast(X[:, 0], tf.int32) #find group indices
+        Xparts, Xsplitn, Xreturn = self.splitback(X[:,1:], Xindex)
+        #noise = 0.0
+
+        if X2 is None:
+            X2, X2parts, X2return, X2splitn = (X, Xparts, Xreturn, Xsplitn)
+            #noise = tf.diag(self.multinoise(Xindex))
+        else:
+            X2index = tf.cast(X2[:, 0], tf.int32)
+            X2parts, X2splitn, X2return = self.splitback(X2[:,1:], X2index)
+
+        #construct kernel matrix for index-sorted data (stacked Xparts)
+        Ksort = self.multikernel(Xparts, X2parts)
+
+        #split matrix into chunks, then stitch them together in correct order
+        Ktmp = self.reconstruct(Ksort, Xsplitn, Xreturn)
+        KT = self.reconstruct(tf.transpose(Ktmp), X2splitn, X2return)
+        return tf.transpose(KT)
+
+    def Kdiag(self, X):
+        X, _ = self._slice(X, None)
+        F = tf.cast(X[:, 0], tf.int32) #find recursion level indices
+        Xparts, Xsplitn, Freturn = self.splitback(X[:,1:], F)
+        Kd = self.multidiag(Xparts)
+        return self.reconstruct(Kd, Xsplitn, Freturn)
+        #return self.reconstruct(Kd, Xsplitn, Freturn) + self.multinoise(F)
+
+    #def multinoise(self, indices):
+    #    '''distribute block-dependent noise'''
+    #    return tf.gather(self.noises, indices)
+
+    def splitback(self, data, indices):
+        '''applies dynamic_partioning and calculates necessary statistics for
+        the inverse mapping.'''
+        parts = tf.dynamic_partition(data, indices, self.groups) #split data based on indices
+
+        #to be able to invert the splitting, we need:
+        splitnum = tf.stack([tf.shape(x)[0] for x in parts]) #the size of each data split
+        goback = tf.dynamic_partition(tf.range(tf.shape(data)[0]), indices, self.groups) #indices to invert dynamic_part
+        return (parts, splitnum, goback)
+
+    def reconstruct(self, K, splitnum, goback):
+        '''uses quantities from splitback to invert a dynamic_partition'''
+        tmp = tf.split_v(K, splitnum, split_dim=0) #split
+        return tf.dynamic_stitch(goback, tmp) #stitch
+
+class HeteroscedasticWhite(GPflow.kernels.Kern):
+    '''Apply different noise to observations with different index.'''
+    def __init__(self, input_dim, groups, active_dims=None):
+        GPflow.kernels.Kern.__init__(self, input_dim, active_dims=None)
+        self.groups = groups
+        self.noises = GPflow.param.Param(1e-3*np.ones(self.groups), GPflow.transforms.positive)
+
+    def K(self, X, X2=None, presliced=False):
+        '''Compute noise kernel. If `X2` is not None, returns 0.0. If `X2` is
+        `None` the function offloads the workload to `Kdiag` as the kernel is
+        diagonal.
+        '''
+        if not presliced:
+            X, X2 = self._slice(X, X2)
+        if X2 is None:
+            return 0.0
+        return tf.diag(self.Kdiag(X, presliced=True))
+
+    def Kdiag(self, X, presliced=False):
+        '''Computes the diagonal of the kernel matrix. Reads off group indices by
+        by casting the single input to integers. It then distributes the noise levels
+        according to group index.
+
+        Parameters:
+        - `X`: Tensor. Assumed that it can be cast to integers in the range [0,self.groups)
+        '''
+        if not presliced:
+            X, _ = self._slice(X, None)
+        indices = tf.cast(X[:, 0], tf.int32)
+        return tf.gather(self.noises, indices)
+
+class RecursiveKernel(MultiKernel):
+    '''This kernel assumes that inputs with index 0 are generated from a single GP,
+    that inputs with index 1 are generated from that GP plus another independent GP,
+    and so on, recursively. This leads to N covariant generative models, and a covariance matrix
+    where submatrices corresponding to a particular index equals the sum of the covariance kernels of all GPs
+    with lower or equal index.'''
+
+    def subKdiag(self, index, X):
+        return NotImplementedError
+
+    def subK(self, index, X, X2=None):
+        return NotImplementedError
+
+    def multikernel(self, Xparts, X2parts):
+        '''this method computes the kernel matrix for a sorted and partitioned dataset'''
+        #build initial empty tensors
+        K = tf.zeros((0,0), dtype=tf.float64)
+        D = tf.zeros((0,self.input_dim-1), dtype=tf.float64)
+        D2 = tf.zeros((0,self.input_dim-1), dtype=tf.float64)
+
+        #zip dataset
+        XandX2 = zip(Xparts, X2parts)
+        #reverse for algorithmic convenience
+        XandX2 = list(reversed(list(XandX2)))
+
+        #kernel shape if all data chunks up to index i are joined.
+        XandX2shapes = tf.cumsum(tf.stack([(tf.shape(d1)[0],tf.shape(d2)[0]) for d1,d2 in XandX2]), axis=0)
+
+        for index, (data1, data2) in enumerate(XandX2):
+            #add incoming data
+            D = tf.concat(0, [data1, D])
+            D2 = tf.concat(0, [data2, D2])
+
+            #look up shape of the new kernel
+            nshape = XandX2shapes[index,:]
+
+            #calculate kernel for current level
+            k_new = self.subK(index, D, D2)
+
+            # grow kernel matrix
+            K = k_new + embedsubmat(K, nshape)
+        return K
+
+    def multidiag(self, Xparts):
+        '''this method computes the diagonal of the kernel matrix
+        for a sorted and partitioned dataset'''
+        datarev = list(reversed(list(Xparts)))
+        Xshapes = tf.cumsum(tf.stack([tf.shape(d)[0] for d in datarev]), axis=0)
+        Kd = tf.zeros((0), dtype=tf.float64)
+        D = tf.zeros((0, self.input_dim-1), dtype=tf.float64)
+        for index, data in enumerate(datarev):
+            D = tf.concat(0, [data, D])
+            sizediff = Xshapes[index]-tf.shape(Kd)[0]
+            Kd = tf.pad(Kd,[[sizediff,0]])  +  self.subKdiag(index, D)
+        return Kd
+
+class BlockKernel(MultiKernel):
+    '''this kernel applies constructs each block of the kernel matrix separately.'''
+    def __init__(self, input_dim, groups, active_dims=None):
+        MultiKernel.__init__(self, input_dim, groups, active_dims)
+
+    def multikernel(self, Xparts, X2parts):
+        '''this method computes the kernel matrix for a sorted and partitioned dataset'''
+
+        #build initial empty tensors
+        K = tf.zeros((0,0), dtype=tf.float64)
+        D = tf.zeros((0,self.input_dim-1), dtype=tf.float64)
+        D2 = tf.zeros((0,self.input_dim-1), dtype=tf.float64)
+
+        #loop over all cases to iteratively construct block matrix
+        rows = []
+        for i in range(self.groups):
+            row_i = []
+            for j in range(self.groups):
+                row_i.append(self.subK((i, j), Xparts[i], X2parts[j]))
+            rows.append(tf.concat(1, row_i))
+        return tf.concat(0, rows)
+
+    def multidiag(self, Xparts):
+        Kd = tf.zeros((0), dtype=tf.float64)
+        D = tf.zeros((0, self.input_dim-1), dtype=tf.float64)
+        subdiags = []
+        for index, data in enumerate(Xparts):
+            subdiags.append(self.subKdiag(index, Xparts[index]))
+        return tf.concat(0, subdiags)
+
+
+class KernelList(GPflow.param.Parameterized):
+    '''This class enables you to store multiple kernels inside your model and
+    have all automatic parameter discovery methods function as designed.
+    '''
+    def __init__(self, kerns, nested = False):
+        GPflow.param.Parameterized.__init__(self)
+        self.keydict = {}
+        if nested:
+            for i, row in enumerate(kerns):
+                for j, k in enumerate(row):
+                    key = (i, j)
+                    name =  'kernel_{}{}'.format(*key)
+                    setattr(self, name, k)
+                    self.keydict[key] = name
+        else:
+            for i, k in enumerate(kerns):
+                key = i
+                name =  'kernel_{}'.format(key)
+                setattr(self, name, k)
+                self.keydict[key] = name
+
+    def __getitem__(self, key):
+        return getattr(self, self.keydict[key])
+
+class KernelKeeper:
+    '''This mix-in class adds a list of kernels to a class'''
+    def __init__(self, kerns):
+        try:
+            self.kerns = KernelList(kerns, nested = True)
+        except TypeError:
+            self.kerns = KernelList(kerns, nested = False)
+
+
+class BlockLookupKernel(KernelKeeper, BlockKernel):
+    '''This kernel keeps a matrix of kernels that it consults to fill out blocks.
+    Note that this kernel is only valid for very particular choices of kernels.'''
+    def __init__(self, input_dim, kerns, active_dims=None):
+        BlockKernel.__init__(self, input_dim, len(kerns), active_dims)
+        KernelKeeper.__init__(self, kerns)
+
+    def subK(self, index, X, Y = None):
+        i, j = index
+        if Y is None:
+            Y = X
+        return self.kerns[i, j].K(X, Y, presliced = True)
+
+    def subKdiag(self, index, X):
+        i = index
+        if Y is None:
+            Y = X
+        return self.kerns[i].Kdiag(X, presliced = True)
+
+class RecursiveLookupKernel(KernelKeeper, RecursiveKernel):
+    '''This kernel does co-kriging using a list of N independent kernels'''
+    def __init__(self, input_dim, kerns, active_dims=None):
+        MultiKernel.__init__(self, input_dim, len(kerns), active_dims)
+        KernelKeeper.__init__(self, kerns)
+
+    def subKdiag(self, index, X):
+        return self.kerns[index].Kdiag(X, presliced=True)
+
+    def subK(self, index, X, X2=None):
+        return self.kerns[index].K(X, X2, presliced=True)
+
+
+ind = np.random.randint(0,3,(20,1))
+val = ind.astype(np.float64) + ind*0.5*np.random.randn(20,1)
+X = np.column_stack([ind, val])
+
+#block kernel won't work for arbitrary kernels, but can be defined as follows:
+#BK = BlockLookupKernel(2, [[GPflow.kernels.RBF(1) for _ in range(3)] for _ in range(3)])
+
+#the Recursive kernel is always valid:
+RK = RecursiveLookupKernel(2, [GPflow.kernels.RBF(1) for _ in range(3)])
+
+m = GPflow.gpr.GPR(X, 0.1*val**2.*np.exp(-val**2.), RK)
+m.optimize()


### PR DESCRIPTION
This pull request is mostly to get opinions on the viability of the proposed approach. It touches on #312. There was concerns about this PR involving too many new features, but I couldn't really find a natural way to split it since the PR consists of an abstract kernel class and then various applications of it. 

There are two files here, `multikernel.py` and `gradkern.py` where the latter is basically an application of the former. Both files predominantly define a new series of abstract classes that can be subclassed to get high-level kernels. Specifically, `multikernel.py` allows kernel matrices that are constructed block-wise according to an integer input denoting each observation's "group".

The highest level class in `multikernel.py` is `MultiKernel` which uses the Tensorflow functions `tf.dynamic_partition` and `tf.dynamic_stitch` to split the input into groups, then construct the kernel matrix from the chunks (left to the user), and then puts it back together and reorders to match the original ordering.

The next two classes implement two schemes for constructing kernel matrices. `BlockKernel` assumes two functions `subK` and `subKdiag` which take an index (i,j) as input. It then loops over all possible group combinations i-and-j, calls the sub functions to construct each block individually, and then collects them.
`RecursiveKernel` instead assumes a co-kriging setup with observations from group 0 being drawn from kernel 0, group 1 from 0 *and* 1, ..., group N from all prior kernels. The final covariance matrix is then a sum of nested submatrices. 

As a simple demonstration, `BlockLookupKernel` and `RecursiveLookupKernel` take lists-of-lists and lists (respectively) of kernels and offload the sub-construction function calls to those kernel functions. `RecursiveLookupKernel` works out of the box, `BlockLookupKernel` is only valid for appropriate choices of off-diagonal covariance. The kernels are stored in a new `KernelList` object to facilitate `Param` discovery.
There is also a `HeteroscedasticWhite` kernel to facilitate groups with different observation noise.

Using `dynamic_partition` and -`stitch` seems to be the only practical approach at the moment. Direct assignment to submatrices would likely be preferable, but does not seem to be supported by Tensorflow (tensors are immutable). Circumventing those two would involve assuming input that is already partitioned appropriately. 
`tf.concat` might be another bottleneck in the block-kernel setting, but is similarly inescapable.

`gradkern.py` implements support for derivative and second derivative observations for stationary kernels. There are two classes, `StationaryGradKernel` and `StationaryHessianKernel`, but they are fundamentally the same - only difference is that the latter instantiates more groups/blocks to accomodate second order derivative observations.

Since it subclasses `BlockKernel` the missing piece the class implements is the appropriate sub-kernel functions for filling in each block. To avoid doing a ton of `tf.cond()` calls I've implemented it using indexing operations. First, during initialization, an array is filled with appropriate tensorflow functions. This array is then indexed to find the appropriate function for each block. 

To generalize to as many kernels as possible, I have used the chain rule to decompose the derivative into univariate derivatives of the kernel function with respect to squared lengthscale-normalized distance and then partial derivatives of said distance with respect to the inputs. The appropriate functions are created dynamically by finding all possible combinations of the differential operators (in line with writing out the chain rule on paper, see [diffkerns.pdf](https://github.com/GPflow/GPflow/files/741860/diffkerns.pdf)). 

I could use your experience with "compiling" TensorFlow code - I have the feeling some of the graphs are being constructed more than once. I think the procedural generation is reasonable, but I'm also quite sure it must be possible to optimize it somewhat. 
    
Would like `gradkern.py` to integrate more neatly with existing `Stationary` kernels, but 1) we need a number of non-implemented derivatives of the kernel function wrt distance and 2) parameters need to be shared between derivatives. 

Ideally, we'd have used Tensorflow's automatic differentiation to build the kernels automatically, but after discussion and experimentation with a colleague this seems to not be possible (`tf.gradient` cannot do element-wise derivatives, `tf.unpack` doesn't work for dynamically-sized Tensors, you cannot use `tf.gradient` inside `while_loop`, `map_fn` or `scan`, and there's no clear route to emulating symbolic differentiation in Tensorflow using e.g. `graph_replace`).

