### PR TITLE
fix reshape issue in Param's get_samples_df

### DIFF
--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -204,11 +204,11 @@ class Param(Parentable):
         if self.fixed:
             return pd.Series([self.value for _ in range(samples.shape[0])], name=self.long_name)
         start, _ = self.highest_parent.get_param_index(self)
-        free_state_shape = self.transform.free_state_shape(self.shape)
-        end = start + np.prod(free_state_shape)
+        free_state_size = self.transform.free_state_size(self.shape)
+        end = start + free_state_size
         samples = samples[:, start:end]
-        samples = samples.reshape((samples.shape[0],) + free_state_shape)
-        samples = [self.transform.forward(s) for s in samples]
+        samples = [np.atleast_1d(self.transform.forward(s).reshape(self.shape))
+                   for s in samples]
         return pd.Series(samples, name=self.long_name)
 
     def make_tf_array(self, free_array):

--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -204,12 +204,11 @@ class Param(Parentable):
         if self.fixed:
             return pd.Series([self.value for _ in range(samples.shape[0])], name=self.long_name)
         start, _ = self.highest_parent.get_param_index(self)
-        free_state_size = self.transform.free_state_size(self.shape)
-        end = start + free_state_size
+        free_state_shape = self.transform.free_state_shape(self.shape)
+        end = start + np.prod(free_state_shape)
         samples = samples[:, start:end]
-        if self.size == free_state_size:
-            samples = samples.reshape((samples.shape[0],) + self.shape)
-        samples = [np.atleast_1d(self.transform.forward(s)) for s in samples]
+        samples = samples.reshape((samples.shape[0],) + free_state_shape)
+        samples = [self.transform.forward(s) for s in samples]
         return pd.Series(samples, name=self.long_name)
 
     def make_tf_array(self, free_array):

--- a/GPflow/param.py
+++ b/GPflow/param.py
@@ -204,11 +204,13 @@ class Param(Parentable):
         if self.fixed:
             return pd.Series([self.value for _ in range(samples.shape[0])], name=self.long_name)
         start, _ = self.highest_parent.get_param_index(self)
-        end = start + self.size
+        free_state_size = self.transform.free_state_size(self.shape)
+        end = start + free_state_size
         samples = samples[:, start:end]
-        samples = samples.reshape((samples.shape[0],) + self.shape)
-        samples = np.atleast_1d(self.transform.forward(samples))
-        return pd.Series([v for v in samples], name=self.long_name)
+        if self.size == free_state_size:
+            samples = samples.reshape((samples.shape[0],) + self.shape)
+        samples = [np.atleast_1d(self.transform.forward(s)) for s in samples]
+        return pd.Series(samples, name=self.long_name)
 
     def make_tf_array(self, free_array):
         """

--- a/GPflow/transforms.py
+++ b/GPflow/transforms.py
@@ -54,8 +54,11 @@ class Transform(object):
         """
         raise NotImplementedError
 
+    def free_state_shape(self, variable_shape):
+        return variable_shape
+
     def free_state_size(self, variable_shape):
-        return np.prod(variable_shape)
+        return np.prod(self.free_state_shape(variable_shape))
 
     def __str__(self):
         """
@@ -287,8 +290,8 @@ class DiagMatrix(Transform):
     def __str__(self):
         return 'DiagMatrix'
 
-    def free_state_size(self, variable_shape):
-        return variable_shape[0] * variable_shape[1]
+    def free_state_shape(self, variable_shape):
+        return (variable_shape[0] * variable_shape[1],)
 
 
 class LowerTriangular(Transform):
@@ -367,7 +370,7 @@ class LowerTriangular(Transform):
     def tf_log_jacobian(self, x):
         return tf.zeros((1,), float_type)
 
-    def free_state_size(self, variable_shape):
+    def free_state_shape(self, variable_shape):
         matrix_batch = len(variable_shape) > 2
         if ((not matrix_batch and self.num_matrices != 1) or
                 (matrix_batch and variable_shape[2] != self.num_matrices)):
@@ -375,7 +378,7 @@ class LowerTriangular(Transform):
         if variable_shape[0] != variable_shape[1]:
             raise ValueError("Matrices passed must be square.")
         N = variable_shape[0]
-        return int(0.5 * N * (N + 1)) * (variable_shape[2] if matrix_batch else 1)
+        return (int(0.5 * N * (N + 1)) * (variable_shape[2] if matrix_batch else 1),)
 
     def __str__(self):
         return "LoTri->vec"

--- a/GPflow/transforms.py
+++ b/GPflow/transforms.py
@@ -378,7 +378,8 @@ class LowerTriangular(Transform):
         if variable_shape[0] != variable_shape[1]:
             raise ValueError("Matrices passed must be square.")
         N = variable_shape[0]
-        return (int(0.5 * N * (N + 1)) * (variable_shape[2] if matrix_batch else 1),)
+        free_state_size = int(0.5 * N * (N + 1)) * (variable_shape[2] if matrix_batch else 1)
+        return (free_state_size,)
 
     def __str__(self):
         return "LoTri->vec"

--- a/GPflow/transforms.py
+++ b/GPflow/transforms.py
@@ -54,11 +54,8 @@ class Transform(object):
         """
         raise NotImplementedError
 
-    def free_state_shape(self, variable_shape):
-        return variable_shape
-
     def free_state_size(self, variable_shape):
-        return np.prod(self.free_state_shape(variable_shape))
+        return np.prod(variable_shape)
 
     def __str__(self):
         """
@@ -290,8 +287,8 @@ class DiagMatrix(Transform):
     def __str__(self):
         return 'DiagMatrix'
 
-    def free_state_shape(self, variable_shape):
-        return (variable_shape[0] * variable_shape[1],)
+    def free_state_size(self, variable_shape):
+        return variable_shape[0] * variable_shape[1]
 
 
 class LowerTriangular(Transform):
@@ -370,7 +367,7 @@ class LowerTriangular(Transform):
     def tf_log_jacobian(self, x):
         return tf.zeros((1,), float_type)
 
-    def free_state_shape(self, variable_shape):
+    def free_state_size(self, variable_shape):
         matrix_batch = len(variable_shape) > 2
         if ((not matrix_batch and self.num_matrices != 1) or
                 (matrix_batch and variable_shape[2] != self.num_matrices)):
@@ -378,8 +375,7 @@ class LowerTriangular(Transform):
         if variable_shape[0] != variable_shape[1]:
             raise ValueError("Matrices passed must be square.")
         N = variable_shape[0]
-        free_state_size = int(0.5 * N * (N + 1)) * (variable_shape[2] if matrix_batch else 1)
-        return (free_state_size,)
+        return int(0.5 * N * (N + 1)) * (variable_shape[2] if matrix_batch else 1)
 
     def __str__(self):
         return "LoTri->vec"


### PR DESCRIPTION
**UPDATED**

When a Param's transform reshapes the input tensor (cf. DiagMatrix and LowerTriangular), the Param's self.size and self.shape refer to the "foward" tensor which are not the same as the "backward"/"free" ones.

The problem arises here (param.py - lines 198 onwards):

```python
def get_samples_df(self, samples):
        """
        Given a numpy array where each row is a valid free-state vector, return
        a pandas.DataFrame which contains the parameter name and associated samples
        in the correct form (e.g. with positive constraints applied).
        """
        if self.fixed:
            return pd.Series([self.value for _ in range(samples.shape[0])], name=self.long_name)
        start, _ = self.highest_parent.get_param_index(self)
        end = start + self.size
        samples = samples[:, start:end]
        samples = samples.reshape((samples.shape[0],) + self.shape)
        samples = np.atleast_1d(self.transform.forward(samples))
        return pd.Series([v for v in samples], name=self.long_name)
```

```samples``` are in the "free state" so the reshape can fail.
I suggest we replace the last 5 lines above with:

```python
        free_state_size = self.transform.free_state_size(self.shape)
        end = start + free_state_size
        samples = samples[:, start:end]
        samples = [np.atleast_1d(self.transform.forward(s).reshape(self.shape))
                   for s in samples]
        return pd.Series(samples, name=self.long_name)
```