### PR TITLE
Use transpose_{a,b}=True in tf.matmul's

### DIFF
--- a/GPflow/conditionals.py
+++ b/GPflow/conditionals.py
@@ -82,7 +82,7 @@ def conditional(Xnew, X, kern, f, full_cov=False, q_sqrt=None, whiten=False):
         A = tf.matrix_triangular_solve(tf.transpose(Lm), A, lower=False)
 
     # construct the conditional mean
-    fmean = tf.matmul(tf.transpose(A), f)
+    fmean = tf.matmul(A, f, transpose_a=True)
 
     if q_sqrt is not None:
         if q_sqrt.get_shape().ndims == 2:

--- a/GPflow/ekernels.py
+++ b/GPflow/ekernels.py
@@ -127,7 +127,7 @@ class Linear(kernels.Linear):
             raise NotImplementedError
         # use only active dimensions
         Z, Xmu = self._slice(Z, Xmu)
-        return self.variance * tf.matmul(Xmu, tf.transpose(Z))
+        return self.variance * tf.matmul(Xmu, Z, transpose_b=True)
 
     def exKxz(self, Z, Xmu, Xcov):
         with tf.control_dependencies([

--- a/GPflow/gplvm.py
+++ b/GPflow/gplvm.py
@@ -174,10 +174,10 @@ class BayesianGPLVM(GPModel):
         c = tf.matrix_triangular_solve(LB, tf.matmul(A, self.Y), lower=True) / sigma
         tmp1 = tf.matrix_triangular_solve(L, Kus, lower=True)
         tmp2 = tf.matrix_triangular_solve(LB, tmp1, lower=True)
-        mean = tf.matmul(tf.transpose(tmp2), c)
+        mean = tf.matmul(tmp2, c, transpose_a=True)
         if full_cov:
-            var = self.kern.K(Xnew) + tf.matmul(tf.transpose(tmp2), tmp2) \
-                  - tf.matmul(tf.transpose(tmp1), tmp1)
+            var = self.kern.K(Xnew) + tf.matmul(tmp2, tmp2, transpose_a=True) \
+                  - tf.matmul(tmp1, tmp1, transpose_a=True)
             shape = tf.stack([1, 1, tf.shape(self.Y)[1]])
             var = tf.tile(tf.expand_dims(var, 2), shape)
         else:

--- a/GPflow/gpr.py
+++ b/GPflow/gpr.py
@@ -1,11 +1,11 @@
 # Copyright 2016 James Hensman, Valentine Svensson, alexggmatthews, fujiisoup
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -78,9 +78,9 @@ class GPR(GPModel):
         L = tf.cholesky(K)
         A = tf.matrix_triangular_solve(L, Kx, lower=True)
         V = tf.matrix_triangular_solve(L, self.Y - self.mean_function(self.X))
-        fmean = tf.matmul(tf.transpose(A), V) + self.mean_function(Xnew)
+        fmean = tf.matmul(A, V, transpose_a=True) + self.mean_function(Xnew)
         if full_cov:
-            fvar = self.kern.K(Xnew) - tf.matmul(tf.transpose(A), A)
+            fvar = self.kern.K(Xnew) - tf.matmul(A, A, transpose_a=True)
             shape = tf.stack([1, 1, tf.shape(self.Y)[1]])
             fvar = tf.tile(tf.expand_dims(fvar, 2), shape)
         else:

--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -331,12 +331,12 @@ class Stationary(Kern):
         X = X / self.lengthscales
         Xs = tf.reduce_sum(tf.square(X), 1)
         if X2 is None:
-            return -2 * tf.matmul(X, tf.transpose(X)) + \
+            return -2 * tf.matmul(X, X, transpose_b=True) + \
                    tf.reshape(Xs, (-1, 1)) + tf.reshape(Xs, (1, -1))
         else:
             X2 = X2 / self.lengthscales
             X2s = tf.reduce_sum(tf.square(X2), 1)
-            return -2 * tf.matmul(X, tf.transpose(X2)) + \
+            return -2 * tf.matmul(X, X2, transpose_b=True) + \
                    tf.reshape(Xs, (-1, 1)) + tf.reshape(X2s, (1, -1))
 
     def euclid_dist(self, X, X2):
@@ -385,9 +385,9 @@ class Linear(Kern):
         if not presliced:
             X, X2 = self._slice(X, X2)
         if X2 is None:
-            return tf.matmul(X * self.variance, tf.transpose(X))
+            return tf.matmul(X * self.variance, X, transpose_b=True)
         else:
-            return tf.matmul(X * self.variance, tf.transpose(X2))
+            return tf.matmul(X * self.variance, X2, transpose_b=True)
 
     def Kdiag(self, X, presliced=False):
         if not presliced:
@@ -561,7 +561,7 @@ class Coregion(Kern):
             X2 = X
         else:
             X2 = tf.cast(X2[:, 0], tf.int32)
-        B = tf.matmul(self.W, tf.transpose(self.W)) + tf.diag(self.kappa)
+        B = tf.matmul(self.W, self.W, transpose_b=True) + tf.diag(self.kappa)
         return tf.gather(tf.transpose(tf.gather(B, X2)), X)
 
     def Kdiag(self, X):

--- a/GPflow/vgp.py
+++ b/GPflow/vgp.py
@@ -138,7 +138,7 @@ class VGP(GPModel):
         K = self.kern.K(self.X)
 
         # predictive mean
-        f_mean = tf.matmul(tf.transpose(Kx), self.q_alpha) + self.mean_function(Xnew)
+        f_mean = tf.matmul(Kx, self.q_alpha, transpose_a=True) + self.mean_function(Xnew)
 
         # predictive var
         A = K + tf.matrix_diag(tf.transpose(1./tf.square(self.q_lambda)))


### PR DESCRIPTION
In digging through the code, I noticed sometimes `tf.matmul(A, B, transpose_a=True)` is used and other times `tf.matmul(tf.transpose(A), B))` is used. For consistency, I grepped all instances where `tf.transpose` is used only for the `matmul` and replaced them with the former approach. The former is also more efficient.

The amount of speedup seems to vary. For large dense matrices, it can be significant.
```python
import numpy as np
import tensorflow as tf
import time

N = 4500
M = 1000

np.random.seed(42)
x_data = np.random.randn(N, M)

x = tf.convert_to_tensor(x_data)
y1 = tf.matmul(x, x, transpose_b=True)
y2 = tf.matmul(x, tf.transpose(x))

sess = tf.Session()

y1_start = time.time()
sess.run(y1)
y1_end = time.time()
print(y1_end - y1_start)
# 3.8839468956

y2_start = time.time()
sess.run(y2)
y2_end = time.time()
print(y2_end - y2_start)
# 5.5900349617
```