### PR TITLE
remove reindex_axis call in pretty_pandas_table

### DIFF
--- a/gpflow/misc.py
+++ b/gpflow/misc.py
@@ -16,6 +16,7 @@
 import tensorflow as tf
 import numpy as np
 import pandas as pd
+from collections import OrderedDict
 
 from . import settings
 
@@ -24,11 +25,10 @@ __TRAINABLES = tf.GraphKeys.TRAINABLE_VARIABLES
 __GLOBAL_VARIABLES = tf.GraphKeys.GLOBAL_VARIABLES
 
 
-def pretty_pandas_table(names, keys, values):
-    df = pd.DataFrame(dict(zip(keys, values)))
-    df.index = names
-    df = df.reindex_axis(keys, axis=1)
-    return df
+def pretty_pandas_table(row_names, column_names, column_values):
+    return pd.DataFrame(
+        OrderedDict(zip(column_names, column_values)),
+        index=row_names)
 
 
 def tensor_name(*subnames):


### PR DESCRIPTION
`df.reindex_axis()` in `pretty_pandas_table` is now deprecated in pandas and can be avoided anyway.