### PR TITLE
Avoid recompilation when creating new model instances

### DIFF
--- a/GPflow/gpmc.py
+++ b/GPflow/gpmc.py
@@ -26,7 +26,7 @@ float_type = settings.dtypes.float_type
 
 class GPMC(GPModel):
     def __init__(self, X, Y, kern, likelihood,
-                 mean_function=Zero(), num_latent=None):
+                 mean_function=None, num_latent=None):
         """
         X is a data matrix, size N x D
         Y is a data matrix, size N x R
@@ -46,6 +46,7 @@ class GPMC(GPModel):
         """
         X = DataHolder(X, on_shape_change='recompile')
         Y = DataHolder(Y, on_shape_change='recompile')
+        mean_function = mean_function or Zero()
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function)
         self.num_data = X.shape[0]
         self.num_latent = num_latent or Y.shape[1]

--- a/GPflow/gpmc.py
+++ b/GPflow/gpmc.py
@@ -46,7 +46,6 @@ class GPMC(GPModel):
         """
         X = DataHolder(X, on_shape_change='recompile')
         Y = DataHolder(Y, on_shape_change='recompile')
-        mean_function = mean_function or Zero()
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function)
         self.num_data = X.shape[0]
         self.num_latent = num_latent or Y.shape[1]

--- a/GPflow/gpr.py
+++ b/GPflow/gpr.py
@@ -37,7 +37,7 @@ class GPR(GPModel):
 
        \\log p(\\mathbf y \\,|\\, \\mathbf f) = \\mathcal N\\left(\\mathbf y\,|\, 0, \\mathbf K + \\sigma_n \\mathbf I\\right)
     """
-    def __init__(self, X, Y, kern, mean_function=Zero(), name='name'):
+    def __init__(self, X, Y, kern, mean_function=None, name='name'):
         """
         X is a data matrix, size N x D
         Y is a data matrix, size N x R
@@ -46,6 +46,7 @@ class GPR(GPModel):
         likelihood = likelihoods.Gaussian()
         X = DataHolder(X, on_shape_change='pass')
         Y = DataHolder(Y, on_shape_change='pass')
+        mean_function = mean_function or Zero()
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function, name)
         self.num_latent = Y.shape[1]
 

--- a/GPflow/gpr.py
+++ b/GPflow/gpr.py
@@ -46,7 +46,6 @@ class GPR(GPModel):
         likelihood = likelihoods.Gaussian()
         X = DataHolder(X, on_shape_change='pass')
         Y = DataHolder(Y, on_shape_change='pass')
-        mean_function = mean_function or Zero()
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function, name)
         self.num_latent = Y.shape[1]
 

--- a/GPflow/model.py
+++ b/GPflow/model.py
@@ -15,6 +15,7 @@
 
 from __future__ import print_function, absolute_import
 from .param import Parameterized, AutoFlow, DataHolder
+from .mean_functions import Zero
 from scipy.optimize import minimize, OptimizeResult
 import numpy as np
 import tensorflow as tf
@@ -350,8 +351,8 @@ class GPModel(Model):
 
     def __init__(self, X, Y, kern, likelihood, mean_function, name='model'):
         Model.__init__(self, name)
-        self.kern, self.likelihood, self.mean_function = \
-            kern, likelihood, mean_function
+        self.mean_function = mean_function or Zero()
+        self.kern, self.likelihood = kern, likelihood
 
         if isinstance(X, np.ndarray):
             #: X is a data matrix; each row represents one instance

--- a/GPflow/sgpmc.py
+++ b/GPflow/sgpmc.py
@@ -65,7 +65,6 @@ class SGPMC(GPModel):
         """
         X = DataHolder(X, on_shape_change='pass')
         Y = DataHolder(Y, on_shape_change='pass')
-        mean_function = mean_function or Zero()
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function)
         self.num_data = X.shape[0]
         self.num_inducing = Z.shape[0]

--- a/GPflow/sgpmc.py
+++ b/GPflow/sgpmc.py
@@ -55,7 +55,7 @@ class SGPMC(GPModel):
 
     """
     def __init__(self, X, Y, kern, likelihood, Z,
-                 mean_function=Zero(), num_latent=None):
+                 mean_function=None, num_latent=None):
         """
         X is a data matrix, size N x D
         Y is a data matrix, size N x R
@@ -65,6 +65,7 @@ class SGPMC(GPModel):
         """
         X = DataHolder(X, on_shape_change='pass')
         Y = DataHolder(Y, on_shape_change='pass')
+        mean_function = mean_function or Zero()
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function)
         self.num_data = X.shape[0]
         self.num_inducing = Z.shape[0]

--- a/GPflow/sgpr.py
+++ b/GPflow/sgpr.py
@@ -56,7 +56,6 @@ class SGPR(GPModel):
         X = DataHolder(X, on_shape_change='pass')
         Y = DataHolder(Y, on_shape_change='pass')
         likelihood = likelihoods.Gaussian()
-        mean_function = mean_function or Zero()
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function)
         self.Z = Param(Z)
         self.num_data = X.shape[0]

--- a/GPflow/sgpr.py
+++ b/GPflow/sgpr.py
@@ -44,7 +44,7 @@ class SGPR(GPModel):
 
     """
 
-    def __init__(self, X, Y, kern, Z, mean_function=Zero()):
+    def __init__(self, X, Y, kern, Z, mean_function=None):
         """
         X is a data matrix, size N x D
         Y is a data matrix, size N x R
@@ -56,6 +56,7 @@ class SGPR(GPModel):
         X = DataHolder(X, on_shape_change='pass')
         Y = DataHolder(Y, on_shape_change='pass')
         likelihood = likelihoods.Gaussian()
+        mean_function = mean_function or Zero()
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function)
         self.Z = Param(Z)
         self.num_data = X.shape[0]

--- a/GPflow/svgp.py
+++ b/GPflow/svgp.py
@@ -60,7 +60,6 @@ class SVGP(GPModel):
         self.num_data = X.shape[0]
         X = MinibatchData(X, minibatch_size, np.random.RandomState(0))
         Y = MinibatchData(Y, minibatch_size, np.random.RandomState(0))
-        mean_function = mean_function or Zero()
 
         # init the super class, accept args
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function)

--- a/GPflow/svgp.py
+++ b/GPflow/svgp.py
@@ -40,7 +40,7 @@ class SVGP(GPModel):
       }
 
     """
-    def __init__(self, X, Y, kern, likelihood, Z, mean_function=Zero(),
+    def __init__(self, X, Y, kern, likelihood, Z, mean_function=None,
                  num_latent=None, q_diag=False, whiten=True, minibatch_size=None):
         """
         - X is a data matrix, size N x D
@@ -60,6 +60,7 @@ class SVGP(GPModel):
         self.num_data = X.shape[0]
         X = MinibatchData(X, minibatch_size, np.random.RandomState(0))
         Y = MinibatchData(Y, minibatch_size, np.random.RandomState(0))
+        mean_function = mean_function or Zero()
 
         # init the super class, accept args
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function)

--- a/GPflow/vgp.py
+++ b/GPflow/vgp.py
@@ -44,7 +44,7 @@ class VGP(GPModel):
 
     """
     def __init__(self, X, Y, kern, likelihood,
-                 mean_function=Zero(), num_latent=None):
+                 mean_function=None, num_latent=None):
         """
         X is a data matrix, size N x D
         Y is a data matrix, size N x R
@@ -54,6 +54,7 @@ class VGP(GPModel):
 
         X = DataHolder(X, on_shape_change='recompile')
         Y = DataHolder(Y, on_shape_change='recompile')
+        mean_function = mean_function or Zero()
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function)
         self.num_data = X.shape[0]
         self.num_latent = num_latent or Y.shape[1]

--- a/GPflow/vgp.py
+++ b/GPflow/vgp.py
@@ -54,7 +54,6 @@ class VGP(GPModel):
 
         X = DataHolder(X, on_shape_change='recompile')
         Y = DataHolder(Y, on_shape_change='recompile')
-        mean_function = mean_function or Zero()
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function)
         self.num_data = X.shape[0]
         self.num_latent = num_latent or Y.shape[1]

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -154,5 +154,52 @@ class TestName(unittest.TestCase):
         assert m.name == 'foo'
 
 
+class TestNoRecompileThroughNewModelInstance(unittest.TestCase):
+    """ Regression tests for Bug #454 """
+
+    def setUp(self):
+        self.X = np.random.rand(10, 2)
+        self.Y = np.random.rand(10, 1)
+
+    def test_gpr(self):
+        m1 = GPflow.gpr.GPR(self.X, self.Y, GPflow.kernels.Matern32(2))
+        m1._compile()
+        m2 = GPflow.gpr.GPR(self.X.copy(), self.Y.copy(), GPflow.kernels.Matern32(2))
+        self.assertFalse(m1._needs_recompile)
+
+    def test_sgpr(self):
+        m1 = GPflow.sgpr.SGPR(self.X, self.Y, GPflow.kernels.Matern32(2), Z=self.X)
+        m1._compile()
+        m2 = GPflow.sgpr.SGPR(self.X, self.Y, GPflow.kernels.Matern32(2), Z=self.X)
+        self.assertFalse(m1._needs_recompile)
+
+    def test_gpmc(self):
+        m1 = GPflow.gpmc.GPMC(self.X, self.Y, GPflow.kernels.Matern32(2), likelihood=GPflow.likelihoods.StudentT())
+        m1._compile()
+        m2 = GPflow.gpmc.GPMC(self.X, self.Y, GPflow.kernels.Matern32(2), likelihood=GPflow.likelihoods.StudentT())
+        self.assertFalse(m1._needs_recompile)
+
+    def test_sgpmc(self):
+        m1 = GPflow.sgpmc.SGPMC(self.X, self.Y, GPflow.kernels.Matern32(2), likelihood=GPflow.likelihoods.StudentT(),
+                                Z=self.X)
+        m1._compile()
+        m2 = GPflow.sgpmc.SGPMC(self.X, self.Y, GPflow.kernels.Matern32(2), likelihood=GPflow.likelihoods.StudentT(),
+                                Z=self.X)
+        self.assertFalse(m1._needs_recompile)
+
+    def test_svgp(self):
+        m1 = GPflow.svgp.SVGP(self.X, self.Y, GPflow.kernels.Matern32(2), likelihood=GPflow.likelihoods.StudentT(),
+                              Z=self.X)
+        m1._compile()
+        m2 = GPflow.svgp.SVGP(self.X, self.Y, GPflow.kernels.Matern32(2), likelihood=GPflow.likelihoods.StudentT(),
+                              Z=self.X)
+        self.assertFalse(m1._needs_recompile)
+
+    def test_vgp(self):
+        m1 = GPflow.vgp.VGP(self.X, self.Y, GPflow.kernels.Matern32(2), likelihood=GPflow.likelihoods.StudentT())
+        m1._compile()
+        m2 = GPflow.vgp.VGP(self.X, self.Y, GPflow.kernels.Matern32(2), likelihood=GPflow.likelihoods.StudentT())
+        self.assertFalse(m1._needs_recompile)
+
 if __name__ == "__main__":
     unittest.main()

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -31,6 +31,7 @@ class TestOptimize(unittest.TestCase):
 
             def build_likelihood(self):
                 return -tf.reduce_sum(tf.square(self.x))
+
         self.m = Quadratic()
 
     def test_adam(self):
@@ -92,6 +93,7 @@ class KeyboardRaiser:
     """
     This wraps a function and makes it raise a KeyboardInterrupt after some number of calls
     """
+
     def __init__(self, iters_to_raise, f):
         self.iters_to_raise, self.f = iters_to_raise, f
         self.count = 0
@@ -200,6 +202,7 @@ class TestNoRecompileThroughNewModelInstance(unittest.TestCase):
         m1._compile()
         m2 = GPflow.vgp.VGP(self.X, self.Y, GPflow.kernels.Matern32(2), likelihood=GPflow.likelihoods.StudentT())
         self.assertFalse(m1._needs_recompile)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/testing/test_model.py
+++ b/testing/test_model.py
@@ -164,7 +164,7 @@ class TestNoRecompileThroughNewModelInstance(unittest.TestCase):
     def test_gpr(self):
         m1 = GPflow.gpr.GPR(self.X, self.Y, GPflow.kernels.Matern32(2))
         m1._compile()
-        m2 = GPflow.gpr.GPR(self.X.copy(), self.Y.copy(), GPflow.kernels.Matern32(2))
+        m2 = GPflow.gpr.GPR(self.X, self.Y, GPflow.kernels.Matern32(2))
         self.assertFalse(m1._needs_recompile)
 
     def test_sgpr(self):


### PR DESCRIPTION
As reported in #454 , the Zero mean function as default argument in the constructor of the 6 models results in recompilations when new model instances are created. This should solve this, also added a regression test. 