### PR TITLE
Fix randomize for multidimensional Params without priors

### DIFF
--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -307,7 +307,7 @@ class Param(Parentable):
                 except AttributeError:
                     randn = np.random.randn(
                         self.transform.free_state_size(self.shape))
-                    self._array = self.transform.forward(randn)
+                    self._array = self.transform.forward(randn).reshape(self.shape)
 
     def build_prior(self):
         """

--- a/testing/test_param.py
+++ b/testing/test_param.py
@@ -629,7 +629,8 @@ class TestRandomizeDefault(unittest.TestCase):
         m.pp = GPflow.param.Param(1.0, GPflow.transforms.Log1pe())
         m.pf = GPflow.param.Param(1.0)
         m.pf.fixed = True
-        m.pmd = GPflow.param.Param(np.ones(5))
+        pmd_shape = (5, 2)
+        m.pmd = GPflow.param.Param(np.ones(pmd_shape))
 
         #should work as (pseudo) random vals a.s. are not 1.0
         m.p.randomize()
@@ -646,6 +647,7 @@ class TestRandomizeDefault(unittest.TestCase):
         #check multidimensional
         m.pmd.randomize()
         self.assertFalse(np.any(m.pmd.value == 1.0))
+        self.assertEquals(m.pmd.shape, pmd_shape)
 
 class TestRandomizePrior(unittest.TestCase):
     """

--- a/testing/test_param.py
+++ b/testing/test_param.py
@@ -629,8 +629,10 @@ class TestRandomizeDefault(unittest.TestCase):
         m.pp = GPflow.param.Param(1.0, GPflow.transforms.Log1pe())
         m.pf = GPflow.param.Param(1.0)
         m.pf.fixed = True
-        pmd_shape = (5, 2)
-        m.pmd = GPflow.param.Param(np.ones(pmd_shape))
+
+        m.pmd = GPflow.param.Param(np.ones((5, 2)))
+        ltr = GPflow.transforms.LowerTriangular(2).forward(np.ones(2 * 10))
+        m.pmd2 = GPflow.param.Param(ltr, transform=GPflow.transforms.LowerTriangular(2))
 
         #should work as (pseudo) random vals a.s. are not 1.0
         m.p.randomize()
@@ -645,9 +647,16 @@ class TestRandomizeDefault(unittest.TestCase):
         self.assertFalse(m.pf.value == 1.0)
 
         #check multidimensional
+        pmd_shape = m.pmd.shape
         m.pmd.randomize()
         self.assertFalse(np.any(m.pmd.value == 1.0))
         self.assertEquals(m.pmd.shape, pmd_shape)
+
+        #check non size-preserving transform
+        pmd2_shape = m.pmd2.shape
+        m.pmd2.randomize()
+        self.assertFalse(np.any(m.pmd2.value == 1.0))
+        self.assertEquals(m.pmd2.shape, pmd2_shape)
 
 class TestRandomizePrior(unittest.TestCase):
     """


### PR DESCRIPTION
Hi everyone!

While trying out the convenient new randomization-feature contributed by @Bonnevie, I found a small bug: Multidimensional Params are flattened when randomized without a prior. The with-prior-case seems to work fine.
An example: The Param `x = Param(np.ones(size=(3, 3)))` with shape `x.shape == (3, 3)` would be of shape `x.shape == (9,)` after calling `x.randomize()`.

This pull request seems to fix the issue and makes the relevant test more specific in order to catch the problem. Care to have a look, @Bonnevie?