### PR TITLE
fixed squeezing bug in LowerTriangular transform

### DIFF
--- a/gpflow/transforms.py
+++ b/gpflow/transforms.py
@@ -368,7 +368,7 @@ class LowerTriangular(Transform):
         for i in range(self.num_matrices):
             indices = np.tril_indices(matsize, 0)
             var[(np.zeros(len(indices[0])).astype(int) + i,) + indices] = xr[i, :]
-        return var.squeeze() if self.squeeze else var
+        return var.squeeze(axis=0) if self.squeeze else var
 
     def backward(self, y):
         """
@@ -387,7 +387,7 @@ class LowerTriangular(Transform):
     def forward_tensor(self, x):
         reshaped = tf.reshape(x, (self.num_matrices, -1))
         fwd = vec_to_tri(reshaped, self.N)
-        return tf.squeeze(fwd) if self.squeeze else fwd
+        return tf.squeeze(fwd, axis=0) if self.squeeze else fwd
 
     def backward_tensor(self, y):
         """

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -202,6 +202,11 @@ class TestMatrixTransforms(GPflowTestCase):
         with self.assertRaises(ValueError):
             t.forward(np.ones(3 * 7))
 
+    def test_LowerTriangular_squeezes_only_first_axis(self):
+        t = gpflow.transforms.LowerTriangular(1, 1, squeeze=True)
+        ret = t.forward(np.ones((1, 1)))
+        self.assertEqual(ret.shape, (1, 1))
+
     def test_DiagMatrix(self):
         t = gpflow.transforms.DiagMatrix(3)
         t.backward(np.eye(3))


### PR DESCRIPTION
Currently the `LowerTriangular` transformation is squeezing all dimensions (if `squeeze=True`). This means that if you have only one data point then it will squeeze the matrix to a scalar.
This can be easily resolved by passing `axis=0` to the squeeze command.

The following test assures that we have the expected behaviour:

```
def test_LowerTriangular_squeezes_only_first_axis(self):
       t = gpflow.transforms.LowerTriangular(1, 1, squeeze=True)
       ret = t.forward(np.ones((1, 1)))
       self.assertEqual(ret.shape, (1, 1))
```