### PR TITLE
Fix pickle idempotence

### DIFF
--- a/GPflow/model.py
+++ b/GPflow/model.py
@@ -108,10 +108,7 @@ class Model(Parameterized):
         """
         d = Parameterized.__getstate__(self)
         for key in ['_graph', '_session', '_free_vars', '_objective', '_minusF', '_minusG', '_feed_dict_keys']:
-            try:
-                d.pop(key)
-            except:
-                pass
+            d.pop(key, None)
         return d
 
     def __setstate__(self, d):

--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -363,8 +363,11 @@ class Param(Parentable):
 
     def __getstate__(self):
         d = Parentable.__getstate__(self)
-        d.pop('_tf_array')
-        d.pop('_log_jacobian')
+        for key in ['_tf_array', '_log_jacobian']:
+            try:
+                d.pop(key)
+            except:
+                pass
         return d
 
     def __setstate__(self, d):

--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -364,10 +364,7 @@ class Param(Parentable):
     def __getstate__(self):
         d = Parentable.__getstate__(self)
         for key in ['_tf_array', '_log_jacobian']:
-            try:
-                d.pop(key)
-            except:
-                pass
+            d.pop(key, None)
         return d
 
     def __setstate__(self, d):

--- a/testing/test_pickle.py
+++ b/testing/test_pickle.py
@@ -69,20 +69,24 @@ class TestPickleGPR(unittest.TestCase):
         # reload the model
         m1 = pickle.loads(s1)
         m2 = pickle.loads(s2)
+        m3 = pickle.loads(pickle.dumps(m1))
 
         # make sure the log likelihoods still match
         l1 = self.m.compute_log_likelihood()
         l2 = m1.compute_log_likelihood()
         l3 = m2.compute_log_likelihood()
-        self.assertTrue(l1 == l2 == l3)
+        l4 = m3.compute_log_likelihood()
+        self.assertTrue(l1 == l2 == l3 == l4)
 
         # make sure predictions still match (this tests AutoFlow)
         pX = np.linspace(-3, 3, 10)[:, None]
         p1, _ = self.m.predict_y(pX)
         p2, _ = m1.predict_y(pX)
         p3, _ = m2.predict_y(pX)
+        p4, _ = m3.predict_y(pX)
         self.assertTrue(np.all(p1 == p2))
         self.assertTrue(np.all(p1 == p3))
+        self.assertTrue(np.all(p1 == p4))
 
 
 class TestPickleFix(unittest.TestCase):
@@ -120,20 +124,24 @@ class TestPickleSVGP(unittest.TestCase):
         # reload the model
         m1 = pickle.loads(s1)
         m2 = pickle.loads(s2)
+        m3 = pickle.loads(pickle.dumps(m2))
 
         # make sure the log likelihoods still match
         l1 = self.m.compute_log_likelihood()
         l2 = m1.compute_log_likelihood()
         l3 = m2.compute_log_likelihood()
-        self.assertTrue(l1 == l2 == l3)
+        l4 = m3.compute_log_likelihood()
+        self.assertTrue(l1 == l2 == l3 == l4)
 
         # make sure predictions still match (this tests AutoFlow)
         pX = np.linspace(-3, 3, 10)[:, None]
         p1, _ = self.m.predict_y(pX)
         p2, _ = m1.predict_y(pX)
         p3, _ = m2.predict_y(pX)
+        p4, _ = m3.predict_y(pX)
         self.assertTrue(np.all(p1 == p2))
         self.assertTrue(np.all(p1 == p3))
+        self.assertTrue(np.all(p1 == p4))
 
 
 class TestTransforms(unittest.TestCase):


### PR DESCRIPTION
In the current master, it is not possible to pickle a model which has been loaded from a pickle itself, i.e. the operation `dumps(loads(dumps(model)))` fails. The problem is that a freshly unpickled and untouched model does not have `_tf_array`s for all Param objects und the corresponding `__getstate__`-method tries to remove it resulting in an exception.
There is a fix for this in in `model.py` which ensures that things like `model._graph` are only removed when they actually exist. This PR does the same in the `Param`-class which seems to fix the issue.