### PR TITLE
Fix GPLVM for GPU/float32

### DIFF
--- a/GPflow/gplvm.py
+++ b/GPflow/gplvm.py
@@ -10,7 +10,7 @@ from . import kernels
 from ._settings import settings
 
 float_type = settings.dtypes.float_type
-
+np_float_type = np.float32 if float_type is tf.float32 else np.float64
 
 def PCA_reduce(X, Q):
     """
@@ -97,15 +97,16 @@ class BayesianGPLVM(GPModel):
         # deal with parameters for the prior mean variance of X
         if X_prior_mean is None:
             X_prior_mean = np.zeros((self.num_data, self.num_latent))
-        self.X_prior_mean = X_prior_mean
         if X_prior_var is None:
             X_prior_var = np.ones((self.num_data, self.num_latent))
-        self.X_prior_var = X_prior_var
 
-        assert X_prior_mean.shape[0] == self.num_data
-        assert X_prior_mean.shape[1] == self.num_latent
-        assert X_prior_var.shape[0] == self.num_data
-        assert X_prior_var.shape[1] == self.num_latent
+        self.X_prior_mean = np.asarray(np.atleast_1d(X_prior_mean), dtype=np_float_type)
+        self.X_prior_var = np.asarray(np.atleast_1d(X_prior_var), dtype=np_float_type)
+
+        assert self.X_prior_mean.shape[0] == self.num_data
+        assert self.X_prior_mean.shape[1] == self.num_latent
+        assert self.X_prior_var.shape[0] == self.num_data
+        assert self.X_prior_var.shape[1] == self.num_latent
 
     def build_likelihood(self):
         """

--- a/GPflow/gplvm.py
+++ b/GPflow/gplvm.py
@@ -117,7 +117,7 @@ class BayesianGPLVM(GPModel):
         psi0 = tf.reduce_sum(self.kern.eKdiag(self.X_mean, self.X_var), 0)
         psi1 = self.kern.eKxz(self.Z, self.X_mean, self.X_var)
         psi2 = tf.reduce_sum(self.kern.eKzxKxz(self.Z, self.X_mean, self.X_var), 0)
-        Kuu = self.kern.K(self.Z) + tf.eye(num_inducing, dtype=float_type) * 1e-6
+        Kuu = self.kern.K(self.Z) + tf.eye(num_inducing, dtype=float_type) * settings.numerics.jitter_level
         L = tf.cholesky(Kuu)
         sigma2 = self.likelihood.variance
         sigma = tf.sqrt(sigma2)
@@ -161,7 +161,7 @@ class BayesianGPLVM(GPModel):
         num_inducing = tf.shape(self.Z)[0]
         psi1 = self.kern.eKxz(self.Z, self.X_mean, self.X_var)
         psi2 = tf.reduce_sum(self.kern.eKzxKxz(self.Z, self.X_mean, self.X_var), 0)
-        Kuu = self.kern.K(self.Z) + tf.eye(num_inducing, dtype=float_type) * 1e-6
+        Kuu = self.kern.K(self.Z) + tf.eye(num_inducing, dtype=float_type) * settings.numerics.jitter_level
         Kus = self.kern.K(self.Z, Xnew)
         sigma2 = self.likelihood.variance
         sigma = tf.sqrt(sigma2)


### PR DESCRIPTION
The GPLVM code was failing when specifying 
float_type = float32
in settings.

Small fix use the correct type as is done in Param.

Testing question: Are we testing the tf.float32 scenario?
