### PR TITLE
Explicit checking of None in set_parent

### DIFF
--- a/gpflow/core/node.py
+++ b/gpflow/core/node.py
@@ -112,7 +112,7 @@ class Node(Parentable, ICompilable):
     def set_parent(self, parent=None):
         if parent is self:
             raise ValueError('Self references are prohibited.')
-        if parent and not isinstance(parent, Parentable):
+        if parent is not None and not isinstance(parent, Parentable):
             raise ValueError('Parent object must implement parentable interface.')
         self._parent = parent if parent is not None else None
 


### PR DESCRIPTION
If `parent` (L115) has `__len__()` defined, this will be called in the `if` statement. This is not the intended check.

I think in this instance it's better to be explicit, as we do really want to check for `None`. Some objects may have a `__len__()` method defined. In my case, this relies on parameters which are set in the constructor, which are not initialised at the time that `if parent` is run.