### PR TITLE
Update README.md to contain reference to gpflow-monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A few projects building on GPflow and demonstrating its usage are listed below.
 | [VFF](https://github.com/jameshensman/VFF)       | Variational Fourier Features for Gaussian Processes. |
 | [Doubly-Stochastic-DGP](https://github.com/ICL-SML/Doubly-Stochastic-DGP)| Deep Gaussian Processes with Doubly Stochastic Variational Inference.|
 | [BranchedGP](https://github.com/ManchesterBioinference/BranchedGP) | Gaussian processes with branching kernels.|
+| [gpflow-monitor](https://github.com/markvdw/gpflow-monitor) | Tools for monitoring and checkpoining optimisation. |
 
 Let us know if you would like your project listed here.
 


### PR DESCRIPTION
Some of the GPflow developers have been using [gpflow-monitor](https://github.com/markvdw/gpflow-monitor) for a while, and have found it useful. Since others may find it useful as well, @vdutor suggested it should be in the readme.