### PR TITLE
Allow reassignment of Param(eterized)s

### DIFF
--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -673,21 +673,23 @@ class Parameterized(Parentable):
 
         if key is not '_parent' and isinstance(value, (Param, Parameterized)):
             # assigning a param that isn't the parent, check that it is not already in the tree
+            if not hasattr(self, key) or not self.__getattribute__(key) is value:
+                # we are not assigning the same value to the same member
 
-            def _raise_for_existing_param(node):
-                """
-                Find a certain param from the root of the tree we're in by depth first search. Raise if found.
-                """
-                if node is value:
-                    raise ValueError('The Param(eterized) object {0} is already present in the tree'.format(value))
+                def _raise_for_existing_param(node):
+                    """
+                    Find a certain param from the root of the tree we're in by depth first search. Raise if found.
+                    """
+                    if node is value:
+                        raise ValueError('The Param(eterized) object {0} is already present in the tree'.format(value))
 
-                # search all children if we aren't at a leaf node
-                if isinstance(node, Parameterized):
-                    for child in node.sorted_params:
-                        _raise_for_existing_param(child)
+                    # search all children if we aren't at a leaf node
+                    if isinstance(node, Parameterized):
+                        for child in node.sorted_params:
+                            _raise_for_existing_param(child)
 
-            root = self.highest_parent
-            _raise_for_existing_param(root)
+                root = self.highest_parent
+                _raise_for_existing_param(root)
 
         # use the standard setattr
         object.__setattr__(self, key, value)

--- a/testing/test_param.py
+++ b/testing/test_param.py
@@ -371,6 +371,15 @@ class SingleParamterizedInvariantTest(unittest.TestCase):
         m2 = GPflow.param.Parameterized()
         m2.foo = m1.foo
 
+    def testReassign(self):
+        """
+        We should be able to reassign the same value to the same param
+        """
+        m1 = GPflow.param.Parameterized()
+        p = GPflow.param.Parameterized()
+        m1.foo = p  # assign
+        m1.foo = p  # reassign
+
 
 class SingleParamInvariantTest(unittest.TestCase):
     """
@@ -423,6 +432,15 @@ class SingleParamInvariantTest(unittest.TestCase):
 
         m2 = GPflow.param.Parameterized()
         m2.foo = m1.foo
+
+    def testReassign(self):
+        """
+        We should be able to reassign the same value to the same param
+        """
+        m1 = GPflow.param.Parameterized()
+        p = GPflow.param.Param(1)
+        m1.foo = p  # assign
+        m1.foo = p  # reassign
 
 
 class TestParamList(unittest.TestCase):


### PR DESCRIPTION
This change fixes a fix I pushed a couple of weeks ago.

The original fix was to make sure that we only have a single copy of a Param/ Paramterized object in the tree. It was a little overzealous and wouldn't allow us to do something like:
```
        m = GPflow.param.Parameterized()
        p = GPflow.param.Parameterized()
        m.foo = p
        m.foo = p  # raise exception here
```
This commit fixes the issue.