### PR TITLE
Cross-covariance between different RBF kernels

### DIFF
--- a/gpflow/decors.py
+++ b/gpflow/decors.py
@@ -195,3 +195,17 @@ def _session_run(session, obj, store, *args, **kwargs):
 
 def _build_method(method, obj, store):
     store['result'] = method(obj, *store['arguments'])
+
+@contextlib.contextmanager
+def nested_with(generator):
+    "Implemented according to the Specification in PEP 343"
+    try:
+        mgr = next(generator)
+        mgr.__enter__()
+        try:
+            with nested_with(generator):
+                yield
+        finally:
+            mgr.__exit__(None, None, None)
+    except StopIteration:
+        yield

--- a/gpflow/expectations.py
+++ b/gpflow/expectations.py
@@ -347,9 +347,17 @@ def _expectation(p, kern1, feat1, kern2, feat2):
             # This is `square_dist` but in a less efficient way. The efficient
             # way would require taking sqrt(La + Lb) which is a little less
             # precise.
-            Zdiff = tf.expand_dims(Za, 1) - tf.expand_dims(Zb, 0)
-            dist = tf.reduce_sum(tf.square(Zdiff) * L_ab, axis=-1)
+            with tf.name_scope("square_dist"):
+                Za2 = tf.reduce_sum(tf.square(Za) * L_ab, axis=1) # Ma
+                if Za == Zb:
+                    Zb2 = Za2
+                else:
+                    Zb2 = tf.reduce_sum(tf.square(Zb) * L_ab, axis=1) # Mb
+                dist = (-2 * tf.matmul(Za * L_ab, Zb, transpose_b=True) # Ma, Mb
+                        + tf.expand_dims(Za2, 1) + Zb2)
             Kmms = tf.exp(-.5 * dist)
+
+
             vec = (tf.reshape(tf.transpose(La_ab * Zb), [1, D, 1, Mb])
                    + tf.reshape(tf.transpose(Lb_ab * Za), [1, D, Ma, 1])
                    - tf.reshape(Xmu, [N, D, 1, 1]))

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -187,9 +187,9 @@ def test_psi_stats(session_tf, feature, distribution, kernel, arg_filter):
 @pytest.mark.parametrize("inputs", [(feature, feature), (feature, feature2),
                                     (feature2, feature)])
 def test_psi2_different_kernels(session_tf, feature, distribution, kernels, inputs):
-    k1, k2 = kernels
+    k1, k2 = (k() for k in kernels)
     z1, z2 = map(lambda z: z(session_tf), inputs)
-    _check((distribution(), (z1, k1()), (z2, k2())))
+    _check((distribution(), (z1, k1), (z2, k2)))
 
 
 @pytest.mark.parametrize("distribution", [gauss])


### PR DESCRIPTION
All the `tests/test_expectations.py` pass, of course including the one I added to test this.

There are a couple of things I don't quite like about my code, and hopefully you know of a better way to do them:
  - Needing `nested_with`. That's because I needed to do `with params_as_tensors_for(a)` for every _different_ kernel and feature `a`, and you can't use `*map(params_as_tensors_for, unique_feat_kern)`.
  - Having to write another implementation for `square_dist` starting on line 350. This is because the desired lengthscale to use `(La + Lb)` doesn't belong to any kernel, and also to use the default kernel's implementation one would need to pass `tf.sqrt(La + Lb)`, only to have it be squared again.