### PR TITLE
Add MLP kernel

### DIFF
--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -491,13 +491,14 @@ class ArcCosine(Kern):
     implemented_orders = {0, 1, 2}
     def __init__(self, input_dim, variance=1.0,
                  weight_variances=1., bias_variance=1.,
-                 order=0,
+                 order=0, num_layers=1,
                  active_dims=None, ARD=False):
         Kern.__init__(self, input_dim, active_dims)
 
         if order not in self.implemented_orders:
             raise ValueError('Requested kernel order is not implemented.')
         self.order = order
+        self.num_layers = num_layers
 
         self.variance = Param(variance, transforms.positive)
         self.bias_variance = Param(bias_variance, transforms.positive)
@@ -534,30 +535,55 @@ class ArcCosine(Kern):
         if not presliced:
             X, X2 = self._slice(X, X2)
 
-        X_denominator = tf.sqrt(self._weighted_product(X))
+        X_product = self._weighted_product(X)
         if X2 is None:
             X2 = X
-            X2_denominator = X_denominator
+            X2_product = X_product
         else:
-            X2_denominator = tf.sqrt(self._weighted_product(X2))
+            X2_product = self._weighted_product(X2)
 
-        numerator = self._weighted_product(X, X2)
-        theta = tf.acos(tf.clip_by_value(numerator / \
-                                         X_denominator[:, None] / \
-                                         X2_denominator[None, :],
-                                         -1., 1.))
+        fraction = self._weighted_product(X, X2) / \
+                   tf.sqrt(X_product[:, None] * X2_product[None, :])
+        joint_theta = tf.acos(tf.clip_by_value(fraction, -1., 1.))
 
-        return self.variance * (1. / np.pi) * self._J(theta) * \
-               X_denominator[:, None] ** self.order * \
-               X2_denominator[None, :] ** self.order
+        joint_kernel = (1. / np.pi) * self._J(joint_theta) * \
+                       tf.sqrt(X_product[:, None] * X2_product[None, :]) ** self.order
+
+        single_theta = tf.constant(0., float_type)
+        X_kernel = (1. / np.pi) * self._J(single_theta) * \
+                   X_product ** self.order
+        X2_kernel = (1. / np.pi) * self._J(single_theta) * \
+                    X2_product ** self.order
+
+        for _ in range(self.num_layers - 1):
+            fraction = joint_kernel / \
+                       tf.sqrt(X_kernel[:, None] * X2_kernel[None, :])
+            joint_theta = tf.acos(tf.clip_by_value(fraction, -1., 1.))
+
+            joint_kernel = (1. / np.pi) * self._J(joint_theta) * \
+                           tf.sqrt(X_kernel[:, None] * X2_kernel[None, :]) ** self.order
+
+            X_kernel = (1. / np.pi) * self._J(single_theta) * \
+                       X_kernel ** self.order
+            X2_kernel = (1. / np.pi) * self._J(single_theta) * \
+                        X2_kernel ** self.order
+
+        return self.variance * joint_kernel
 
     def Kdiag(self, X, presliced=False):
         if not presliced:
             X, _ = self._slice(X, None)
 
         X_product = self._weighted_product(X)
-        theta = tf.constant(0., float_type)
-        return self.variance * (1. / np.pi) * self._J(theta) * X_product ** self.order
+
+        joint_theta = tf.constant(0., float_type)
+        joint_kernel = (1. / np.pi) * self._J(joint_theta) * X_product ** self.order
+
+        for _ in range(self.num_layers):
+            joint_kernel = (1. / np.pi) * self._J(joint_theta) * \
+                           joint_kernel ** self.order
+
+        return self.variance * joint_kernel
 
 
 class PeriodicKernel(Kern):

--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -495,7 +495,7 @@ class ArcCosine(Kern):
                  active_dims=None, ARD=False):
         Kern.__init__(self, input_dim, active_dims)
 
-        if not order in self.implemented_orders:
+        if order not in self.implemented_orders:
             raise ValueError('Requested kernel order is not implemented.')
         self.order = order
 
@@ -541,8 +541,8 @@ class ArcCosine(Kern):
         else:
             X2_denominator = tf.sqrt(self._weighted_product(X2))
 
-        enumerator = self._weighted_product(X, X2)
-        theta = tf.acos(tf.clip_by_value(enumerator / \
+        numerator = self._weighted_product(X, X2)
+        theta = tf.acos(tf.clip_by_value(numerator / \
                                          X_denominator[:, None] / \
                                          X2_denominator[None, :],
                                          -1., 1.))

--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -546,7 +546,7 @@ class ArcCosine(Kern):
         if X2 is None:
             return tf.reduce_sum(self.weight_variances * tf.square(X), axis=1) + self.bias_variance
         else:
-            return tf.matmul((self.weight_variances * X), tf.transpose(X2)) + self.bias_variance
+            return tf.matmul((self.weight_variances * X), X2, transpose_b=True) + self.bias_variance
 
     def _J(self, theta):
         """

--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -485,14 +485,41 @@ class Cosine(Stationary):
 
 class ArcCosine(Kern):
     """
-    The arc cosine family of kernels
+    The Arc-cosine family of kernels which mimics the computation in neural
+    networks. The order parameter specifies the assumed activation function.
+    The Multi Layer Perceptron (MLP) kernel is closely related to the ArcCosine
+    kernel of order 0. The key reference is
+
+    ::
+
+        @incollection{NIPS2009_3628,
+            title = {Kernel Methods for Deep Learning},
+            author = {Youngmin Cho and Lawrence K. Saul},
+            booktitle = {Advances in Neural Information Processing Systems 22},
+            year = {2009},
+            url = {http://papers.nips.cc/paper/3628-kernel-methods-for-deep-learning.pdf}
+        }
     """
 
     implemented_orders = {0, 1, 2}
-    def __init__(self, input_dim, variance=1.0,
-                 weight_variances=1., bias_variance=1.,
+    def __init__(self, input_dim,
                  order=0,
+                 variance=1.0, weight_variances=1., bias_variance=1.,
                  active_dims=None, ARD=False):
+        """
+        - input_dim is the dimension of the input to the kernel
+        - order specifies the activation function of the neural network
+          the function is a rectified monomial of the chosen order.
+        - variance is the initial value for the variance parameter
+        - weight_variances is the initial value for the weight_variances parameter
+          defaults to 1.0 (ARD=False) or np.ones(input_dim) (ARD=True).
+        - bias_variance is the initial value for the bias_variance parameter
+          defaults to 1.0.
+        - active_dims is a list of length input_dim which controls which
+          columns of X are used.
+        - ARD specifies whether the kernel has one weight_variance per dimension
+          (ARD=True) or a single weight_variance (ARD=False).
+        """
         Kern.__init__(self, input_dim, active_dims)
 
         if order not in self.implemented_orders:
@@ -522,6 +549,10 @@ class ArcCosine(Kern):
             return tf.matmul((self.weight_variances * X), tf.transpose(X2)) + self.bias_variance
 
     def _J(self, theta):
+        """
+        Implements the order dependent family of functions defined in equations
+        4 to 7 in the reference paper.
+        """
         if self.order == 0:
             return np.pi - theta
         elif self.order == 1:

--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -556,7 +556,7 @@ class ArcCosine(Kern):
             X, _ = self._slice(X, None)
 
         X_product = self._weighted_product(X)
-        theta = tf.zeros([tf.shape(X)[0]], float_type)
+        theta = tf.constant(0., float_type)
         return self.variance * (1. / np.pi) * self._J(theta) * X_product ** self.order
 
 

--- a/testing/reference.py
+++ b/testing/reference.py
@@ -13,16 +13,7 @@ def referenceRbfKernel( X, lengthScale, signalVariance ):
     return kernel
 
 
-def referenceArcCosineKernel( X, order, num_layers, weightVariances, biasVariance, signalVariance ):
-    def J(theta):
-        if order == 0:
-            return np.pi - theta
-        elif order == 1:
-            return np.sin(theta) + (np.pi - theta) * np.cos(theta)
-        elif order == 2:
-            return  3. * np.sin(theta) * np.cos(theta) + \
-                    (np.pi - theta) * (1. + 2. * np.cos(theta) ** 2)
-
+def referenceArcCosineKernel( X, order, weightVariances, biasVariance, signalVariance ):
     num_points = X.shape[0]
     kernel = np.empty((num_points, num_points))
     for row in range(num_points):
@@ -34,28 +25,19 @@ def referenceArcCosineKernel( X, order, num_layers, weightVariances, biasVarianc
 
             x_denominator = np.sqrt((weightVariances * x).dot(x) + biasVariance)
             y_denominator = np.sqrt((weightVariances * y).dot(y) + biasVariance)
+            denominator = x_denominator * y_denominator
 
-            xy_theta = np.arccos(np.clip(numerator / x_denominator / y_denominator,
-                                         -1., 1.))
-            xy_kernel = (1. / np.pi) * J(xy_theta) * \
-                        x_denominator ** order * \
-                        y_denominator ** order
+            theta = np.arccos(np.clip(numerator / denominator, -1., 1.))
+            if order == 0:
+                J = np.pi - theta
+            elif order == 1:
+                J = np.sin(theta) + (np.pi - theta) * np.cos(theta)
+            elif order == 2:
+                J = 3. * np.sin(theta) * np.cos(theta) + (np.pi - theta) * (1. + 2. * np.cos(theta) ** 2)
 
-            xx_kernel = (1. / np.pi) * J(0.) * x_denominator ** order
-            yy_kernel = (1. / np.pi) * J(0.) * y_denominator ** order
-
-            for _ in range(num_layers - 1):
-                xy_theta = np.arccos(np.clip(xy_kernel / \
-                                             np.sqrt(xx_kernel * yy_kernel),
-                                             -1., 1.))
-
-                xy_kernel = (1. / np.pi) * J(xy_theta) * \
-                            (xx_kernel * yy_kernel) ** (0.5 * order)
-
-                xx_kernel = (1. / np.pi) * J(0.) * xx_kernel ** order
-                yy_kernel = (1. / np.pi) * J(0.) * yy_kernel ** order
-
-            kernel[row, col] = signalVariance * xy_kernel
+            kernel[row, col] = signalVariance * (1. / np.pi) * J * \
+                               x_denominator ** order * \
+                               y_denominator ** order
     return kernel
 
 

--- a/testing/reference.py
+++ b/testing/reference.py
@@ -13,7 +13,16 @@ def referenceRbfKernel( X, lengthScale, signalVariance ):
     return kernel
 
 
-def referenceArcCosineKernel( X, order, weightVariances, biasVariance, signalVariance ):
+def referenceArcCosineKernel( X, order, num_layers, weightVariances, biasVariance, signalVariance ):
+    def J(theta):
+        if order == 0:
+            return np.pi - theta
+        elif order == 1:
+            return np.sin(theta) + (np.pi - theta) * np.cos(theta)
+        elif order == 2:
+            return  3. * np.sin(theta) * np.cos(theta) + \
+                    (np.pi - theta) * (1. + 2. * np.cos(theta) ** 2)
+
     num_points = X.shape[0]
     kernel = np.empty((num_points, num_points))
     for row in range(num_points):
@@ -25,19 +34,28 @@ def referenceArcCosineKernel( X, order, weightVariances, biasVariance, signalVar
 
             x_denominator = np.sqrt((weightVariances * x).dot(x) + biasVariance)
             y_denominator = np.sqrt((weightVariances * y).dot(y) + biasVariance)
-            denominator = x_denominator * y_denominator
 
-            theta = np.arccos(np.clip(numerator / denominator, -1., 1.))
-            if order == 0:
-                J = np.pi - theta
-            elif order == 1:
-                J = np.sin(theta) + (np.pi - theta) * np.cos(theta)
-            elif order == 2:
-                J = 3. * np.sin(theta) * np.cos(theta) + (np.pi - theta) * (1. + 2. * np.cos(theta) ** 2)
+            xy_theta = np.arccos(np.clip(numerator / x_denominator / y_denominator,
+                                         -1., 1.))
+            xy_kernel = (1. / np.pi) * J(xy_theta) * \
+                        x_denominator ** order * \
+                        y_denominator ** order
 
-            kernel[row, col] = signalVariance * (1. / np.pi) * J * \
-                               x_denominator ** order * \
-                               y_denominator ** order
+            xx_kernel = (1. / np.pi) * J(0.) * x_denominator ** order
+            yy_kernel = (1. / np.pi) * J(0.) * y_denominator ** order
+
+            for _ in range(num_layers - 1):
+                xy_theta = np.arccos(np.clip(xy_kernel / \
+                                             np.sqrt(xx_kernel * yy_kernel),
+                                             -1., 1.))
+
+                xy_kernel = (1. / np.pi) * J(xy_theta) * \
+                            (xx_kernel * yy_kernel) ** (0.5 * order)
+
+                xx_kernel = (1. / np.pi) * J(0.) * xx_kernel ** order
+                yy_kernel = (1. / np.pi) * J(0.) * yy_kernel ** order
+
+            kernel[row, col] = signalVariance * xy_kernel
     return kernel
 
 

--- a/testing/reference.py
+++ b/testing/reference.py
@@ -21,13 +21,13 @@ def referenceArcCosineKernel( X, order, weightVariances, biasVariance, signalVar
             x = X[row]
             y = X[col]
 
-            enumerator = (weightVariances * x).dot(y) + biasVariance
+            numerator = (weightVariances * x).dot(y) + biasVariance
 
             x_denominator = np.sqrt((weightVariances * x).dot(x) + biasVariance)
             y_denominator = np.sqrt((weightVariances * y).dot(y) + biasVariance)
             denominator = x_denominator * y_denominator
 
-            theta = np.arccos(np.clip(enumerator / denominator, -1., 1.))
+            theta = np.arccos(np.clip(numerator / denominator, -1., 1.))
             if order == 0:
                 J = np.pi - theta
             elif order == 1:

--- a/testing/reference.py
+++ b/testing/reference.py
@@ -13,9 +13,26 @@ def referenceRbfKernel( X, lengthScale, signalVariance ):
     return kernel
 
 
+def referenceMLPKernel( X, weightVariances, biasVariance, signalVariance ):
+    num_points = X.shape[0]
+    kernel = np.empty((num_points, num_points))
+    for row in range(num_points):
+        for col in range(num_points):
+            x = X[row]
+            y = X[col]
+
+            enumerator = (weightVariances * x).dot(y) + biasVariance
+
+            x_denominator = np.sqrt((weightVariances * x).dot(x) + biasVariance + 1.)
+            y_denominator = np.sqrt((weightVariances * y).dot(y) + biasVariance + 1.)
+            denominator = x_denominator * y_denominator
+
+            kernel[row, col] = signalVariance * 2. / np.pi * np.arcsin(enumerator / denominator)
+    return kernel
+
+
 def referencePeriodicKernel( X, lengthScale, signalVariance, period ):
     # Based on the GPy implementation of standard_period kernel
     base = np.pi * (X[:, None, :] - X[None, :, :]) / period
     exp_dist = np.exp( -0.5* np.sum( np.square(  np.sin( base ) / lengthScale ), axis = -1 ) )
     return signalVariance * exp_dist
-    

--- a/testing/test_kerns.py
+++ b/testing/test_kerns.py
@@ -29,10 +29,11 @@ class TestRbf(unittest.TestCase):
 class TestArcCosine(unittest.TestCase):
     def evalKernelError(self, D, variance, weight_variances,
                         bias_variance, order, ARD, X_data):
-        kernel = GPflow.kernels.ArcCosine(D, variance=variance,
+        kernel = GPflow.kernels.ArcCosine(D,
+                                          order=order,
+                                          variance=variance,
                                           weight_variances=weight_variances,
                                           bias_variance=bias_variance,
-                                          order=order,
                                           ARD=ARD)
         rng = np.random.RandomState(1)
 

--- a/testing/test_kerns.py
+++ b/testing/test_kerns.py
@@ -28,18 +28,18 @@ class TestRbf(unittest.TestCase):
 
 class TestArcCosine(unittest.TestCase):
     def evalKernelError(self, D, variance, weight_variances,
-                        bias_variance, order, num_layers, ARD, X_data):
+                        bias_variance, order, ARD, X_data):
         kernel = GPflow.kernels.ArcCosine(D, variance=variance,
                                           weight_variances=weight_variances,
                                           bias_variance=bias_variance,
-                                          order=order, num_layers=num_layers,
+                                          order=order,
                                           ARD=ARD)
         rng = np.random.RandomState(1)
 
         x_free = tf.placeholder('float64')
         kernel.make_tf_array(x_free)
         X = tf.placeholder('float64')
-        reference_gram_matrix = referenceArcCosineKernel(X_data, order, num_layers,
+        reference_gram_matrix = referenceArcCosineKernel(X_data, order,
                                                          weight_variances,
                                                          bias_variance,
                                                          variance)
@@ -51,20 +51,18 @@ class TestArcCosine(unittest.TestCase):
 
     def test_1d(self):
         D = 1
-        N = 4
+        N = 3
         weight_variances = 1.7
         bias_variance = 0.6
         variance = 2.3
         ARD = False
         orders = GPflow.kernels.ArcCosine.implemented_orders
-        layers = {1, 2, 6}
 
         rng = np.random.RandomState(1)
         X_data = rng.randn(N, D)
         for order in orders:
-            for layer in layers:
-                self.evalKernelError(D, variance, weight_variances,
-                                     bias_variance, order, layer, ARD, X_data)
+            self.evalKernelError(D, variance, weight_variances,
+                                 bias_variance, order, ARD, X_data)
 
     def test_3d(self):
         D = 3
@@ -74,14 +72,12 @@ class TestArcCosine(unittest.TestCase):
         variance = 1e-2
         ARD = True
         orders = GPflow.kernels.ArcCosine.implemented_orders
-        layers = {1, 2, 6}
 
         rng = np.random.RandomState(1)
         X_data = rng.randn(N, D)
         for order in orders:
-            for layer in layers:
-                self.evalKernelError(D, variance, weight_variances,
-                                     bias_variance, order, layer, ARD, X_data)
+            self.evalKernelError(D, variance, weight_variances,
+                                bias_variance, order, ARD, X_data)
 
 
 class TestPeriodic(unittest.TestCase):
@@ -197,10 +193,8 @@ class TestKernDiags(unittest.TestCase):
         self.kernels.append(GPflow.kernels.RBF(inputdim) +
                             GPflow.kernels.Linear(inputdim, ARD=True, variance=rng.rand(inputdim)))
         self.kernels.append(GPflow.kernels.PeriodicKernel(inputdim))
-        self.kernels.extend(GPflow.kernels.ArcCosine(inputdim,
-                                                     order=order, num_layers=layers)
-                            for order in GPflow.kernels.ArcCosine.implemented_orders
-                            for layers in {1, 2, 6})
+        self.kernels.extend(GPflow.kernels.ArcCosine(inputdim, order=order)
+                            for order in GPflow.kernels.ArcCosine.implemented_orders)
 
         self.x_free = tf.placeholder('float64')
         [k.make_tf_array(self.x_free) for k in self.kernels]


### PR DESCRIPTION
This pull request adds an implementation of the MLP kernel as used in [GPy](https://pythonhosted.org/GPy/GPy.kern.src.html#module-GPy.kern.src.mlp), together with a few tests. If there is interest to merge this PR, I can add more information to the docstring or maybe more tests. This code is also not tested very thoroughly yet.