### PR TITLE
<__str__> must implement pandas printing not <__repr__>

### DIFF
--- a/gpflow/core/node.py
+++ b/gpflow/core/node.py
@@ -186,3 +186,9 @@ class Node(Parentable, ICompilable):
         compabilities instead of public `build`.
         """
         raise NotImplementedError('Private method `build` must be implemented by successor.')
+    
+    def __repr__(self):
+        type_name = self.__class__.__name__
+        name = self.name
+        msg = "<{type_name} '{name}'>"
+        return msg.format(type_name=type_name, name=name)

--- a/gpflow/core/node.py
+++ b/gpflow/core/node.py
@@ -190,5 +190,6 @@ class Node(Parentable, ICompilable):
     def __repr__(self):
         type_name = self.__class__.__name__
         name = self.name
-        msg = "<{type_name} '{name}'>"
-        return msg.format(type_name=type_name, name=name)
+        pathname = self.full_name
+        msg = "<{type_name} name='{name}' pathname='{pathname}'>"
+        return msg.format(type_name=type_name, name=name, pathname=pathname)

--- a/gpflow/params/dataholders.py
+++ b/gpflow/params/dataholders.py
@@ -113,9 +113,6 @@ class DataHolder(Parameter):
     def __setattr__(self, name, value):
         object.__setattr__(self, name, value)
 
-    def __repr__(self):
-        return str(self.as_pandas_table())
-
 
 class Minibatch(DataHolder):
     """

--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -469,7 +469,7 @@ class Parameter(Node):
             pass
         object.__setattr__(self, name, value)
 
-    def __repr__(self):
+    def __str__(self):
         return str(self.as_pandas_table())
 
     @property

--- a/gpflow/params/parameterized.py
+++ b/gpflow/params/parameterized.py
@@ -350,8 +350,8 @@ class Parameterized(Node):
             value.set_name(key)
 
         object.__setattr__(self, key, value)
-
-    def __repr__(self):
+    
+    def __str__(self):
         return str(self.as_pandas_table())
 
     @property


### PR DESCRIPTION
Hello everyone, 

As many of you know that default __str__ implemented using __repr__, and gpflow defines its own implementation of __repr__. But sometimes it causes troubles and misinterpretations when user does not print, but just returns object in `ipython`. Instead of short object description, you will get full table with all parameters:
```
In [10]: m
Out[10]:
                                                        class prior transform  \
SVGP-de20fbbe99/Sum/Matern32..  Parameter  None       +ve
SVGP-de20fbbe99/Sum/Matern32...  Parameter  None       +ve
SVGP-de20fbbe99/Sum/White...  Parameter  None       +ve
...
```
Ipython output for list of models looks terrible, you will not see elements or model objects, just many rows of parameters.

I resolved this issue:

```
In [2]: m
Out[2]: <SVGP name='SVGP' pathname='SVGP'>

In [3]: m.X
Out[3]: <DataHolder name='X' pathname='SVGP/X'>
```

