### PR TITLE
Exclusive behaviour for Minibatch

### DIFF
--- a/gpflow/misc.py
+++ b/gpflow/misc.py
@@ -185,9 +185,10 @@ def _find_initializable_tensors(intializables, session):
         if isinstance(v, (tuple, list)):
             status_tensors.append(v[0])
             boolean_tensors.append(v[1])
-        # TODO(@awav): Tensorflow Iterator must have init status.
+        # TODO(@awav): Tensorflow Iterator must have to be skipped at
+        # auto-intialization unless TensorFlow issue #14633 is resolved.
         elif isinstance(v, tf.data.Iterator):
-            yield v
+            continue
         else:
             for_reports.append(v)
 

--- a/gpflow/params/dataholders.py
+++ b/gpflow/params/dataholders.py
@@ -119,6 +119,21 @@ class Minibatch(DataHolder):
     Minibatch is shape agnostic at zero axe. Once you created a minibatch you can
     vary size of the dataset, but feature shapes must be fixed.
 
+    CAVEAT: Minibatch is not auto-initializable. It means that whenever you switch
+    to another session, autoflow methods and optimizers will not be able to
+    intialize TensorFlow dataset iterator. You have to call `intialize` method
+    for Minibatch explicitly. Simple cases are not affected though.
+
+    ```
+    with tf.Session() as session1:
+        mini = gpflow.Minibatch(data)
+
+    with tf.Session() as session2:
+        # mini.read_value(session=session2) # <<< fails.
+        mini.initialize(session=session2)
+        mini.read_value(session=session2) # <<< works fine.
+    ```
+
     :param value: Numpy array.
     :param batch_size: Size of the batches.
     :param shuffle: If `True` then input data will be shuffled before batching.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -180,12 +180,18 @@ class TestMinibatchSVGP(GPflowTestCase):
             X = np.random.randn(1000, 1)
             Y = X.copy()
             Z = X[:100, :].copy()
-            m = EvalDataSVGP(X, Y, gpflow.kernels.RBF(1), gpflow.likelihoods.Gaussian(), minibatch_size=10, Z=Z)
+            size = 10
+            m = EvalDataSVGP(X, Y, gpflow.kernels.RBF(1),
+                             gpflow.likelihoods.Gaussian(),
+                             minibatch_size=size, Z=Z)
 
+            eX_prev, eY_prev = np.random.randn(size, 1), np.random.randn(size, 1)
             for _ in range(10):
-                eX, eY = m.XY(initialize=True)
-                self.assertTrue(np.all(eX == eY))
-
+                eX, eY = m.XY()
+                assert not np.allclose(eX, eX_prev)
+                assert not np.allclose(eY, eY_prev)
+                assert np.allclose(eX, eY)
+                eX_prev, eY_prev = eX, eY
 
 # class TestNoRecompileThroughNewModelInstance(GPflowTestCase):
 #     """ Regression tests for Bug #454 """


### PR DESCRIPTION
Until https://github.com/tensorflow/tensorflow/issues/14633 is resolved, Minibatch should be kept from `auto-initializing` feature. Simple cases are not affected. Only when you switch between sessions you will have to re-initialize Minibatch explicitly.