### PR TITLE
`q_sqrt` is now D x M x M.

### DIFF
--- a/gpflow/conditionals.py
+++ b/gpflow/conditionals.py
@@ -51,7 +51,7 @@ def conditional(Xnew, X, kern, f, *, full_cov=False, q_sqrt=None, white=False):
     :param f: data matrix, M x K, representing the function values at X,
         for K functions.
     :param q_sqrt: matrix of standard-deviations or Cholesky matrices,
-        size M x K or M x M x K.
+        size M x K or K x M x M.
     :param white: boolean of whether to use the whitened representation as
         described above.
 
@@ -107,7 +107,7 @@ def base_conditional(Kmn, Kmm, Knn, f, *, full_cov=False, q_sqrt=None, white=Fal
         if q_sqrt.get_shape().ndims == 2:
             LTA = A * tf.expand_dims(tf.transpose(q_sqrt), 2)  # K x M x N
         elif q_sqrt.get_shape().ndims == 3:
-            L = tf.matrix_band_part(tf.transpose(q_sqrt, (2, 0, 1)), -1, 0)  # K x M x M
+            L = tf.matrix_band_part(q_sqrt, -1, 0)  # K x M x M
             A_tiled = tf.tile(tf.expand_dims(A, 0), tf.stack([num_func, 1, 1]))
             LTA = tf.matmul(L, A_tiled, transpose_a=True)  # K x M x N
         else:  # pragma: no cover
@@ -134,7 +134,7 @@ def uncertain_conditional(Xnew_mu, Xnew_var, feat, kern, q_mu, q_sqrt, *,
     :param feat: gpflow.InducingFeature object, only InducingPoints is supported
     :param kern: gpflow kernel or ekernel object.
     :param q_mu: mean inducing points, size M x Dout
-    :param q_sqrt: cholesky of the covariance matrix of the inducing points, size M x M x Dout
+    :param q_sqrt: cholesky of the covariance matrix of the inducing points, size Dout x M x M
     :param full_cov_output: boolean wheter to compute covariance between output dimension.
                             Influences the shape of return value ``fvar``. Default is False
     :param white: boolean whether to use whitened representation. Default is False.
@@ -165,7 +165,7 @@ def uncertain_conditional(Xnew_mu, Xnew_var, feat, kern, q_mu, q_sqrt, *,
     num_ind = tf.shape(q_mu)[0]  # number of inducing points (M)
     num_func = tf.shape(q_mu)[1]  # output dimension (D)
 
-    q_sqrt_r = tf.matrix_band_part(tf.transpose(q_sqrt, (2, 0, 1)), -1, 0)  # D x M x M
+    q_sqrt_r = tf.matrix_band_part(q_sqrt, -1, 0)  # D x M x M
 
     eKuf = tf.transpose(expectation(pXnew, (feat, kern))) # M x N (psi1)
     Kuu = feat.Kuu(kern, jitter=settings.numerics.jitter_level)  # M x M

--- a/gpflow/kullback_leiblers.py
+++ b/gpflow/kullback_leiblers.py
@@ -35,7 +35,7 @@ def gauss_kl(q_mu, q_sqrt, K=None):
 
     q_mu is a matrix (M x N), each column contains a mean.
 
-    q_sqrt can be a 3D tensor (M x M x N), each matrix within is a lower
+    q_sqrt can be a 3D tensor (N xM x M), each matrix within is a lower
         triangular square-root matrix of the covariance of q.
     q_sqrt can be a matrix (M x N), each column represents the diagonal of a
         square-root matrix of the covariance of q.
@@ -59,11 +59,11 @@ def gauss_kl(q_mu, q_sqrt, K=None):
         Lq = Lq_diag = q_sqrt
     elif q_sqrt.get_shape().ndims == 3:
         diag = False
-        num_latent = tf.shape(q_sqrt)[2]
-        NM = tf.reduce_prod(tf.shape(q_sqrt)[1:])
-        Lq = tf.matrix_band_part(tf.transpose(q_sqrt, (2, 0, 1)), -1, 0)  # force lower triangle
+        num_latent = tf.shape(q_sqrt)[0]
+        NM = tf.reduce_prod(tf.shape(q_sqrt)[:2])
+        Lq = tf.matrix_band_part(q_sqrt, -1, 0)  # force lower triangle
         Lq_diag = tf.matrix_diag_part(Lq)
-    else: # pragma: no cover
+    else:  # pragma: no cover
         raise ValueError("Bad dimension for q_sqrt: {}".format(q_sqrt.get_shape().ndims))
 
     # Mahalanobis term: μqᵀ Σp⁻¹ μq

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -93,7 +93,7 @@ class SVGP(GPModel):
                                 transforms.positive)
         else:
             q_sqrt = np.array([np.eye(num_inducing, dtype=settings.float_type)
-                               for _ in range(self.num_latent)]).swapaxes(0, 2)
+                               for _ in range(self.num_latent)])
             self.q_sqrt = Parameter(q_sqrt, transform=transforms.LowerTriangular(num_inducing, self.num_latent))
 
     @params_as_tensors

--- a/gpflow/models/vgp.py
+++ b/gpflow/models/vgp.py
@@ -67,7 +67,7 @@ class VGP(GPModel):
 
         self.q_mu = Parameter(np.zeros((self.num_data, self.num_latent)))
         q_sqrt = np.array([np.eye(self.num_data)
-                           for _ in range(self.num_latent)]).swapaxes(0, 2)
+                           for _ in range(self.num_latent)])
         transform = transforms.LowerTriangular(self.num_data, self.num_latent)
         self.q_sqrt = Parameter(q_sqrt, transform=transform)
 
@@ -111,7 +111,7 @@ class VGP(GPModel):
 
         fmean = tf.matmul(L, self.q_mu) + self.mean_function(self.X)  # NN,ND->ND
 
-        q_sqrt_dnn = tf.matrix_band_part(tf.transpose(self.q_sqrt, [2, 0, 1]), -1, 0)  # D x N x N
+        q_sqrt_dnn = tf.matrix_band_part(self.q_sqrt, -1, 0)  # D x N x N
 
         L_tiled = tf.tile(tf.expand_dims(L, 0), tf.stack([self.num_latent, 1, 1]))
 

--- a/tests/test_conditionals.py
+++ b/tests/test_conditionals.py
@@ -50,7 +50,6 @@ class DiagsTest(GPflowTestCase):
 
         #the chols are diagonal matrices, with the same entries as the diag representation.
         chol = tf.stack([tf.diag(sqrt[:, i]) for i in range(num_latent)])
-        chol = tf.transpose(chol, perm=[1, 2, 0])
         return Xs, X, k, mu, sqrt, chol, feed_dict
 
     def test_whiten(self):
@@ -147,8 +146,7 @@ class WhitenTestGaussian(WhitenTest):
             K = k.K(X)
             L = tf.cholesky(K)
             V = tf.matrix_triangular_solve(L, F, lower=True)
-            V_chol = tf.matrix_triangular_solve(L, tf.diag(F_sqrt[:, 0]), lower=True)
-            V_sqrt = tf.expand_dims(V_chol, 2)
+            V_sqrt = tf.matrix_triangular_solve(L, tf.diag(F_sqrt[:, 0]), lower=True)[None, :, :]
 
             Fstar_mean, Fstar_var = gpflow.conditionals.conditional(
                 Xs, X, k, F, q_sqrt=F_sqrt)

--- a/tests/test_kldiv.py
+++ b/tests/test_kldiv.py
@@ -58,7 +58,6 @@ class DiagsTest(GPflowTestCase):
 
             # the chols are diagonal matrices, with the same entries as the diag representation.
             self.chol = tf.stack([tf.diag(self.sqrt[:, i]) for i in range(N)])
-            self.chol = tf.transpose(self.chol, perm=[1, 2, 0])
 
     def test_white(self):
         with self.test_session() as sess:
@@ -141,7 +140,7 @@ class EqualityTest(GPflowTestCase):
             M = 5
             self.mu = tf.placeholder(settings.float_type, [M, N])
             self.sqrt = tf.placeholder(settings.float_type, [M, N])
-            self.chol = tf.placeholder(settings.float_type, [M, M, N])
+            self.chol = tf.placeholder(settings.float_type, [N, M, M])
             self.K = tf.placeholder(settings.float_type, [M, M])
             self.Kdiag = tf.placeholder(settings.float_type, [M, M])
 
@@ -150,7 +149,7 @@ class EqualityTest(GPflowTestCase):
             sqrt_diag = self.rng.randn(M)
             self.sqrt_data = np.array([sqrt_diag for _ in range(N)]).T
             sqrt_chol = np.tril(self.rng.randn(M, M))
-            self.chol_data = np.rollaxis(np.array([sqrt_chol for _ in range(N)]), 0, 3)
+            self.chol_data = np.array([sqrt_chol for _ in range(N)])
 
             self.feed_dict = {
                 self.mu: np.zeros((M, N)),
@@ -194,13 +193,13 @@ class OneDTest(GPflowTestCase):
             M = 1
             self.mu = tf.placeholder(settings.float_type, [M, N])
             self.sqrt = tf.placeholder(settings.float_type, [M, N])
-            self.chol = tf.placeholder(settings.float_type, [M, M, N])
+            self.chol = tf.placeholder(settings.float_type, [N, M, M])
             self.K = tf.placeholder(settings.float_type, [M, M])
             self.Kdiag = tf.placeholder(settings.float_type, [M, M])
 
             self.mu_data = np.array([[1.3], [1.7]]).T
             self.sqrt_data = np.array([[0.8], [1.5]]).T
-            self.chol_data = self.sqrt_data[None, :, :]
+            self.chol_data = self.sqrt_data.T[:, :, None]
             self.K_data = np.array([[2.5]])
 
             self.feed_dict = {

--- a/tests/test_method_equivalence.py
+++ b/tests/test_method_equivalence.py
@@ -128,7 +128,7 @@ class VGPTest(GPflowTestCase):
             m_vgp.compile()
 
             q_mu = np.random.randn(N, DY)
-            q_sqrt = np.random.randn(N, N, DY)
+            q_sqrt = np.random.randn(DY, N, N)
 
             m_svgp.q_mu = q_mu
             m_svgp.q_sqrt = q_sqrt
@@ -182,14 +182,14 @@ class VGPTest(GPflowTestCase):
                 whiten=False, q_diag=False)
 
             m_svgp_unwhitened.q_mu = mean
-            m_svgp_unwhitened.q_sqrt = np.transpose(np.linalg.cholesky(var_dnn), [1, 2, 0])
+            m_svgp_unwhitened.q_sqrt = np.linalg.cholesky(var_dnn)
 
             m_svgp_unwhitened.compile()
 
             mean_white_nd = L_inv.dot(mean)
             var_white_dnn = np.einsum('nN,dNM,mM->dnm', L_inv, var_dnn, L_inv)
 
-            q_sqrt_nnd = np.transpose(np.linalg.cholesky(var_white_dnn), [1, 2, 0])
+            q_sqrt_nnd = np.linalg.cholesky(var_white_dnn)
 
             m_vgp.q_mu = mean_white_nd
             m_vgp.q_sqrt = q_sqrt_nnd

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -111,8 +111,7 @@ class TestSVGP(GPflowTestCase):
             qsqrt = (qsqrt**2) * 0.01
             m1.q_sqrt = qsqrt
             m1.q_mu = qmean
-            m2.q_sqrt = np.array([np.diag(qsqrt[:, 0]),
-                                  np.diag(qsqrt[:, 1])]).swapaxes(0, 2)
+            m2.q_sqrt = np.array([np.diag(qsqrt[:, 0]), np.diag(qsqrt[:, 1])])
             m2.q_mu = qmean
 
             obj1 = session.run(m1.objective, feed_dict=m1.feeds)
@@ -141,7 +140,7 @@ class TestSVGP(GPflowTestCase):
             qsqrt = (qsqrt**2)*0.01
             m1.q_sqrt = qsqrt
             m1.q_mu = qmean
-            m2.q_sqrt = np.array([np.diag(qsqrt[:, 0]), np.diag(qsqrt[:, 1])]).swapaxes(0, 2)
+            m2.q_sqrt = np.array([np.diag(qsqrt[:, 0]), np.diag(qsqrt[:, 1])])
             m2.q_mu = qmean
             obj1 = session.run(m1.objective, feed_dict=m1.feeds)
             obj2 = session.run(m2.objective, feed_dict=m2.feeds)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -67,8 +67,6 @@ class TransformTests(GPflowTestCase):
     def test_forward_backward(self):
         with self.test_context() as session:
             x, x_np, transforms = self.prepare()
-            x_expect = x_np.copy()
-            x_expect = x_expect.reshape(1, x_np.size)
             for t in transforms:
                 y_np_res = t.forward(x_np)
                 y_tf = t.forward_tensor(x)

--- a/tests/test_uncertain_conditional.py
+++ b/tests/test_uncertain_conditional.py
@@ -54,8 +54,7 @@ def gen_L(rng, n, *shape):
 
 
 def gen_q_sqrt(rng, D_out, *shape):
-    q_sqrt = np.array([np.tril(rng.randn(*shape)) for _ in range(D_out)])
-    return np.transpose(q_sqrt, [1, 2, 0])
+    return np.array([np.tril(rng.randn(*shape)) for _ in range(D_out)])
 
 
 def mean_function_factory(rng, mean_function_name, D_in, D_out):
@@ -121,7 +120,7 @@ class DataQuadrature:
         Xmu = tf.placeholder(float_type, [cls.num_data, cls.D_in])
         Xvar = tf.placeholder(float_type, [cls.num_data, cls.D_in, cls.D_in])
         q_mu = tf.placeholder(float_type, [cls.num_ind, cls.D_out])
-        q_sqrt = tf.placeholder(float_type, [cls.num_ind, cls.num_ind, cls.D_out])
+        q_sqrt = tf.placeholder(float_type, [cls.D_out, cls.num_ind, cls.num_ind])
 
         kern = gpflow.kernels.RBF(cls.D_in)
         feat = gpflow.features.InducingPoints(cls.Z)

--- a/tests/test_variational.py
+++ b/tests/test_variational.py
@@ -183,7 +183,7 @@ class VariationalMultivariateTest(GPflowTestCase):
         if is_diagonal:
             m.q_sqrt = self.q_sqrt_diag
         else:
-            m.q_sqrt = self.q_sqrt_full[:, :, None]
+            m.q_sqrt = self.q_sqrt_full[None, :, :]
         m.q_mu = self.q_mean
         return m
 


### PR DESCRIPTION
As discussed in #610, this PR makes `q_sqrt` D x M x M. This was long overdue, and pulls `q_sqrt` in line with the TensorFlow convention of how to represent lists of matrices.