### PR TITLE
Enabled nested AutoFlow types

### DIFF
--- a/gpflow/core/autoflow.py
+++ b/gpflow/core/autoflow.py
@@ -14,6 +14,9 @@
 
 
 from gpflow.misc import get_attribute
+from gpflow import settings
+import tensorflow as tf
+from tensorflow.python.util import nest
 
 
 class AutoFlow:
@@ -41,3 +44,42 @@ class AutoFlow:
             keys = [attr for attr in obj.__dict__ if attr.startswith(prefix)]
             for key in keys:
                 delattr(obj, key)
+
+
+class TensorType:
+    """
+    Represents the type of a tensor, that is, its data type and shape. Its
+    purpose is to create `tf.placeholder`s for `AutoFlow`. Can contain
+    additional arguments to pass to the creation of the placeholder.
+
+    It is necessary to stop `tf.python.utils.nest.flatten` from destructuring
+    the information about placeholder types.
+    """
+    def __init__(self, dtype, shape=None, dims=None, **kwargs):
+        """
+        Can specify shape of tensor either by an integer giving the number
+        of dimensions, using `dims`, or a list, using `shape`.
+
+        `dtype` can be a TensorFlow type, or the `float` class. If it is
+        `float`, then the data type is `gpflow.settings.tf_float`.
+        """
+        if dtype is float:
+            dtype = settings.tf_float
+
+        if shape is None:
+            if dims is not None:
+                shape = [None]*dims
+        else:
+            assert dims is None, ("It is redundant to specify both shape and "
+                                  "number of dimensions.")
+        self._args = (dtype, shape)
+        self._kwargs = kwargs
+
+    def placeholder(self):
+        return tf.placeholder(*self._args, **self._kwargs)
+
+    @staticmethod
+    def make_structure(structure):
+        types = nest.flatten(structure)
+        phs = [tt.placeholder() for tt in types]
+        return nest.pack_sequence_as(structure, phs)

--- a/gpflow/decors.py
+++ b/gpflow/decors.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 from .core.base import GPflowError
 from .core.base import Build
 from .core.node import Node
-from .core.autoflow import AutoFlow
+from .core.autoflow import AutoFlow, TensorType
 from .core.tensor_converter import TensorConverter
 
 from .params import Parameterized
@@ -100,7 +100,7 @@ def _params_as_tensors_exit(obj, previous):
 
 
 def _setup_storage(store, *args, **_kwargs):
-    store['arguments'] = [tf.placeholder(*arg) for arg in args]
+    store['arguments'] = TensorType.make_structure(args)
 
 
 def _name_scope_name(obj, name):

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -24,6 +24,7 @@ from gpflow import transforms
 
 from gpflow.params import Parameter, Parameterized
 from gpflow.decors import params_as_tensors, autoflow
+from gpflow.core.autoflow import TensorType
 from gpflow.quadrature import mvnquad
 
 from gpflow import settings
@@ -63,37 +64,34 @@ class Kern(Parameterized):
 
         self.num_gauss_hermite_points = 20
 
-    @autoflow((settings.tf_float, [None, None]),
-              (settings.tf_float, [None, None]))
+    @autoflow(TensorType(float, dims=2), TensorType(float, dims=2))
     def compute_K(self, X, Z):
         return self.K(X, Z)
 
-    @autoflow((settings.tf_float, [None, None]))
+    @autoflow(TensorType(float, dims=2))
     def compute_K_symm(self, X):
         return self.K(X)
 
-    @autoflow((settings.tf_float, [None, None]))
+    @autoflow(TensorType(float, dims=2))
     def compute_Kdiag(self, X):
         return self.Kdiag(X)
 
-    @autoflow((settings.tf_float, [None, None]),
-              (settings.tf_float,))
+    @autoflow(TensorType(float, dims=2), TensorType(float))
     def compute_eKdiag(self, X, Xcov=None):
         return self.eKdiag(X, Xcov)
 
-    @autoflow((settings.tf_float, [None, None]),
-              (settings.tf_float, [None, None]),
-              (settings.tf_float,))
+    @autoflow(TensorType(float, dims=2), TensorType(float, dims=2),
+              TensorType(float))
     def compute_eKxz(self, Z, Xmu, Xcov):
         return self.eKxz(Z, Xmu, Xcov)
 
-    @autoflow((settings.tf_float, [None, None]),
-              (settings.tf_float, [None, None]),
-              (settings.tf_float, [None, None, None, None]))
+    @autoflow(TensorType(float, dims=2), TensorType(float, dims=2),
+              TensorType(float, dims=4))
     def compute_exKxz(self, Z, Xmu, Xcov):
         return self.exKxz(Z, Xmu, Xcov)
 
-    @autoflow((settings.tf_float, [None, None]), (settings.tf_float, [None, None]), (settings.tf_float,))
+    @autoflow(TensorType(float, dims=2), TensorType(float, dims=2),
+              TensorType(float))
     def compute_eKzxKxz(self, Z, Xmu, Xcov):
         return self.eKzxKxz(Z, Xmu, Xcov)
 

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -22,6 +22,7 @@ import tensorflow as tf
 from gpflow import settings
 from gpflow.params import Parameterized, DataHolder
 from gpflow.decors import autoflow
+from gpflow.core.autoflow import TensorType
 from gpflow.mean_functions import Zero
 from gpflow.core.base import Build
 
@@ -140,7 +141,7 @@ class GPModel(Model):
             Y = DataHolder(Y)
         self.X, self.Y = X, Y
 
-    @autoflow((settings.tf_float, [None, None]))
+    @autoflow(TensorType(float, dims=2))
     def predict_f(self, Xnew):
         """
         Compute the mean and variance of the latent function(s) at the points
@@ -148,7 +149,7 @@ class GPModel(Model):
         """
         return self._build_predict(Xnew)
 
-    @autoflow((settings.tf_float, [None, None]))
+    @autoflow(TensorType(float, dims=2))
     def predict_f_full_cov(self, Xnew):
         """
         Compute the mean and covariance matrix of the latent function(s) at the
@@ -156,7 +157,7 @@ class GPModel(Model):
         """
         return self._build_predict(Xnew, full_cov=True)
 
-    @autoflow((settings.tf_float, [None, None]), (tf.int32, []))
+    @autoflow(TensorType(float, dims=2), TensorType(tf.int32, dims=0))
     def predict_f_samples(self, Xnew, num_samples):
         """
         Produce samples from the posterior latent function(s) at the points
@@ -172,7 +173,7 @@ class GPModel(Model):
             samples.append(mu[:, i:i + 1] + tf.matmul(L, V))
         return tf.transpose(tf.stack(samples))
 
-    @autoflow((settings.tf_float, [None, None]))
+    @autoflow(TensorType(float, dims=2))
     def predict_y(self, Xnew):
         """
         Compute the mean and variance of held-out data at the points Xnew
@@ -180,7 +181,7 @@ class GPModel(Model):
         pred_f_mean, pred_f_var = self._build_predict(Xnew)
         return self.likelihood.predict_mean_and_var(pred_f_mean, pred_f_var)
 
-    @autoflow((settings.tf_float, [None, None]), (settings.tf_float, [None, None]))
+    @autoflow(TensorType(float, dims=2), TensorType(float, dims=2))
     def predict_density(self, Xnew, Ynew):
         """
         Compute the (log) density of the data Ynew at the points Xnew


### PR DESCRIPTION
The type descriptions of AutoFlow inputs now can be any nested structure
that is accepted by `tensorflow.python.util.nest`.

This is perhaps an unwanted feature; it breaks the existing uses of AutoFlow and needs one extra class. On the other hand, if you really want a namedtuple input to your functions, it works wonderfully: the TensorType class is there solely to break the nesting at the desired depth.