### PR TITLE
Preventing multiple params in tree

### DIFF
--- a/GPflow/model.py
+++ b/GPflow/model.py
@@ -348,9 +348,9 @@ class GPModel(Model):
     """
 
     def __init__(self, X, Y, kern, likelihood, mean_function, name='model'):
+        Model.__init__(self, name)
         self.kern, self.likelihood, self.mean_function = \
             kern, likelihood, mean_function
-        Model.__init__(self, name)
 
         if isinstance(X, np.ndarray):
             #: X is a data matrix; each row represents one instance

--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -671,6 +671,24 @@ class Parameterized(Parentable):
                 p.set_data(value)
                 return  # don't call object.setattr or set the _parent value
 
+        if key is not '_parent' and isinstance(value, (Param, Parameterized)):
+            # assigning a param that isn't the parent, check that it is not already in the tree
+
+            def _raise_for_existing_param(node):
+                """
+                Find a certain param from the root of the tree we're in by depth first search. Raise if found.
+                """
+                if node is value:
+                    raise ValueError('The Param(eterized) object {0} is already present in the tree'.format(value))
+
+                # search all children if we aren't at a leaf node
+                if isinstance(node, Parameterized):
+                    for child in node.sorted_params:
+                        _raise_for_existing_param(child)
+
+            root = self.highest_parent
+            _raise_for_existing_param(root)
+
         # use the standard setattr
         object.__setattr__(self, key, value)
 
@@ -748,7 +766,7 @@ class Parameterized(Parentable):
 
         This makes sure they're always in the same order.
         """
-        params = [child for key, child in self.__dict__.items()
+        params=  [child for key, child in self.__dict__.items()
                   if isinstance(child, (Param, Parameterized)) and
                   key is not '_parent']
         return sorted(params, key=id)

--- a/testing/test_mean_functions.py
+++ b/testing/test_mean_functions.py
@@ -1,3 +1,4 @@
+import itertools
 import GPflow
 import tensorflow as tf
 import numpy as np
@@ -18,37 +19,57 @@ class TestMeanFuncs(unittest.TestCase):
         self.output_dim = 2
         self.N = 20
         rng = np.random.RandomState(0)
-        self.mfs = [GPflow.mean_functions.Zero(),
-                    GPflow.mean_functions.Linear(rng.randn(self.input_dim, self.output_dim).astype(np_float_type), rng.randn(self.output_dim).astype(np_float_type)),
-                    GPflow.mean_functions.Constant(rng.randn(self.output_dim).astype(np_float_type))]
+        self.mfs1 = [GPflow.mean_functions.Zero(),
+                     GPflow.mean_functions.Linear(rng.randn(self.input_dim, self.output_dim).astype(np_float_type), rng.randn(self.output_dim).astype(np_float_type)),
+                     GPflow.mean_functions.Constant(rng.randn(self.output_dim).astype(np_float_type))]
+        rng = np.random.RandomState(0)
+        self.mfs2 = [GPflow.mean_functions.Zero(),
+                     GPflow.mean_functions.Linear(rng.randn(self.input_dim, self.output_dim).astype(np_float_type), rng.randn(self.output_dim).astype(np_float_type)),
+                     GPflow.mean_functions.Constant(rng.randn(self.output_dim).astype(np_float_type))]
+
 
         self.composition_mfs_add = []
         self.composition_mfs_mult = []
 
-        for mean_f1 in self.mfs:
-            self.composition_mfs_add.extend([mean_f1 + mean_f2 for mean_f2 in self.mfs])
-            self.composition_mfs_mult.extend([mean_f1 * mean_f2 for mean_f2 in self.mfs])
+        for (mean_f1, mean_f2) in itertools.product(self.mfs1, self.mfs2):
+            self.composition_mfs_add.extend([mean_f1 + mean_f2])
+            self.composition_mfs_mult.extend([mean_f1 * mean_f2])
 
         self.composition_mfs = self.composition_mfs_add + self.composition_mfs_mult
         self.x = tf.placeholder(float_type)
 
-        for mf in self.mfs:
+        for mf in self.mfs1:
+            mf.make_tf_array(self.x)
+        for mf in self.mfs2:
             mf.make_tf_array(self.x)
 
         self.X = tf.placeholder(float_type, [self.N, self.input_dim])
         self.X_data = np.random.randn(self.N, self.input_dim).astype(np_float_type)
 
     def test_basic_output_shape(self):
-        for mf in self.mfs:
+        for mf in self.mfs1:
             with mf.tf_mode():
                 Y = tf.Session().run(mf(self.X), feed_dict={self.x: mf.get_free_state(), self.X: self.X_data})
             self.assertTrue(Y.shape in [(self.N, self.output_dim), (self.N, 1)])
 
-    def test_composition_output_shape(self):
-        for comp_mf in self.composition_mfs:
+    def test_add_output_shape(self):
+        for comp_mf in self.composition_mfs_add:
             with comp_mf.tf_mode():
                 Y = tf.Session().run(comp_mf(self.X), feed_dict={self.x: comp_mf.get_free_state(), self.X: self.X_data})
             self.assertTrue(Y.shape in [(self.N, self.output_dim), (self.N, 1)])
+
+    def test_mult_output_shape(self):
+        for comp_mf in self.composition_mfs_mult:
+            with comp_mf.tf_mode():
+                Y = tf.Session().run(comp_mf(self.X), feed_dict={self.x: comp_mf.get_free_state(), self.X: self.X_data})
+            self.assertTrue(Y.shape in [(self.N, self.output_dim), (self.N, 1)])
+
+    def test_composition_output_shape(self):
+        comp_mf = self.composition_mfs[1]
+        # for comp_mf in self.composition_mfs:
+        with comp_mf.tf_mode():
+            Y = tf.Session().run(comp_mf(self.X), feed_dict={self.x: comp_mf.get_free_state(), self.X: self.X_data})
+        self.assertTrue(Y.shape in [(self.N, self.output_dim), (self.N, 1)])
 
     def test_combination_types(self):
         self.assertTrue(all(isinstance(mfAdd, GPflow.mean_functions.Additive) for mfAdd in self.composition_mfs_add))
@@ -74,38 +95,46 @@ class TestModelCompositionOperations(unittest.TestCase):
 
         zero = GPflow.mean_functions.Zero()
 
-        linear1 = GPflow.mean_functions.Linear(rng.randn(self.input_dim, self.output_dim).astype(np_float_type), rng.randn(self.output_dim).astype(np_float_type))
+        # need two copies of the linear1_1 since we can't add the same parameter twice to a single tree
+        _rng = np.random.RandomState(0)
+        linear1_1 = GPflow.mean_functions.Linear(_rng.randn(self.input_dim, self.output_dim).astype(np_float_type),
+                                                 _rng.randn(self.output_dim).astype(np_float_type))
+        _rng = np.random.RandomState(0)
+        linear1_2 = GPflow.mean_functions.Linear(_rng.randn(self.input_dim, self.output_dim).astype(np_float_type),
+                                                 _rng.randn(self.output_dim).astype(np_float_type))
         linear2 = GPflow.mean_functions.Linear(rng.randn(self.input_dim, self.output_dim).astype(np_float_type), rng.randn(self.output_dim).astype(np_float_type))
         linear3 = GPflow.mean_functions.Linear(rng.randn(self.input_dim, self.output_dim).astype(np_float_type), rng.randn(self.output_dim).astype(np_float_type))
 
-        const1 = GPflow.mean_functions.Constant(rng.randn(self.output_dim).astype(np_float_type))
+        # need two copies of the const1 since we can't add the same parameter twice to a single tree
+        const1_1 = GPflow.mean_functions.Constant(np.random.RandomState(0).randn(self.output_dim).astype(np_float_type))
+        const1_2 = GPflow.mean_functions.Constant(np.random.RandomState(0).randn(self.output_dim).astype(np_float_type))
         const2 = GPflow.mean_functions.Constant(rng.randn(self.output_dim).astype(np_float_type))
         const3 = GPflow.mean_functions.Constant(rng.randn(self.output_dim).astype(np_float_type))
 
-        const1inv = GPflow.mean_functions.Constant(np.reshape(const1.c.get_free_state() * -1, [self.output_dim]))
-        linear1inv = GPflow.mean_functions.Linear(A=np.reshape(linear1.A.get_free_state() * -1., [self.input_dim, self.output_dim]),
-                                                  b=np.reshape(linear1.b.get_free_state() * -1., [self.output_dim]))
+        const1inv = GPflow.mean_functions.Constant(np.reshape(const1_1.c.get_free_state() * -1, [self.output_dim]))
+        linear1inv = GPflow.mean_functions.Linear(A=np.reshape(linear1_1.A.get_free_state() * -1., [self.input_dim, self.output_dim]),
+                                                  b=np.reshape(linear1_2.b.get_free_state() * -1., [self.output_dim]))
 
         # a * (b + c)
-        const_set1 = GPflow.mean_functions.Product(const1,
+        const_set1 = GPflow.mean_functions.Product(const1_1,
                                                    GPflow.mean_functions.Additive(const2, const3))
-        linear_set1 = GPflow.mean_functions.Product(linear1,
+        linear_set1 = GPflow.mean_functions.Product(linear1_1,
                                                     GPflow.mean_functions.Additive(linear2, linear3))
 
         # ab + ac
-        const_set2 = GPflow.mean_functions.Additive(GPflow.mean_functions.Product(const1, const2),
-                                                    GPflow.mean_functions.Product(const1, const3))
+        const_set2 = GPflow.mean_functions.Additive(GPflow.mean_functions.Product(const1_1, const2),
+                                                    GPflow.mean_functions.Product(const1_2, const3))
 
-        linear_set2 = GPflow.mean_functions.Additive(GPflow.mean_functions.Product(linear1, linear2),
-                                                     GPflow.mean_functions.Product(linear1, linear3))
+        linear_set2 = GPflow.mean_functions.Additive(GPflow.mean_functions.Product(linear1_1, linear2),
+                                                     GPflow.mean_functions.Product(linear1_2, linear3))
         # a-a = 0, (a + b) -a = b = a + (b - a)
 
-        linear1_minus_linear1 = GPflow.mean_functions.Additive(linear1, linear1inv)
-        const1_minus_const1 = GPflow.mean_functions.Additive(const1, const1inv)
+        linear1_minus_linear1 = GPflow.mean_functions.Additive(linear1_1, linear1inv)
+        const1_minus_const1 = GPflow.mean_functions.Additive(const1_1, const1inv)
 
-        comp_minus_constituent1 = GPflow.mean_functions.Additive(GPflow.mean_functions.Additive(linear1, linear2),
+        comp_minus_constituent1 = GPflow.mean_functions.Additive(GPflow.mean_functions.Additive(linear1_1, linear2),
                                                                       linear1inv)
-        comp_minus_constituent2 = GPflow.mean_functions.Additive(linear1,
+        comp_minus_constituent2 = GPflow.mean_functions.Additive(linear1_1,
                                                                       GPflow.mean_functions.Additive(linear2,
                                                                                                      linear1inv))
 

--- a/testing/test_param.py
+++ b/testing/test_param.py
@@ -369,7 +369,7 @@ class SingleParamterizedInvariantTest(unittest.TestCase):
         m1.foo = GPflow.param.Parameterized()
 
         m2 = GPflow.param.Parameterized()
-        m2.foo = GPflow.param.Parameterized()
+        m2.foo = m1.foo
 
 
 class SingleParamInvariantTest(unittest.TestCase):
@@ -422,7 +422,7 @@ class SingleParamInvariantTest(unittest.TestCase):
         m1.foo = GPflow.param.Param(1)
 
         m2 = GPflow.param.Parameterized()
-        m2.foo = GPflow.param.Param(1)
+        m2.foo = m1.foo
 
 
 class TestParamList(unittest.TestCase):

--- a/testing/test_param.py
+++ b/testing/test_param.py
@@ -38,13 +38,6 @@ class NamingTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             print(p.name)
 
-    def test_two_parents(self):
-        m = GPflow.model.Model()
-        m.p = GPflow.param.Param(1)
-        m.p2 = m.p  # do not do this!
-        with self.assertRaises(ValueError):
-            print(m.p.name)
-
 
 class ParamTestsScalar(unittest.TestCase):
     def setUp(self):
@@ -316,6 +309,120 @@ class ParamTestsWider(unittest.TestCase):
         with self.m.tf_mode():
             self.assertTrue(all([isinstance(p, tf.Tensor)
                                  for p in (self.m.foo, self.m.bar, self.m.baz)]))
+
+
+class SingleParamterizedInvariantTest(unittest.TestCase):
+    """
+    Tests that invariants of only allowing a single reference to a given Parameterized in a tree
+    """
+    def setUp(self):
+        tf.reset_default_graph()
+
+    def testSelfReference(self):
+        """
+        Test we raise when a Parameterized object references itself
+        """
+        m = GPflow.param.Parameterized()
+
+        with self.assertRaises(ValueError):
+            m.foo = m
+
+    def testReferenceBelow(self):
+        """
+        Test we raise when we reference the same Parameterized object in a descendent node
+        """
+        m = GPflow.param.Parameterized()
+        m.foo = GPflow.param.Parameterized()
+
+        with self.assertRaises(ValueError):
+            m.foo.bar = m
+
+    def testReferenceAbove(self):
+        """
+        Test we raise when we reference the same Parameterized object in an ancestor node
+        """
+        m = GPflow.param.Parameterized()
+        m.foo = GPflow.param.Parameterized()
+        m.foo.bar = GPflow.param.Parameterized()
+
+        with self.assertRaises(ValueError):
+            m.baz = m.foo.bar
+
+    def testReferenceAccross(self):
+        """
+        Test we raise when we reference the same Parameterized object in a sibling node
+        """
+        m = GPflow.param.Parameterized()
+        m.foo = GPflow.param.Parameterized()
+        m.foo.bar = GPflow.param.Parameterized()
+
+        m.boo = GPflow.param.Parameterized()
+
+        with self.assertRaises(ValueError):
+            m.boo.far = m.foo.bar
+
+    def testAddingToAnother(self):
+        """
+        Adding the same Paramterized object to another tree is fine.
+        """
+        m1 = GPflow.param.Parameterized()
+        m1.foo = GPflow.param.Parameterized()
+
+        m2 = GPflow.param.Parameterized()
+        m2.foo = GPflow.param.Parameterized()
+
+
+class SingleParamInvariantTest(unittest.TestCase):
+    """
+    Tests that invariants of only allowing a single reference to a given Param in a tree
+    """
+    def setUp(self):
+        tf.reset_default_graph()
+
+    def testReferenceBelow(self):
+        """
+        Test we raise when the same Param object is added further down the tree
+        """
+        m = GPflow.param.Parameterized()
+        m.p = GPflow.param.Param(1)
+        m.foo = GPflow.param.Parameterized()
+
+        with self.assertRaises(ValueError):
+            m.foo.p = m.p
+
+    def testReferenceAbove(self):
+        """
+        Test we raise when we reference the same Param object in a an ancestor node
+        """
+        m = GPflow.param.Parameterized()
+        m.foo = GPflow.param.Parameterized()
+        m.foo.p = GPflow.param.Param(1)
+
+        with self.assertRaises(ValueError):
+            m.p = m.foo.p
+
+    def testReferenceAccross(self):
+        """
+        Test we raise when we reference the same Param object in a sibling node
+        """
+        m = GPflow.param.Parameterized()
+        m.foo = GPflow.param.Parameterized()
+        m.foo.p = GPflow.param.Param(1)
+
+        m.bar = GPflow.param.Parameterized()
+
+        with self.assertRaises(ValueError):
+            m.bar.p = m.foo.p
+
+    def testAddingToAnother(self):
+        """
+        Adding the same Param object to another tree is fine.
+        """
+        m1 = GPflow.param.Parameterized()
+        m1.foo = GPflow.param.Param(1)
+
+        m2 = GPflow.param.Parameterized()
+        m2.foo = GPflow.param.Param(1)
 
 
 class TestParamList(unittest.TestCase):


### PR DESCRIPTION
This addresses the issue of multiple parameters being in the tree (#349) which was causing ```longname``` to crash. It was decided with @jameshensman that rather than delaying until the construction of the name to detect and maybe recover from multiple parameters in the tree, that we should detect and abort as soon as someone tries to add the same param to the same tree.

This PR therefore adds the invariant to a tree that a ```Param```/ ```Parameterized``` may only appear that a single point.

Cheers.