### PR TITLE
Fixed SVGP minibatch issue, plus regression test

### DIFF
--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -76,7 +76,7 @@ class SVGP(GPModel):
             Y = DataHolder(Y)
         else:
             X = Minibatch(X, batch_size=minibatch_size, seed=0)
-            Y = Minibatch(Y, batch_size=minibatch_size, seed=1)
+            Y = Minibatch(Y, batch_size=minibatch_size, seed=0)
 
         # init the super class, accept args
         GPModel.__init__(self, X, Y, kern, likelihood, mean_function, **kwargs)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -167,6 +167,26 @@ class TestName(GPflowTestCase):
             self.assertEqual(m2.name, 'foo')
 
 
+class EvalDataSVGP(gpflow.models.SVGP):
+    @gpflow.decors.autoflow()
+    @gpflow.decors.params_as_tensors
+    def XY(self):
+        return self.X, self.Y
+
+
+class TestMinibatchSVGP(GPflowTestCase):
+    def test_minibatch_sync(self):
+        with self.test_context():
+            X = np.random.randn(1000, 1)
+            Y = X.copy()
+            Z = X[:100, :].copy()
+            m = EvalDataSVGP(X, Y, gpflow.kernels.RBF(1), gpflow.likelihoods.Gaussian(), minibatch_size=10, Z=Z)
+
+            for _ in range(10):
+                eX, eY = m.XY(initialize=True)
+                self.assertTrue(np.all(eX == eY))
+
+
 # class TestNoRecompileThroughNewModelInstance(GPflowTestCase):
 #     """ Regression tests for Bug #454 """
 


### PR DESCRIPTION
A very bad bug in SVGP, which had the minibatches out of sync (they were given different initial seeds). The fix is a oneliner, and this adds a regression test as well.