### PR TITLE
Avoid copies via tiling in eKernels

### DIFF
--- a/GPflow/ekernels.py
+++ b/GPflow/ekernels.py
@@ -77,13 +77,10 @@ class RBF(kernels.RBF):
         )  # N
 
         vec = tf.expand_dims(tf.transpose(Z), 0) - tf.expand_dims(Xmum, 2)  # NxDxM
-        smIvec = tf.matrix_solve(scalemat, vec) # NxDxM
-        q = tf.reduce_sum(smIvec * vec, [1]) # NxM
+        smIvec = tf.matrix_solve(scalemat, vec)  # NxDxM
+        q = tf.reduce_sum(smIvec * vec, [1])  # NxM
 
-        # Xsigmc: NxD*xD
-        # smIvec: NxD*xM
-        # addvec: NxMxD
-        addvec = tf.einsum('ned,nem->nmd', Xsigmc, smIvec) + tf.expand_dims(Xmup, 1)
+        addvec = tf.matmul(smIvec, Xsigmc, transpose_a=True) + tf.expand_dims(Xmup, 1)  # NxMxD
 
         return self.variance * addvec * tf.reshape(det ** -0.5, (N, 1, 1)) * tf.expand_dims(tf.exp(-0.5 * q), 2)
 


### PR DESCRIPTION
As discussed in #327, the tiling operations in `ekernels.py` seem to be the main reason for the bad performance of LVMs on GPUs right now. This pull request avoids these tiling operations, but currently only for the RBF-kernel, so it is not ready to merge yet. It seems like the most important change is the one in `eKzxKxz`. For some toy data, the running time on GPUs reduced from `2s` to `25ms`.

You can comparre the traces before and after the change:
* [timeline_objective_lvm_cpu.json.gz](https://github.com/GPflow/GPflow/files/744540/timeline_objective_lvm_cpu.json.gz)
* [**timeline_objective_lvm_gpu.json.gz**](https://github.com/GPflow/GPflow/files/744541/timeline_objective_lvm_gpu.json.gz)
* [**timeline_objective_lvm_gpu_new.json.gz**](https://github.com/GPflow/GPflow/files/747623/timeline_objective_lvm_gpu_new.json.gz)

There is some feedback I would like:
1. I use `tf.einsum` to avoid one tiling operation in a matrix product. This is the only use of `tf.einsum` in GPflow. Should and can the line be formulated differently? I will probably remove the extra comments later on.
2. There is still a huge allocation in [ekernels.py#L112](https://github.com/GPflow/GPflow/pull/329/files#diff-77a07191da6b8b3d69177df73dbe080dR112), but this one does not contain duplicates it think. Can it be formulated any better?