### PR TITLE
Remove TF import in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ GPflow implements modern Gaussian process inference for composable kernels and l
 
 # Install
 
-## 1) Install TensorFlow. 
-Please see instructions on the main TensorFlow [webpage](https://www.tensorflow.org/versions/r1.0/get_started/get_started). You will need at least version 1.0 (we aim to support the latest version). We find that for most users pip installation is the fastest way to get going.
+## 1) Quick install
+GPflow can be installed by cloning the repository and running
+```
+pip install .
+```
+in the root folder. This also installs required dependencies including TensorFlow.
 
-## 2) install package
-GPflow includes some tensorflow extensions that are compiled when you run setup.py.  For those interested in modifying the source of GPflow, we recommend  
+## 2) Alternative method
+A different option to install GPflow requires installation of TensorFlow first. Please see instructions on the main TensorFlow [webpage](https://www.tensorflow.org/versions/r1.0/get_started/get_started). You will need at least version 1.0 (we aim to support the latest version). We find that for most users pip installation is the fastest way to get going. Then, for those interested in modifying the source of GPflow, we recommend  
 ```
 python setup.py develop
 ```

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -8,11 +8,10 @@ The full list of `contributors <http://github.com/GPflow/GPflow/graphs/contribut
 Install
 -------
 
-1. Install TensorFlow. 
-Please see instructions on the main TensorFlow `webpage <https://www.tensorflow.org/versions/r1.0/get_started/get_started>`_. You will need version 1.0. . We find that for many users pip installation is the fastest way to get going.
+GPflow can be installed by cloning the repository and running ``pip install .`` in the root folder. This also installs required dependencies including TensorFlow, and sets everything up.
 
-2. install package
-GPflow is a pure python library for now, so you could just add it to your path (we use ``python setup.py develop``) or try an install ``python setup.py install`` (untested). You can run the tests with ``python setup.py test``.
+A different installation approach requires installation of TensorFlow first. Please see instructions on the main TensorFlow `webpage <https://www.tensorflow.org/versions/r1.0/get_started/get_started>`_. You will need version 1.0 or higher. We find that for many users pip installation is the fastest way to get going.
+As GPflow is a pure python library for now, you could just add it to your path (we use ``python setup.py develop``) or try an install ``python setup.py install`` (untested). You can run the tests with ``python setup.py test``.
 
 Version history is documented `here <https://github.com/GPflow/GPflow/blob/master/RELEASE.md>`_.
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from setuptools import setup
 import re
 import os
 import sys
-import tensorflow as tf
 
 # load version form _version.py
 VERSIONFILE = "GPflow/_version.py"
@@ -32,9 +31,8 @@ setup(name='GPflow',
       package_dir={'GPflow': 'GPflow'},
       py_modules=['GPflow.__init__'],
       test_suite='testing',
-      install_requires=['numpy>=1.9', 'scipy>=0.16'],
-      extras_require={'tensorflow': ['tensorflow>=1.0.0'],
-                      'tensorflow with gpu': ['tensorflow-gpu>=1.0.0'],
+      install_requires=['numpy>=1.9', 'scipy>=0.16', 'tensorflow>=1.0.0'],
+      extras_require={'tensorflow with gpu': ['tensorflow-gpu>=1.0.0'],
                       'Export parameters as pandas dataframes': ['pandas>=0.18.1']},
       classifiers=['License :: OSI Approved :: Apache Software License',
                    'Natural Language :: English',

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup
 import re
 import os
 import sys
+from pkg_resources import parse_version
 
 # load version form _version.py
 VERSIONFILE = "GPflow/_version.py"
@@ -15,6 +16,23 @@ if mo:
     verstr = mo.group(1)
 else:
     raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
+
+# Dependencies of GPflow
+dependencies = ['numpy>=1.9', 'scipy>=0.16']
+min_tf_version = '1.0.0'
+
+# Only detect TF if not installed or outdated. If not, do not do not list as 
+# requirement to avoid installing over e.g. tensorflow-gpu
+# To avoid this, rely on importing rather than the package name (like pip). 
+try:
+    # If tf not installed, import raises ImportError
+    import tensorflow as tf
+    if parse_version(tf.__version__) < parse_version(min_tf_version):
+        # TF pre-installed, but below the minimum required version
+        raise DeprecationWarning("TensorFlow version below minimum requirement")
+except (ImportError, DeprecationWarning) as e:
+    # Add TensorFlow to dependencies to trigger installation/update
+    dependencies.append('tensorflow>={0}'.format(min_tf_version))
 
 setup(name='GPflow',
       version=verstr,
@@ -31,7 +49,7 @@ setup(name='GPflow',
       package_dir={'GPflow': 'GPflow'},
       py_modules=['GPflow.__init__'],
       test_suite='testing',
-      install_requires=['numpy>=1.9', 'scipy>=0.16', 'tensorflow>=1.0.0'],
+      install_requires=dependencies,
       extras_require={'tensorflow with gpu': ['tensorflow-gpu>=1.0.0'],
                       'Export parameters as pandas dataframes': ['pandas>=0.18.1']},
       classifiers=['License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
Following #487 , removal of the TF import in setup.py. This allows single-command installation in clean environments, without first installing TF. I also updated the installation instructions in the documentation and readme.