### PR TITLE
Fix combined (sliced) kernel input_dim 

### DIFF
--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -718,10 +718,18 @@ class Combination(Kern):
         for k in kern_list:
             assert isinstance(k, Kern), "can only add Kern instances"
 
-        input_dim = np.max([k.input_dim
-                            if type(k.active_dims) is slice else
-                            np.max(k.active_dims) + 1
-                            for k in kern_list])
+        def _max_input_dim(k):
+            if type(k.active_dims) is slice:
+                if k.active_dims.stop is not None:
+                    d = k.active_dims.stop
+                else:
+                    step = k.active_dims.step or 1
+                    d = k.active_dims.start + step * (k.input_dims - 1)
+            else:
+                d = np.max(k.active_dims) + 1
+            return d
+
+        input_dim = np.max([_max_input_dim(k) for k in kern_list])
         Kern.__init__(self, input_dim=input_dim)
 
         # add kernels to a list, flattening out instances of this class therein

--- a/testing/test_kerns.py
+++ b/testing/test_kerns.py
@@ -282,7 +282,7 @@ class TestKernDiags(GPflowTestCase):
 class TestAdd(GPflowTestCase):
     """
     add a rbf and linear kernel, make sure the result is the same as adding
-    the result of the kernels separaetely
+    the result of the kernels separately
     """
 
     def setUp(self):
@@ -319,6 +319,17 @@ class TestAdd(GPflowTestCase):
                         k.K(X),
                         feed_dict={x_free: k.get_free_state(), X: X_data, Z: Z_data})
             self.assertTrue(np.allclose(self.rbf._K + self.lin._K, self.k._K))
+
+
+class TestCombinedSliced(GPflowTestCase):
+    """ Ensure dimensions of combined kernels are correct."""
+    def test_dims(self):
+        """ Separate kernels for feature indexes [0] and [1, 2]"""
+        rbf = gpflow.kernels.RBF(1, active_dims=[0])
+        lin = gpflow.kernels.Linear(2, active_dims=slice(1, 3))
+        kern = rbf + lin
+        self.assertTrue(kern.input_dim == 3)
+        self.assertTrue(kern.active_dims == slice(3))
 
 
 class TestWhite(GPflowTestCase):


### PR DESCRIPTION
Fix for a small bug where the input_dim of a combined kernel is incorrectly calculated if one one of the kernels active_dims was specified as a slice.