### PR TITLE
remove conditional shape changes from multivariate_normal

### DIFF
--- a/gpflow/densities.py
+++ b/gpflow/densities.py
@@ -91,7 +91,7 @@ def multivariate_normal(x, mu, L):
         raise ValueError('Shape of x must be 2D.')
     if mu.shape.ndims is None:
         warnings.warn('Shape of mu may be unknown or not 2D.')
-    elif x.shape.ndims != 2:
+    elif mu.shape.ndims != 2:
         raise ValueError('Shape of mu must be 2D.')
         
     d = x - mu

--- a/gpflow/densities.py
+++ b/gpflow/densities.py
@@ -85,9 +85,15 @@ def multivariate_normal(x, mu, L):
     p[n] = log pdf of:
     x[n] ~ N(mu, LL^T) or x ~ N(mu[n], LL^T) or x[n] ~ N(mu[n], LL^T)
     """
-    if  x.shape.ndims != 2: warnings.warn('Shape of x may be unknown or not 2D.')
-    if mu.shape.ndims != 2: warnings.warn('Shape of mu may be unknown or not 2D.')
-
+    if x.shape.ndims is None:
+        warnings.warn('Shape of x must be 2D at computation.')
+    elif x.shape.ndims != 2:
+        raise ValueError('Shape of x must be 2D.')
+    if mu.shape.ndims is None:
+        warnings.warn('Shape of mu may be unknown or not 2D.')
+    elif x.shape.ndims != 2:
+        raise ValueError('Shape of mu must be 2D.')
+        
     d = x - mu
     alpha = tf.matrix_triangular_solve(L, d, lower=True)
     num_dims = tf.cast(tf.shape(d)[0], L.dtype)

--- a/gpflow/densities.py
+++ b/gpflow/densities.py
@@ -15,6 +15,7 @@
 
 import tensorflow as tf
 import numpy as np
+import warnings
 
 
 from . import settings
@@ -72,20 +73,21 @@ def laplace(mu, sigma, y):
 def multivariate_normal(x, mu, L):
     """
     Computes the log-density of a multivariate normal.
-    :param x  : D or DxN sample(s) for which we want the density
-    :param mu : D or DxN mean(s) of the normal distribution
+    :param x  : Dx1 or DxN sample(s) for which we want the density
+    :param mu : Dx1 or DxN mean(s) of the normal distribution
     :param L  : DxD Cholesky decomposition of the covariance matrix
-    :return p : N vector of log densities for each of the N x's and/or mu's
+    :return p : (1,) or (N,) vector of log densities for each of the N x's and/or mu's
 
-    x and mu are either vectors or matrices. If both are vectors ((N,) or (N,1)):
+    x and mu are either vectors or matrices. If both are vectors (N,1):
     p[0] = log pdf(x) where x ~ N(mu, LL^T)
     If at least one is a matrix, we assume independence over the *columns*:
     the number of rows must match the size of L. Broadcasting behaviour:
     p[n] = log pdf of:
     x[n] ~ N(mu, LL^T) or x ~ N(mu[n], LL^T) or x[n] ~ N(mu[n], LL^T)
     """
-    x  = tf.cond(tf.rank(x)  < 2, lambda: x[:, None],  lambda: x)
-    mu = tf.cond(tf.rank(mu) < 2, lambda: mu[:, None], lambda: mu)
+    if  x.shape.ndims != 2: warnings.warn('Shape of x may be unknown or not 2D.')
+    if mu.shape.ndims != 2: warnings.warn('Shape of mu may be unknown or not 2D.')
+
     d = x - mu
     alpha = tf.matrix_triangular_solve(L, d, lower=True)
     num_dims = tf.cast(tf.shape(d)[0], L.dtype)

--- a/tests/test_densities.py
+++ b/tests/test_densities.py
@@ -17,7 +17,7 @@ from numpy.random import randn
 import tensorflow as tf
 import pytest
 import gpflow
-from gpflow import densities
+from gpflow import densities, settings
 from gpflow.test_util import session_tf
 from scipy.stats import multivariate_normal as mvn
 from numpy.testing import assert_allclose
@@ -40,12 +40,12 @@ def test_multivariate_normal(session_tf, x, mu, cov_sqrt):
                 tf.convert_to_tensor(mu),
                 tf.convert_to_tensor(L))
     else:
+        x_tf = tf.placeholder(settings.float_type)
+        mu_tf = tf.placeholder(settings.float_type)
         gp_result = densities.multivariate_normal(
-            tf.convert_to_tensor(x),
-            tf.convert_to_tensor(mu),
-            tf.convert_to_tensor(L))
+            x_tf, mu_tf, tf.convert_to_tensor(L))
 
-        gp_result = session_tf.run(gp_result)
+        gp_result = session_tf.run(gp_result, feed_dict={x_tf: x, mu_tf: mu})
 
         if mu.shape[1] > 1:
             if x.shape[1] > 1:

--- a/tests/test_densities.py
+++ b/tests/test_densities.py
@@ -26,16 +26,18 @@ from numpy.testing import assert_allclose
 rng = np.random.RandomState(1)
 
 
-@pytest.mark.parametrize("x", [randn(4,10), randn(4,1), randn(4)])
-@pytest.mark.parametrize("mu", [randn(4,10), randn(4,1), randn(4)])
-@pytest.mark.parametrize("cov", [randn(4,4), np.eye(4)])
-def test_multivariate_normal(session_tf, x, mu, cov):
-    cov = np.dot(cov, cov.T)
+@pytest.mark.parametrize("x", [randn(4,10), randn(4,1)])
+@pytest.mark.parametrize("mu", [randn(4,10), randn(4,1)])
+@pytest.mark.parametrize("cov_sqrt", [randn(4,4), np.eye(4)])
+def test_multivariate_normal(session_tf, x, mu, cov_sqrt):
+    cov = np.dot(cov_sqrt, cov_sqrt.T)
     L = np.linalg.cholesky(cov)
-    gp_result = densities.multivariate_normal(x, mu, L)
+    gp_result = densities.multivariate_normal(tf.convert_to_tensor(x),
+                                              tf.convert_to_tensor(mu),
+                                              tf.convert_to_tensor(L))
     gp_result = session_tf.run(gp_result)
-    if len(mu.shape) > 1 and mu.shape[1] > 1:
-        if len(x.shape) > 1 and x.shape[1] > 1:
+    if mu.shape[1] > 1:
+        if x.shape[1] > 1:
             sp_result = [mvn.logpdf(x[:,i], mu[:,i], cov) for i in range(mu.shape[1])]
         else:
             sp_result = [mvn.logpdf(x.ravel(), mu[:, i], cov) for i in range(mu.shape[1])]


### PR DESCRIPTION
tf.cond breaks things when the shapes are unknown, make `multivariate_normal` require column vectors or matrices (i.e. 2D input) and raise a warning when the shape is unknown or less than 2D