### PR TITLE
fix consistency of triangular transform

### DIFF
--- a/gpflow/transforms.py
+++ b/gpflow/transforms.py
@@ -327,17 +327,20 @@ class LowerTriangular(Transform):
     def __init__(self, N, num_matrices=1, squeeze=False):
         """
         Create an instance of LowerTriangular transform.
+
         Args:
             N the size of the final lower triangular matrices.
             num_matrices: Number of matrices to be stored.
             squeeze: If num_matrices == 1, drop the redundant axis.
+
+        :raises ValueError: squeezing is impossible when num_matrices > 1.
         """
         self.N = N
         self.num_matrices = num_matrices  # We need to store this for reconstruction.
         self.squeeze = squeeze
 
         if self.squeeze and (num_matrices != 1):
-            raise ValueError("cannot squeeze matrices unless the first dim is 1.")
+            raise ValueError("cannot squeeze matrices unless num_matrices is 1.")
 
     def forward(self, x):
         """

--- a/gpflow/transforms.py
+++ b/gpflow/transforms.py
@@ -382,7 +382,7 @@ class LowerTriangular(Transform):
         N = int(np.sqrt(y.size / self.num_matrices))
         reshaped = np.reshape(y, (self.num_matrices, N, N))
         # return reshaped[np.tril_indices(N, 0)].T
-        return np.vstack([reshaped[i, :, :][np.tril_indices(N, 0)] for i in range(len(reshaped))])
+        return np.vstack([reshaped[i, :, :][np.tril_indices(N, 0)] for i in range(len(reshaped))]).flatten()
 
     def forward_tensor(self, x):
         reshaped = tf.reshape(x, (self.num_matrices, -1))
@@ -399,7 +399,7 @@ class LowerTriangular(Transform):
         indices = np.array([np.hstack(x) for x in
                             itertools.product(np.arange(self.num_matrices), np.dstack(np.tril_indices(N))[0])])
         triangular = tf.reshape(tf.gather_nd(reshaped, indices), shape=[-1])
-        return triangular[None, :]
+        return triangular
 
     def log_jacobian_tensor(self, x):
         return tf.zeros((1,), settings.float_type)

--- a/gpflow/transforms.py
+++ b/gpflow/transforms.py
@@ -368,7 +368,7 @@ class LowerTriangular(Transform):
         for i in range(self.num_matrices):
             indices = np.tril_indices(matsize, 0)
             var[(np.zeros(len(indices[0])).astype(int) + i,) + indices] = xr[i, :]
-        return var.squeeze() if self.squeeze else var
+        return var.squeeze(axis=0) if self.squeeze else var
 
     def backward(self, y):
         """
@@ -387,7 +387,7 @@ class LowerTriangular(Transform):
     def forward_tensor(self, x):
         reshaped = tf.reshape(x, (self.num_matrices, -1))
         fwd = vec_to_tri(reshaped, self.N)
-        return tf.squeeze(fwd) if self.squeeze else fwd
+        return tf.squeeze(fwd, axis=0) if self.squeeze else fwd
 
     def backward_tensor(self, y):
         """

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -223,14 +223,17 @@ class TestMatrixTransforms(GPflowTestCase):
         t1 = gpflow.transforms.LowerTriangular(N=3, num_matrices=1)
         t2 = gpflow.transforms.LowerTriangular(N=3, num_matrices=1, squeeze=True)
         X = np.random.randn(1, 6)
+        Y = np.random.randn(1, 3, 3)
 
         self.assertTrue(np.all(t1.forward(X).squeeze() == t2.forward(X)))
+        self.assertTrue(np.all(t1.forward(X).squeeze().shape == t2.forward(X).shape))
+        self.assertTrue(np.all(t1.backward(Y) == t2.backward(Y.squeeze())))
+        self.assertTrue(np.all(t1.backward(Y).shape == t2.backward(Y.squeeze()).shape))
 
         with self.test_context() as session:
             self.assertTrue(np.all(session.run(tf.squeeze(t1.forward_tensor(X))) == 
                                    session.run(t2.forward_tensor(X))))
 
-            Y = np.random.randn(1, 3, 3)
             self.assertTrue(np.all(session.run(t1.backward_tensor(Y)) == 
                                    session.run(t2.backward_tensor(Y.squeeze()))))
 
@@ -238,8 +241,6 @@ class TestMatrixTransforms(GPflowTestCase):
         with self.assertRaises(ValueError):
             gpflow.transforms.LowerTriangular(N=3, num_matrices=2, squeeze=True)
 
-
-            
 
     def test_DiagMatrix(self):
         t = gpflow.transforms.DiagMatrix(3)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -202,6 +202,11 @@ class TestMatrixTransforms(GPflowTestCase):
         with self.assertRaises(ValueError):
             t.forward(np.ones(3 * 7))
 
+    def test_LowerTriangular_squeezes_only_first_axis(self):
+        t = gpflow.transforms.LowerTriangular(1, 1, squeeze=True)
+        ret = t.forward(np.ones((1, 1)))
+        self.assertEqual(ret.shape, (1, 1))
+
     def test_DiagMatrix(self):
         t = gpflow.transforms.DiagMatrix(3)
         t.backward(np.eye(3))

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -207,6 +207,18 @@ class TestMatrixTransforms(GPflowTestCase):
         ret = t.forward(np.ones((1, 1)))
         self.assertEqual(ret.shape, (1, 1))
 
+    def test_LowerTriangularConsistency(self):
+        t = gpflow.transforms.LowerTriangular(2, 4)
+        M = np.random.randn(4, 2, 2) * np.tri(2, 2)[None, :, :]
+
+        M_free = t.backward(M)
+        assert_allclose(M, t.forward(M_free))
+
+        with self.test_context() as session:
+            M_free_tf = session.run(t.backward_tensor(tf.identity(M)))
+            assert_allclose(M_free, M_free_tf)
+            assert_allclose(M, session.run(t.forward_tensor(tf.identity(M_free_tf))))
+
     def test_DiagMatrix(self):
         t = gpflow.transforms.DiagMatrix(3)
         t.backward(np.eye(3))

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -33,7 +33,7 @@ class TransformTests(GPflowTestCase):
             if transform_class == Chain:
                 continue  # Chain transform cannot be tested on its own
             if transform_class == gpflow.transforms.LowerTriangular:
-                transforms.append(transform_class(4))
+                pass  # Test triangular transforms separately.
             elif transform_class == gpflow.transforms.DiagMatrix:
                 transforms.append(transform_class(5))
             else:
@@ -197,10 +197,10 @@ class TestMatrixTransforms(GPflowTestCase):
     Some extra tests for the matrix transformations.
     """
     def test_LowerTriangular(self):
-        t = gpflow.transforms.LowerTriangular(1, 3)
-        t.forward(np.ones(3 * 6))
+        t = gpflow.transforms.LowerTriangular(N=3, num_matrices=2)
+        t.forward(np.ones((2, 6)))
         with self.assertRaises(ValueError):
-            t.forward(np.ones(3 * 7))
+            t.forward(np.ones((2, 7)))
 
     def test_LowerTriangular_squeezes_only_first_axis(self):
         t = gpflow.transforms.LowerTriangular(1, 1, squeeze=True)


### PR DESCRIPTION
The free vector for the lower triangular transform wasn't being handled consistently. This PR makes the free state a vector of length `num_matrices * triangle_num`. A test ensures that the numpy and tensorflow transforms agree 