### PR TITLE
Fix for Paramlist append method to handle Parameterized objects

### DIFF
--- a/gpflow/params/paramlist.py
+++ b/gpflow/params/paramlist.py
@@ -53,7 +53,7 @@ class ParamList(Parameterized):
             yield item
 
     def append(self, item):
-        item = self._valid_list_input(item, self.trainable)
+        item = self._valid_list_input(item, self._trainable)
         length = self.__len__()
         item.set_parent(self)
         item.set_name(self._item_name(length))

--- a/gpflow/params/paramlist.py
+++ b/gpflow/params/paramlist.py
@@ -41,7 +41,8 @@ class ParamList(Parameterized):
         super(ParamList, self).__init__(name=None)
         if not isinstance(list_of_params, list):
             raise ValueError('Not acceptable argument type at list_of_params.')
-        self._list = [self._valid_list_input(item, trainable)
+        self._trainable = trainable
+        self._list = [self._valid_list_input(item, self._trainable)
                       for item in list_of_params]
         for index, item in enumerate(self._list):
             self._set_param(index, item)
@@ -52,9 +53,7 @@ class ParamList(Parameterized):
             yield item
 
     def append(self, item):
-        if not isinstance(item, Parameter):
-            raise ValueError(
-                'Non parameter type cannot be appended to the list.')
+        item = self._valid_list_input(item, self.trainable)
         length = self.__len__()
         item.set_parent(self)
         item.set_name(self._item_name(length))

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -866,6 +866,8 @@ class TestParamList(GPflowTestCase):
             p = gpflow.ParamList([])
             p.append(gpflow.Param(1.0))
             p.append(gpflow.Param(2.0))
+            # This test fails with new fix as 2.0 is automatically converted to
+            # a Parameter
             with self.assertRaises(ValueError):
                 p.append(2.0)
             with self.assertRaises(ValueError):
@@ -929,6 +931,18 @@ class TestParamList(GPflowTestCase):
             param_list = gpflow.ParamList([pzd])
             param_list[0].p = 5.
             self.assertEqual(param_list[0].p.read_value(), 5)
+
+    def test_append_with_parameterized(self):
+        with self.test_context():
+            pzd1 = gpflow.params.Parameterized()
+            p1 = gpflow.Param(1.2)
+            pzd1.p = p1
+            pzd2 = gpflow.params.Parameterized()
+            p2 = gpflow.Param(np.array([3.4, 5.6], settings.float_type))
+            pzd2.p = p2
+            param_list = gpflow.ParamList([pzd1])
+            param_list.append(pzd2)
+            self.assertTrue(pzd2 in param_list.params)
 
     def test_in_model(self):
         class Foo(gpflow.models.Model):


### PR DESCRIPTION
Hello,

This PR fixes #605

One of the tests for `ParamList` fail on this one because it alters the behaviour of the `append` method.
```python
with self.assertRaises(ValueError):
    p.append(2.0)
```
The statement `p.append(2.0)` does not raise a `ValueError` anymore as the value is automatically converted into a `Parameter` by the `_valid_list_input` method. This is the original behaviour of `ParamList` when initialised with non-`Parameter`/`Parameterized` objects. I am not sure if this is intentional or not, so I put this comment out there just in case.