### PR TITLE
Clarify TF version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GPflow implements modern Gaussian process inference for composable kernels and l
 # Install
 
 ## 1) Install TensorFlow. 
-Please see instructions on the main TensorFlow [webpage](https://www.tensorflow.org/versions/r1.0/get_started/get_started). You will need version 1.0. We find that for most users pip installation is the fastest way to get going.
+Please see instructions on the main TensorFlow [webpage](https://www.tensorflow.org/versions/r1.0/get_started/get_started). You will need at least version 1.0 (we aim to support the latest version). We find that for most users pip installation is the fastest way to get going.
 
 ## 2) install package
 GPflow includes some tensorflow extensions that are compiled when you run setup.py.  For those interested in modifying the source of GPflow, we recommend  


### PR DESCRIPTION
The readme is a bit unclear on the TF version (see #479). The updated one indicates that we support at least tf1.0 and that we aim to support the latest version.