### PR TITLE
Fix MLP acos numerics

### DIFF
--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -574,7 +574,7 @@ class ArcCosine(Kern):
 
         numerator = self._weighted_product(X, X2)
         cos_theta = numerator / X_denominator[:, None] / X2_denominator[None, :]
-        jitter = settings.numerics.jitter_level
+        jitter = 1e-15
         theta = tf.acos(jitter + (1 - 2 * jitter) * cos_theta)
 
         return self.variance * (1. / np.pi) * self._J(theta) * \

--- a/GPflow/kernels.py
+++ b/GPflow/kernels.py
@@ -573,10 +573,9 @@ class ArcCosine(Kern):
             X2_denominator = tf.sqrt(self._weighted_product(X2))
 
         numerator = self._weighted_product(X, X2)
-        theta = tf.acos(tf.clip_by_value(numerator / \
-                                         X_denominator[:, None] / \
-                                         X2_denominator[None, :],
-                                         -1., 1.))
+        cos_theta = numerator / X_denominator[:, None] / X2_denominator[None, :]
+        jitter = settings.numerics.jitter_level
+        theta = tf.acos(jitter + (1 - 2 * jitter) * cos_theta)
 
         return self.variance * (1. / np.pi) * self._J(theta) * \
                X_denominator[:, None] ** self.order * \

--- a/testing/test_kerns.py
+++ b/testing/test_kerns.py
@@ -102,6 +102,24 @@ class TestArcCosine(unittest.TestCase):
             self.evalKernelError(D, variance, weight_variances,
                                  bias_variance, order, ARD, X_data)
 
+    def test_nan_in_gradient(self):
+        D = 1
+        N = 4
+
+        rng = np.random.RandomState(23)
+        X_data = rng.rand(N, D)
+        kernel = GPflow.kernels.ArcCosine(D)
+
+        x_free = tf.placeholder('float64')
+        kernel.make_tf_array(x_free)
+        X = tf.placeholder('float64')
+
+        with kernel.tf_mode():
+            gradients = tf.Session().run(tf.gradients(kernel.K(X), X), feed_dict={x_free: kernel.get_free_state(), X: X_data})
+
+        self.assertFalse(np.any(np.isnan(gradients)))
+
+
 class TestPeriodic(unittest.TestCase):
     def evalKernelError(self, D, lengthscale, variance, period, X_data):
         kernel = GPflow.kernels.PeriodicKernel(D, period=period, variance=variance, lengthscales=lengthscale)


### PR DESCRIPTION
This PR accompanies #409.

Adding a jitter to the `tf.acos`-operation fixes the gradient problem, but introduces a new one: Now, the kernel does not pass the correctness-tests anymore. We can make the closness-test more lenient, but I wanted to ask for your opinion: Using a jitter larger than `1e-10` results in the diagonal of `kern.K(X)` not being equal to `1` anymore. Will this be a problem?