### PR TITLE
Increase test coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ before_install:
   # - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 
 install:
-#  - sudo apt-get install -qq g++-5
-#  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 90
   - pip install numpy scipy pandas pytest nbformat nbconvert jupyter_client jupyter matplotlib pytest-xdist pytest-cov codecov
   - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.0-cp36-cp36m-linux_x86_64.whl
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ python:
 
 before_install:
   - sudo apt-get update -qq
-  # - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 
 install:
   - pip install numpy scipy pandas pytest nbformat nbconvert jupyter_client jupyter matplotlib pytest-xdist pytest-cov codecov
   - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.0-cp36-cp36m-linux_x86_64.whl
-  - pip install codecov
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,13 @@ python:
   - 3.6
 
 before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
+  # - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 
 install:
-  - sudo apt-get install -qq g++-5
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 90
-
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
-
-  # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=3.6 numpy scipy pandas pytest nbformat nbconvert jupyter_client jupyter matplotlib pytest-xdist pytest-cov
-  - source activate test-environment
+#  - sudo apt-get install -qq g++-5
+#  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 90
+  - pip install numpy scipy pandas pytest nbformat nbconvert jupyter_client jupyter matplotlib pytest-xdist pytest-cov codecov
   - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.0-cp36-cp36m-linux_x86_64.whl
   - pip install codecov
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,15 @@ dist: trusty
 language: python
 python:
   - 3.6
+
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
+
 install:
-  - sudo apt-get update
+  - sudo apt-get install -qq g++-5
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 90
+
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
@@ -17,9 +24,17 @@ install:
   # Replace dep1 dep2 ... with your dependencies
   - conda create -q -n test-environment python=3.6 numpy scipy pandas pytest nbformat nbconvert jupyter_client jupyter matplotlib pytest-xdist pytest-cov
   - source activate test-environment
-  - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.3.0-cp36-cp36m-linux_x86_64.whl
+  - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.0-cp36-cp36m-linux_x86_64.whl
   - pip install codecov
   - python setup.py install
+
 script:
   - pytest --cov=./ -d --tx 3*popen//python=python3.6 --pyargs tests
   - codecov --token=2ae2a756-f39c-467c-bd9c-4bdb3dc439c8
+
+cache:
+  apt: true
+  pip: true
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/download

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,11 @@ coverage:
   status:
     project:
       default:
-        target: 90%
+        target: 97%
         threshold: 1%
     patch:
       default:
-        target: 90%
+        target: 97%
         threshold: 1%
 
 ignore:

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,3 +12,4 @@ coverage:
 ignore:
   - "*.py"
   - "tests/*.py"
+  - "gpflow/training/external_optimizer.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,3 +11,4 @@ coverage:
 
 ignore:
   - "*.py"
+  - "tests/*.py"

--- a/gpflow/misc.py
+++ b/gpflow/misc.py
@@ -84,13 +84,14 @@ def initialize_variables(variables=None, session=None, force=False, **run_kwargs
             uninitialized = tf.report_uninitialized_variables(var_list=variables)
             def uninitialized_names():
                 for uv in session.run(uninitialized):
-                    if isinstance(uv, bytes):
-                        yield uv.decode('utf-8')
-                    elif isinstance(uv, str):
-                        yield uv
-                    else:
-                        msg = 'Unknown output type "{}" from `tf.report_uninitialized_variables`'
-                        raise ValueError(msg.format(type(uv)))
+                    yield uv.decode('utf-8')
+                    # if isinstance(uv, bytes):
+                    #     yield uv.decode('utf-8')
+                    # elif isinstance(uv, str):
+                    #     yield uv
+                    # else:
+                    #     msg = 'Unknown output type "{}" from `tf.report_uninitialized_variables`'
+                    #     raise ValueError(msg.format(type(uv)))
             names = set(uninitialized_names())
             vars_for_init = [v for v in variables if v.name.split(':')[0] in names]
             initializer = tf.variables_initializer(vars_for_init)

--- a/gpflow/params/dataholders.py
+++ b/gpflow/params/dataholders.py
@@ -140,6 +140,14 @@ class Minibatch(DataHolder):
         self._seed = seed
 
     @property
+    def batch_size(self):
+        return self._batch_size
+
+    @batch_size.setter
+    def batch_size(self, value):
+        return self.set_batch_size(value)
+
+    @property
     def initializables(self):
         return [self._iterator_tensor]
 
@@ -164,7 +172,7 @@ class Minibatch(DataHolder):
         self._batch_size = size
         session = self.enquire_session(session)
         if session is not None:
-            self.initialize(session=session)
+            self.initialize(session=session, force=True)
 
     def _clear(self):
         self._reset_name()

--- a/gpflow/params/dataholders.py
+++ b/gpflow/params/dataholders.py
@@ -17,9 +17,6 @@
 # limitations under the License.
 
 
-from __future__ import absolute_import
-from pkg_resources import parse_version
-
 import tensorflow as tf
 
 from .. import misc
@@ -196,12 +193,7 @@ class Minibatch(DataHolder):
     def _build_dataholder(self, initial_tensor):
         if initial_tensor is None:
             raise GPflowError("Minibatch state corrupted.")
-        if parse_version(tf.VERSION) < parse_version('1.4.0rc0'):
-            from tensorflow.contrib.data import Dataset
-        else:
-            from tensorflow import data
-            Dataset = data.Dataset
-        data = Dataset.from_tensor_slices(initial_tensor)
+        data = tf.data.Dataset.from_tensor_slices(initial_tensor)
         data = data.repeat()
         if self._shuffle:
             shape = self._value.shape

--- a/gpflow/params/dataholders.py
+++ b/gpflow/params/dataholders.py
@@ -183,22 +183,23 @@ class Minibatch(DataHolder):
         self._seed = None
 
     def _build(self):
-        self._cache_tensor = self._build_placeholder_cache()
-        self._dataholder_tensor = self._build_dataholder()
+        initial_tensor = self._build_placeholder_cache()
+        self._cache_tensor = initial_tensor
+        self._dataholder_tensor = self._build_dataholder(initial_tensor)
 
     def _build_placeholder_cache(self):
         value = self._value
         return tf.placeholder(dtype=value.dtype, shape=value.shape, name='minibatch_init')
 
-    def _build_dataholder(self):
-        if self._cache_tensor is None:
+    def _build_dataholder(self, initial_tensor):
+        if initial_tensor is None:
             raise GPflowError("Minibatch state corrupted.")
         if parse_version(tf.VERSION) < parse_version('1.4.0rc0'):
             from tensorflow.contrib.data import Dataset
         else:
             from tensorflow import data
             Dataset = data.Dataset
-        data = Dataset.from_tensor_slices(self._cache_tensor)
+        data = Dataset.from_tensor_slices(initial_tensor)
         data = data.repeat()
         if self._shuffle:
             shape = self._value.shape

--- a/gpflow/params/dataholders.py
+++ b/gpflow/params/dataholders.py
@@ -60,13 +60,7 @@ class DataHolder(Parameter):
     def parameter_tensor(self):
         return self._dataholder_tensor
 
-    @property
-    def shape(self):
-        # if self.parameter_tensor is not None:
-        #     return tuple(self.parameter_tensor.shape.as_list())
-        return self._value.shape
-
-    def set_trainable(self, _value, graph=None):
+    def set_trainable(self, value, graph=None):
         raise NotImplementedError('Data holder cannot be fixed.')
 
     def is_built(self, graph):

--- a/gpflow/params/dataholders.py
+++ b/gpflow/params/dataholders.py
@@ -156,6 +156,16 @@ class Minibatch(DataHolder):
         return {self._cache_tensor: self._value,
                 self._batch_size_tensor: self._batch_size}
 
+    @property
+    def seed(self):
+        return self._seed
+
+    @seed.setter
+    def seed(self, seed):
+        if self.graph is not None and self.is_built_coherence():
+            raise GPflowError('Minibatch seed cannot be changed when it is built.')
+        self._seed = seed
+
     def set_batch_size(self, size, session=None):
         self._batch_size = size
         session = self.enquire_session(session)

--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -224,8 +224,8 @@ class Parameter(Node):
             self.assign(value, session=session)
 
     def is_built(self, graph):
-        if graph is None:
-            raise ValueError('Graph is not specified.')
+        if not isinstance(graph, tf.Graph):
+            raise ValueError('TensorFlow graph expected for build status testing.')
         if self.graph and self.graph is not graph:
             return Build.NOT_COMPATIBLE_GRAPH
         elif self.prior_tensor is None:

--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -146,14 +146,14 @@ class Parameter(Node):
     @property
     def shape(self):
         if self._externally_defined:
-            return self.parameter_tensor.shape.as_numpy_dtype
+            return tuple(self.parameter_tensor.shape.as_list())
         return self._value.shape
 
     @property
     def dtype(self):
-        if self.parameter_tensor is None:
-            return self._value.dtype
-        return np.dtype(self.parameter_tensor.dtype.as_numpy_dtype)
+        if self._externally_defined:
+            return self.parameter_tensor.dtype.as_numpy_dtype
+        return self._value.dtype
 
     @property
     def size(self):

--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -392,6 +392,7 @@ class Parameter(Node):
             if is_trainable != self.trainable:
                 status = 'trainable' if is_trainable else 'not trainable'
                 raise ValueError('Externally defined tensor is {0}.'.format(status))
+            self._fixed_shape = True
             self._externally_defined = True
             self._set_parameter_tensor(value)
         else:

--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -217,8 +217,8 @@ class Parameter(Node):
         self._fixed_shape = True
 
     def anchor(self, session):
-        if session is None:
-            ValueError('Session is required when anchoring.')
+        if not isinstance(session, tf.Session):
+            ValueError('TensorFlow Session expected when anchoring.')
         if self.trainable:
             value = self.read_value(session=session)
             self.assign(value, session=session)
@@ -234,7 +234,7 @@ class Parameter(Node):
 
     def set_trainable(self, value):
         if not isinstance(value, bool):
-            raise TypeError('Fixed property value must be boolean.')
+            raise ValueError('Fixed property value must be boolean.')
 
         if self._externally_defined:
             raise GPflowError('Externally defined parameter tensor is not modifiable.')
@@ -266,7 +266,9 @@ class Parameter(Node):
             self.initialize(session=session, force=force)
 
     def read_value(self, session=None):
-        if session:
+        if session is not None:
+            if not isinstance(session, tf.Session):
+                raise ValueError('TensorFlow session expected as session argument.')
             is_built = self.is_built_coherence(session.graph)
             if is_built is Build.YES:
                 return self._read_parameter_tensor(session)
@@ -474,10 +476,10 @@ class Parameter(Node):
 
     def __setattr__(self, name, value):
         try:
-            attr = self.ParameterAttribute(name)
+            attr = self.ParameterAttribute[name.upper()]
             self._set_parameter_attribute(attr, value)
             return
-        except ValueError:
+        except KeyError:
             pass
         object.__setattr__(self, name, value)
 

--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -17,8 +17,6 @@
 # limitations under the License.
 
 
-from __future__ import absolute_import
-
 import enum
 import numpy as np
 import tensorflow as tf

--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -146,6 +146,8 @@ class Parameter(Node):
 
     @property
     def shape(self):
+        if self._externally_defined:
+            return self.parameter_tensor.shape.as_numpy_dtype
         return self._value.shape
 
     @property

--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -130,7 +130,6 @@ class Parameter(Node):
                 return IPrior
             elif self.value == self.TRANSFORM.value:
                 return ITransform
-            return None
 
     def __init__(self, value, transform=None, prior=None,
                  trainable=True, dtype=None, fix_shape=True,

--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -233,20 +233,19 @@ class Parameter(Node):
             return Build.NO
         return Build.YES
 
-    def set_trainable(self, value, graph=None):
+    def set_trainable(self, value):
         if not isinstance(value, bool):
             raise TypeError('Fixed property value must be boolean.')
 
         if self._externally_defined:
             raise GPflowError('Externally defined parameter tensor is not modifiable.')
 
-        graph = self.enquire_graph(graph)
-        is_built = self.is_built_coherence(graph)
-
-        if is_built is Build.YES:
+        graph = self.graph
+        if graph is not None:
             if self.trainable == value:
                 return
-            elif value:
+
+            if value:
                 misc.add_to_trainables(self.parameter_tensor, graph)
             else:
                 misc.remove_from_trainables(self.parameter_tensor, graph)
@@ -419,7 +418,7 @@ class Parameter(Node):
 
     def _set_parameter_attribute(self, attr, value):
         if attr is self.ParameterAttribute.TRAINABLE:
-            self.set_trainable(value, graph=self.graph)
+            self.set_trainable(value)
             return
 
         is_built = self.is_built_coherence(self.graph)

--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -34,6 +34,7 @@ from .. import misc
 
 from ..transforms import Identity
 
+EMPTY_FEEDS = {}
 
 class Parameter(Node):
     """
@@ -178,7 +179,7 @@ class Parameter(Node):
 
     @property
     def feeds(self):
-        return None
+        return EMPTY_FEEDS
 
     @property
     def initializables(self):
@@ -189,7 +190,7 @@ class Parameter(Node):
     @property
     def initializable_feeds(self):
         if self._externally_defined:
-            return None
+            return EMPTY_FEEDS
         return {self._initial_value_tensor: self._apply_transform(self._value)}
 
     @property

--- a/gpflow/params/parameterized.py
+++ b/gpflow/params/parameterized.py
@@ -144,8 +144,6 @@ class Parameterized(Node):
             holder_feeds = data_holder.feeds
             if holder_feeds is not None:
                 total_feeds.update(holder_feeds)
-        if not total_feeds:
-            return None
         return total_feeds
 
     @property
@@ -170,8 +168,6 @@ class Parameterized(Node):
         feeds = {}
         get_initializable_feeds(self.parameters, feeds)
         get_initializable_feeds(self.data_holders, feeds)
-        if not feeds:
-            return None
         return feeds
 
     @property

--- a/gpflow/params/parameterized.py
+++ b/gpflow/params/parameterized.py
@@ -240,8 +240,8 @@ class Parameterized(Node):
                 for param in self.parameters}
 
     def is_built(self, graph):
-        if graph is None:
-            raise ValueError('Graph is not specified.')
+        if not isinstance(graph, tf.Graph):
+            raise ValueError('TensorFlow graph expected for checking build status.')
         statuses = set([param.is_built(graph) for param in self.non_empty_params])
         if Build.NOT_COMPATIBLE_GRAPH in statuses:
             return Build.NOT_COMPATIBLE_GRAPH

--- a/gpflow/params/parameterized.py
+++ b/gpflow/params/parameterized.py
@@ -225,8 +225,8 @@ class Parameterized(Node):
                 raise error
 
     def anchor(self, session):
-        if session is None:
-            ValueError('Session is required when anchoring.')
+        if not isinstance(session, tf.Session):
+            raise ValueError('TensorFlow session expected when anchoring.')
         for parameter in self.trainable_parameters:
             value = parameter.read_value(session)
             parameter.assign(value, session=session, force=False)

--- a/gpflow/params/parameterized.py
+++ b/gpflow/params/parameterized.py
@@ -251,9 +251,12 @@ class Parameterized(Node):
             return Build.NO
         return Build.YES
 
-    def set_trainable(self, value, graph=None):
+    def set_trainable(self, value):
+        if not isinstance(value, bool):
+            raise ValueError('Boolean value expected.')
         for param in self.params:
-            param.set_trainable(value, graph=graph)
+            if not isinstance(param, DataHolder):
+                param.set_trainable(value)
 
     @staticmethod
     def _is_param_like(value):
@@ -356,4 +359,3 @@ class Parameterized(Node):
     @fixed.setter
     def fixed(self, _):
         raise NotImplementedError("`fixed` property is no longer supported. Please use `trainable` instead.")
-

--- a/gpflow/params/parameterized.py
+++ b/gpflow/params/parameterized.py
@@ -224,8 +224,7 @@ class Parameterized(Node):
         if not isinstance(session, tf.Session):
             raise ValueError('TensorFlow session expected when anchoring.')
         for parameter in self.trainable_parameters:
-            value = parameter.read_value(session)
-            parameter.assign(value, session=session, force=False)
+            parameter.anchor(session)
 
     def read_trainables(self, session=None):
         return {param.full_name: param.read_value(session)

--- a/gpflow/params/parameterized.py
+++ b/gpflow/params/parameterized.py
@@ -17,8 +17,6 @@
 # limitations under the License.
 
 
-from __future__ import absolute_import
-
 import tensorflow as tf
 import pandas as pd
 

--- a/gpflow/params/paramlist.py
+++ b/gpflow/params/paramlist.py
@@ -17,8 +17,6 @@
 # limitations under the License.
 
 
-from __future__ import absolute_import
-
 from ..core.tensor_converter import TensorConverter
 from ..core.errors import GPflowError
 from ..core.compilable import Build

--- a/gpflow/test_util.py
+++ b/gpflow/test_util.py
@@ -32,7 +32,5 @@ class GPflowTestCase(tf.test.TestCase):
     @contextlib.contextmanager
     def test_context(self, graph=None):
         graph = self.test_graph if graph is None else graph
-        if graph is None:
-            graph = tf.Graph()
         with graph.as_default(), self.test_session(graph=graph) as session:
             yield session

--- a/gpflow/training/tensorflow_optimizer.py
+++ b/gpflow/training/tensorflow_optimizer.py
@@ -27,10 +27,8 @@ class _TensorFlowOptimizer(optimizer.Optimizer):
     def __init__(self, *args, **kwargs):
         name = self.__class__.__name__
         tf_optimizer = _get_registered_optimizer(name)
-        if tf_optimizer is None:
-            raise ValueError('Optimizer not found.')
         self._model = None
-        super(_TensorFlowOptimizer, self).__init__()
+        super().__init__()
         self._optimizer = tf_optimizer(*args, **kwargs)
         self._minimize_operation = None
 
@@ -112,7 +110,10 @@ class _TensorFlowOptimizer(optimizer.Optimizer):
 
 
 def _get_registered_optimizer(name):
-    return _REGISTERED_TENSORFLOW_OPTIMIZERS.get(name)
+    tf_optimizer = _REGISTERED_TENSORFLOW_OPTIMIZERS.get(name, None)
+    if tf_optimizer is None:
+        raise TypeError('Optimizer not found.')
+    return tf_optimizer
 
 
 def _register_optimizer(name, optimizer_type):

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(name='gpflow',
           'Operating System :: MacOS :: MacOS X',
           'Operating System :: Microsoft :: Windows',
           'Operating System :: POSIX :: Linux',
-          'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Topic :: Scientific/Engineering :: Artificial Intelligence'
       ])

--- a/setup.py
+++ b/setup.py
@@ -12,37 +12,38 @@ import sys
 from pkg_resources import parse_version
 
 # load version form _version.py
-VERSIONFILE = "gpflow/_version.py"
-verstrline = open(VERSIONFILE, "rt").read()
-VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
-mo = re.search(VSRE, verstrline, re.M)
-if mo:
-    verstr = mo.group(1)
-else:
-    raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
+exec(open("gpflow/_version.py").read())
 
 # Dependencies of GPflow
-dependencies = ['numpy>=1.10.0', 'scipy>=0.18.0', 'pandas>=0.18.1']
-min_tf_version = '1.3.0'
+requirements = [
+    'numpy>=1.10.0',
+    'scipy>=0.18.0',
+    'pandas>=0.18.1'
+]
+
+min_tf_version = '1.4.0'
+tf_cpu = 'tensorflow>={}'.format(min_tf_version)
+tf_gpu = 'tensorflow-gpu>={}'.format(min_tf_version)
 
 # Only detect TF if not installed or outdated. If not, do not do not list as
 # requirement to avoid installing over e.g. tensorflow-gpu
 # To avoid this, rely on importing rather than the package name (like pip).
+
 try:
     # If tf not installed, import raises ImportError
     import tensorflow as tf
-    if parse_version(tf.__version__) < parse_version(min_tf_version):
+    if parse_version(tf.VERSION) < parse_version(min_tf_version):
         # TF pre-installed, but below the minimum required version
         raise DeprecationWarning("TensorFlow version below minimum requirement")
 except (ImportError, DeprecationWarning) as e:
     # Add TensorFlow to dependencies to trigger installation/update
-    dependencies.append('tensorflow>={0}'.format(min_tf_version))
+    requirements.append(tf_cpu)
 
 packages = find_packages('.')
 package_data={'gpflow': ['gpflow/gpflowrc']}
 
 setup(name='gpflow',
-      version=verstr,
+      version=__version__,
       author="James Hensman, Alex Matthews",
       author_email="james.hensman@gmail.com",
       description=("Gaussian process methods in tensorflow"),
@@ -50,18 +51,19 @@ setup(name='gpflow',
       keywords="machine-learning gaussian-processes kernels tensorflow",
       url="http://github.com/GPflow/GPflow",
       packages=packages,
-      install_requires=dependencies,
+      install_requires=requirements,
       tests_require=['pytest'],
       package_data=package_data,
       include_package_data=True,
       test_suite='tests',
-      extras_require={'Tensorflow with GPU': ['tensorflow-gpu>=1.3.0'],
-                      'Export parameters as pandas dataframes': ['pandas>=0.18.1']},
-      classifiers=['License :: OSI Approved :: Apache Software License',
-                   'Natural Language :: English',
-                   'Operating System :: MacOS :: MacOS X',
-                   'Operating System :: Microsoft :: Windows',
-                   'Operating System :: POSIX :: Linux',
-                   'Programming Language :: Python :: 2.7',
-                   'Programming Language :: Python :: 3.5',
-                   'Topic :: Scientific/Engineering :: Artificial Intelligence'])
+      extras_require={'Tensorflow with GPU': [tf_gpu]},
+      classifiers=[
+          'License :: OSI Approved :: Apache Software License',
+          'Natural Language :: English',
+          'Operating System :: MacOS :: MacOS X',
+          'Operating System :: Microsoft :: Windows',
+          'Operating System :: POSIX :: Linux',
+          'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.5',
+          'Topic :: Scientific/Engineering :: Artificial Intelligence'
+      ])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,34 @@
+# Copyright 2017 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.from __future__ import print_function
+
+import tensorflow as tf
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+import gpflow
+from gpflow.test_util import GPflowTestCase
+
+
+class TestTensorConverter(GPflowTestCase):
+    def test_failures(self):
+        values = ['', 'test', 1., None, object()]
+        for v in values:
+            with self.assertRaises(ValueError, msg='Raises at "{}"'.format(v)):
+                gpflow.core.tensor_converter.TensorConverter.tensor_mode(v)
+
+        p = gpflow.core.parentable.Parentable()
+        p._parent = p
+        with self.assertRaises(gpflow.GPflowError):
+            gpflow.core.tensor_converter.TensorConverter.tensor_mode(p)

--- a/tests/test_dataholders.py
+++ b/tests/test_dataholders.py
@@ -136,19 +136,28 @@ class TestDataholder(GPflowTestCase):
                 p.assign(np.zeros((3, 3)), force=True)
             assert_allclose(p.read_value(), value)
 
+
 class TestMinibatch(GPflowTestCase):
     def test_clean(self):
         with self.test_context() as session:
             length = 10
+            seed = 10
             arr = np.random.randn(length, 2)
             m = gpflow.Minibatch(arr, shuffle=False)
             self.assertEqual(m.is_built_coherence(), gpflow.Build.YES)
             self.assertEqual(m.seed, None)
             with self.assertRaises(gpflow.GPflowError):
-                m.seed = 10
+                m.seed = seed
             self.assertEqual(m.seed, None)
             for i in range(length):
                 assert_allclose(m.read_value(session=session), [arr[i]])
+
+            m.clear()
+            self.assertEqual(m.seed, None)
+            m.seed = seed
+            self.assertEqual(m.seed, seed)
+            self.assertEqual(m.is_built_coherence(), gpflow.Build.NO)
+            self.assertEqual(m.parameter_tensor, None)
 
     def test_seed(self):
         with self.test_context() as session:

--- a/tests/test_dataholders.py
+++ b/tests/test_dataholders.py
@@ -66,12 +66,34 @@ class TestDataholder(GPflowTestCase):
             self.assertTrue(d.fixed_shape)
             self.assertFalse(d.trainable)
 
-            tensor = tf.get_variable('dataholder', shape=(1,))
+            var = tf.get_variable('dataholder', shape=(1,), trainable=False)
+            d = gpflow.DataHolder(var)
+            self.assertAllEqual(d.shape, ())
+            self.assertEqual(d.dtype, np.float64)
+            self.assertTrue(d.fixed_shape)
+            self.assertFalse(d.trainable)
+
+            tensor = tensor + 1
             d = gpflow.DataHolder(tensor)
             self.assertAllEqual(d.shape, ())
             self.assertEqual(d.dtype, np.float64)
             self.assertTrue(d.fixed_shape)
             self.assertFalse(d.trainable)
+
+
+    def test_failed_creation(self):
+        with self.test_context():
+            tensor = tf.get_variable('dataholder', shape=(1,)),
+            values = [
+                tensor,
+                [1, [1, [1]]],
+                None,
+                "test",
+                object(),
+            ]
+            for value in values:
+                with self.assertRaises(ValueError, msg='Value {}'.format(value)):
+                    gpflow.DataHolder(tensor)
 
     def test_fixed_shape(self):
         with self.test_context():

--- a/tests/test_dataholders.py
+++ b/tests/test_dataholders.py
@@ -1,0 +1,107 @@
+# Copyright 2017 the GPflow authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.from __future__ import print_function
+
+import tensorflow as tf
+import numpy as np
+import pandas as pd
+
+import gpflow
+from gpflow import settings
+from gpflow.test_util import GPflowTestCase
+
+from numpy.testing import assert_allclose
+
+
+class TestDataholder(GPflowTestCase):
+    def test_create_dataholder(self):
+        with self.test_context():
+            shape = (10,)
+            d = gpflow.DataHolder(np.ones(shape))
+            self.assertAllEqual(d.shape, shape)
+            self.assertEqual(d.dtype, np.float64)
+            self.assertFalse(d.fixed_shape)
+            self.assertFalse(d.trainable)
+
+            shape = (10,)
+            d = gpflow.DataHolder(np.ones(shape), dtype=gpflow.settings.np_float)
+            self.assertAllEqual(d.shape, shape)
+            self.assertEqual(d.dtype, gpflow.settings.np_float)
+            self.assertFalse(d.fixed_shape)
+            self.assertFalse(d.trainable)
+
+            d = gpflow.DataHolder(1)
+            self.assertAllEqual(d.shape, ())
+            self.assertEqual(d.dtype, np.int32)
+            self.assertFalse(d.fixed_shape)
+            self.assertFalse(d.trainable)
+
+            d = gpflow.DataHolder(1.0)
+            self.assertAllEqual(d.shape, ())
+            self.assertEqual(d.dtype, np.float64)
+            self.assertFalse(d.fixed_shape)
+            self.assertFalse(d.trainable)
+
+            size = 10
+            shape = (size,)
+            d = gpflow.DataHolder([1.] * size)
+            self.assertAllEqual(d.shape, shape)
+            self.assertEqual(d.dtype, np.float64)
+            self.assertFalse(d.fixed_shape)
+            self.assertFalse(d.trainable)
+
+            d = gpflow.DataHolder(1.0, fix_shape=True)
+            self.assertAllEqual(d.shape, ())
+            self.assertEqual(d.dtype, np.float64)
+            self.assertTrue(d.fixed_shape)
+            self.assertFalse(d.trainable)
+
+            tensor = tf.get_variable('dataholder', shape=(1,))
+            d = gpflow.DataHolder(tensor)
+            self.assertAllEqual(d.shape, ())
+            self.assertEqual(d.dtype, np.float64)
+            self.assertTrue(d.fixed_shape)
+            self.assertFalse(d.trainable)
+
+    def test_fixed_shape(self):
+        with self.test_context():
+            p = gpflow.DataHolder(1.)
+            assert_allclose(1., 1.)
+            self.assertFalse(p.fixed_shape)
+            self.assertAllEqual(p.shape, ())
+
+            value = [10., 10.]
+            p.assign(value)
+            assert_allclose(p.read_value(), value)
+            self.assertFalse(p.fixed_shape)
+            self.assertAllEqual(p.shape, (2,))
+
+            p.fix_shape()
+            assert_allclose(p.read_value(), value)
+            self.assertTrue(p.fixed_shape)
+            self.assertAllEqual(p.shape, (2,))
+            p.assign(np.zeros(p.shape))
+
+            value = np.zeros(p.shape)
+
+            with self.assertRaises(ValueError):
+                p.assign([1.], force=True)
+            assert_allclose(p.read_value(), value)
+
+            with self.assertRaises(ValueError):
+                p.assign(1., force=True)
+            assert_allclose(p.read_value(), value)
+
+            with self.assertRaises(ValueError):
+                p.assign(np.zeros((3, 3)), force=True)
+            assert_allclose(p.read_value(), value)

--- a/tests/test_dataholders.py
+++ b/tests/test_dataholders.py
@@ -66,17 +66,17 @@ class TestDataholder(GPflowTestCase):
             self.assertTrue(d.fixed_shape)
             self.assertFalse(d.trainable)
 
-            var = tf.get_variable('dataholder', shape=(1,), trainable=False)
+            var = tf.get_variable('dataholder', shape=(), trainable=False)
             d = gpflow.DataHolder(var)
             self.assertAllEqual(d.shape, ())
-            self.assertEqual(d.dtype, np.float64)
+            self.assertEqual(d.dtype, np.float32)
             self.assertTrue(d.fixed_shape)
             self.assertFalse(d.trainable)
 
             tensor = tensor + 1
             d = gpflow.DataHolder(tensor)
             self.assertAllEqual(d.shape, ())
-            self.assertEqual(d.dtype, np.float64)
+            self.assertEqual(d.dtype, np.float32)
             self.assertTrue(d.fixed_shape)
             self.assertFalse(d.trainable)
 

--- a/tests/test_dataholders.py
+++ b/tests/test_dataholders.py
@@ -73,7 +73,7 @@ class TestDataholder(GPflowTestCase):
             self.assertTrue(d.fixed_shape)
             self.assertFalse(d.trainable)
 
-            tensor = tensor + 1
+            tensor = var + 1
             d = gpflow.DataHolder(tensor)
             self.assertAllEqual(d.shape, ())
             self.assertEqual(d.dtype, np.float32)

--- a/tests/test_dataholders.py
+++ b/tests/test_dataholders.py
@@ -138,7 +138,14 @@ class TestDataholder(GPflowTestCase):
 
 
 class TestMinibatch(GPflowTestCase):
-    def test_clean(self):
+    def test_create(self):
+        with self.test_context():
+            values = [tf.get_variable('test', shape=()), "test", None]
+            for v in values:
+                with self.assertRaises(ValueError):
+                    gpflow.Minibatch(v)
+
+    def test_clear(self):
         with self.test_context() as session:
             length = 10
             seed = 10

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -66,7 +66,7 @@ class TestNotebooks(GPflowTestCase):
 
     # def test_classification(self):
     #     self._exec_notebook_ts("classification.ipynb")
-    
+
     # def test_coreg_demo(self):
     #     self._exec_notebook_ts("coreg_demo.ipynb")
 

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -118,24 +118,24 @@ class OptimizerCase:
                 opt.minimize(demo, session=session, var_list=[var3], maxiter=5,
                              initialize=False, anchor=False)
 
-        def test_optimizer_tensors(self):
-            with self.test_context():
-                if not isinstance(self.optimizer, gpflow.train.ScipyOptimizer):
-                    demo = Demo()
-                    opt = self.optimizer()
-                    opt.minimize(demo, maxiter=0)
-                    self.assertEqual(opt.model, demo)
+    def test_optimizer_tensors(self):
+        with self.test_context():
+            opt = self.optimizer()
+            if not isinstance(opt, gpflow.train.ScipyOptimizer):
+                demo = Demo()
+                opt.minimize(demo, maxiter=0)
+                self.assertEqual(opt.model, demo)
 
-                    opt.model = Demo()
-                    self.assertNotEqual(opt.model, demo)
-                    self.assertEqual(opt.minimize_operation, None)
-                    self.assertEqual(opt.optmizer, None)
+                opt.model = Demo()
+                self.assertNotEqual(opt.model, demo)
+                self.assertEqual(opt.minimize_operation, None)
+                self.assertEqual(opt.optimizer, None)
 
-        def test_non_gpflow_model(self):
-            with self.test_context():
-                opt = self.optimizer()
-                with self.assertRaises(ValueError):
-                    opt.minimize(None)
+    def test_non_gpflow_model(self):
+        with self.test_context():
+            opt = self.optimizer()
+            with self.assertRaises(ValueError):
+                opt.minimize(None)
 
 
     def test_external_variables_in_model(self):

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -67,19 +67,19 @@ class OptimizerCase:
         with self.test_context() as session1:
             gpflow.reset_default_session()
             opt = self.optimizer()
-            opt.minimize(demo, maxiter=10)
+            opt.minimize(demo, maxiter=1)
 
         # Mild initialization requirement: default changed session case.
         with self.test_context() as session2:
             self.assertFalse(session1 == session2)
             gpflow.reset_default_session()
             opt = self.optimizer()
-            opt.minimize(demo, maxiter=10, initialize=False)
+            opt.minimize(demo, maxiter=1, initialize=False)
 
         # Mild initialization requirement: pass session case.
         with self.test_context() as session3:
             opt = self.optimizer()
-            opt.minimize(demo, maxiter=10, session=session3, initialize=False)
+            opt.minimize(demo, maxiter=1, session=session3, initialize=False)
 
     def test_optimizer_with_var_list(self):
         with self.test_context():
@@ -93,11 +93,11 @@ class OptimizerCase:
             opt = self.optimizer()
 
             # No var list variables and empty feed_dict
-            opt.minimize(demo, maxiter=5, initialize=False, anchor=False)
+            opt.minimize(demo, maxiter=1, initialize=False, anchor=False)
 
             # Var list is empty
             with self.assertRaises(ValueError):
-                opt.minimize(Empty(), var_list=[], maxiter=5)
+                opt.minimize(Empty(), var_list=[], maxiter=1)
 
             # Var list variable
             session.run(var1.initializer)
@@ -109,13 +109,13 @@ class OptimizerCase:
 
             # Var list variable is not trainable
             session.run(var2.initializer)
-            opt.minimize(demo, var_list=[var2], maxiter=5, initialize=False)
+            opt.minimize(demo, var_list=[var2], maxiter=1, initialize=False)
 
             # NOTE(@awav): TensorFlow optimizer skips uninitialized values which
             # are not present in objective.
             demo._objective += var3
             with self.assertRaises(tf.errors.FailedPreconditionError):
-                opt.minimize(demo, session=session, var_list=[var3], maxiter=5,
+                opt.minimize(demo, session=session, var_list=[var3], maxiter=1,
                              initialize=False, anchor=False)
 
     def test_optimizer_tensors(self):
@@ -135,7 +135,7 @@ class OptimizerCase:
         with self.test_context():
             opt = self.optimizer()
             with self.assertRaises(ValueError):
-                opt.minimize(None)
+                opt.minimize(None, maxiter=0)
 
 
     def test_external_variables_in_model(self):

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -745,6 +745,23 @@ class TestParamList(GPflowTestCase):
                 # param objects not valid in constructor (must be in list)
                 gpflow.ParamList(gpflow.Param(1))
 
+            with gpflow.defer_build():
+                p = gpflow.ParamList([0.0])
+                p[0] = gpflow.Param(1.0)
+                with self.assertRaises(ValueError):
+                    p[0] = 1.0
+                with self.assertRaises(ValueError):
+                    p[0] = "test"
+
+            p = gpflow.ParamList([])
+            p.append(gpflow.Param(1.0))
+            p.append(gpflow.Param(2.0))
+            with self.assertRaises(ValueError):
+                p.append(2.0)
+            with self.assertRaises(ValueError):
+                p.append("test")
+            self.assertEqual(len(p), 2)
+
     def test_naming(self):
         with self.test_context():
             p1 = gpflow.Param(1.2)

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -128,33 +128,44 @@ class TestParameter(GPflowTestCase):
             val = 10.
             a = gpflow.Param(val)
             assert_allclose(a.read_value(), val)
+            self.assertEqual(a.size, 1)
 
-            val = [10.] * 2
-            b = gpflow.Param([10.] * 2, fix_shape=False)
+            size = 2
+            val = [10.] * size
+            b = gpflow.Param([10.] * size, fix_shape=False)
             assert_allclose(b.read_value(), val)
             self.assertEqual(b.dtype, np.float64)
+            self.assertEqual(b.size, size)
 
-            val = [10] * 3
+            size = 3
+            val = [10] * size
             c = gpflow.Param(val, dtype=np.float16)
             assert_allclose(c.read_value(), val)
             self.assertEqual(c.dtype, np.float16)
+            self.assertEqual(c.size, size)
 
-            val = [10.] * 4
+            size = 4
+            val = [10.] * size
             d = gpflow.Param(val, trainable=False)
             assert_allclose(d.read_value(), val)
             self.assertEqual(d.trainable, False)
+            self.assertEqual(d.size, size)
 
-            val = [10.] * 5
+            size = 5
+            val = [10.] * size
             transform = gpflow.transforms.Log1pe()
             e = gpflow.Param(val, transform=transform)
             assert_allclose(e.read_value(), val)
+            self.assertEqual(e.size, size)
             unconstrained = transform.backward(np.array(val))
             assert_allclose(session.run(e.unconstrained_tensor), unconstrained)
 
-            val = [10.] * 6
+            size = 6
+            val = [10.] * size
             f = gpflow.Param(val, prior=gpflow.priors.Gaussian(1, 2))
             assert_allclose(f.read_value(), val)
             assert_allclose(f.read_value(session), val)
+            self.assertEqual(f.size, size)
             self.assertTrue(isinstance(f.prior, gpflow.priors.Gaussian))
 
     def test_generators(self):
@@ -292,14 +303,17 @@ class TestParameter(GPflowTestCase):
             p = gpflow.Param(1., fix_shape=False)
             self.assertFalse(p.fixed_shape)
             self.assertAllEqual(p.shape, ())
+            self.assertEqual(p.size, 1)
 
             p.assign([10., 10.])
             self.assertFalse(p.fixed_shape)
             self.assertAllEqual(p.shape, (2,))
+            self.assertEqual(p.size, 2)
 
             p.fix_shape()
             self.assertTrue(p.fixed_shape)
             self.assertAllEqual(p.shape, (2,))
+            self.assertEqual(p.size, 2)
             p.assign(np.zeros(p.shape))
 
             with self.assertRaises(ValueError):

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -405,6 +405,43 @@ class TestParameterized(GPflowTestCase):
                 for name in df_slice2.index:
                     assert_allclose(df_slice2[name], values[name])
 
+    def test_fix_shapes(self):
+        with self.test_context():
+            def children(p):
+                yield from p.parameters
+                yield from p.data_holders
+
+            p = self.create_layout()
+            self.assertFalse(all([c.fixed_shape for c in children(p)]))
+            p.fix_shape()
+            self.assertTrue(all([c.fixed_shape for c in children(p)]))
+
+            p = self.create_layout()
+            p.fix_shape(parameters=False, data_holders=True)
+            self.assertTrue(all([c.fixed_shape for c in p.data_holders]))
+            p.fix_shape(parameters=True)
+            self.assertTrue(all([c.fixed_shape for c in p.parameters]))
+            self.assertTrue(all([c.fixed_shape for c in children(p)]))
+
+    def test_trainables(self):
+        with self.test_context():
+            p = self.create_layout()
+            self.assertTrue(all([c.trainable for c in p.parameters]))
+            self.assertTrue(p.trainable)
+
+            p.set_trainable(False)
+            self.assertFalse(all([c.trainable for c in p.parameters]))
+            self.assertFalse(p.trainable)
+
+            p.set_trainable(True)
+            self.assertTrue(all([c.trainable for c in p.parameters]))
+            self.assertTrue(p.trainable)
+
+            values = [None, "test", "", 1]
+
+            for v in values:
+                with self.assertRaises(ValueError, msg='Caught exception for "{}"'.format(v)):
+                    p.set_trainable(v)
 
 
 class TestParameterizedNoParameters(GPflowTestCase):

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -173,10 +173,14 @@ class TestParameter(GPflowTestCase):
             p = gpflow.Param(1.0)
             values = ['', 'test', 1., object(), None]
             for v in values:
-                with self.assertRaises(ValueError, msg='Raised at "{}"'.format(v)):
+                def value_error(value):
+                    return self.assertRaises(ValueError, msg='Raised at "{}"'.format(value))
+                with value_error(v):
                     p.set_trainable(v)
-                with self.assertRaises(ValueError, msg='Raised at "{}"'.format(v)):
+                with value_error(v):
                     p.trainable = v
+                with value_error(v):
+                    p.is_built(v)
 
             tensor = tf.get_variable('test', shape=())
             p = gpflow.Param(tensor)

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -325,10 +325,14 @@ class TestParameterized(GPflowTestCase):
         with self.test_context():
             p = gpflow.Parameterized()
             self.assertTrue(p.is_built_coherence())
+
             # TODO(@awav): Should it be NO?
             self.assertEqual(p.is_built_coherence(tf.Graph()), gpflow.Build.YES)
-            with self.assertRaises(ValueError):
-                p.is_built(None)
+
+            values = [None, "", 1.0, object()]
+            for v in values:
+                with self.assertRaises(ValueError, msg='Passed value {}'.format(v)):
+                    p.is_built(v)
 
             p.a = gpflow.Param(1.0)
             self.assertEqual(p.is_built_coherence(), gpflow.Build.NO)
@@ -337,10 +341,12 @@ class TestParameterized(GPflowTestCase):
             not_compatible = gpflow.Build.NOT_COMPATIBLE_GRAPH
             self.assertTrue(p.is_built_coherence())
             self.assertEqual(p.is_built(tf.Graph()), not_compatible)
+
             with self.assertRaises(gpflow.GPflowError):
                 p.is_built_coherence(tf.Graph())
-            with self.assertRaises(ValueError):
-                p.is_built(None)
+            for v in values:
+                with self.assertRaises(ValueError, msg='Passed value "{}"'.format(v)):
+                    p.is_built(v)
 
     def test_anchor(self):
         with self.test_context() as session:

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -513,6 +513,13 @@ class TestParameterizedNoParameters(GPflowTestCase):
             self.m.p = gpflow.params.Parameterized()
             self.m.b = gpflow.params.Parameterized()
 
+    def test_feeds_empty(self):
+        with self.test_context():
+            p = gpflow.Parameterized()
+            self.assertEqual(p.initializables, [])
+            self.assertEqual(p.initializable_feeds, {})
+            self.assertEqual(p.feeds, {})
+
     def test_is_built(self):
         with self.test_context():
             self.assertEqual(self.m.is_built_coherence(), gpflow.Build.YES)


### PR DESCRIPTION
This PR major aim is an increasing the test coverage. Previously, `codecov` **was configured to calculate coverage score for both python folders**: `gpflow` and `tests`. This is a little bit unfair as we are really interested only in `gpflow` package. Because `tests` directory was included into `codecov` reports, the scores were skewed towards 100% a bit. When I turned off coverage for `tests` the score dropped from `97%` to `94.7%`, so I managed to push it back to `97.31%`.

Additionally, I removed `miniconda` installation, switched tensorflow version to 1.4 and turned on caching in travis builds - as a result installation takes twice less time then before.

@alexggmatthews, @jameshensman, @markvdw 