### PR TITLE
Corrected the PCA implementation

### DIFF
--- a/gpflow/models/gplvm.py
+++ b/gpflow/models/gplvm.py
@@ -201,8 +201,6 @@ def PCA_reduce(X, Q):
     :return: PCA projection array of size N x Q.
     """
     assert Q <= X.shape[1], 'Cannot have more latent dimensions than observed'
-    evecs, evals = np.linalg.eigh(np.cov(X.T))
-    i = np.argsort(evecs)[::-1]
-    W = evals[:, i]
-    W = W[:, :Q]
+    evals, evecs = np.linalg.eigh(np.cov(X.T))
+    W = evecs[:, -Q:]
     return (X - X.mean(0)).dot(W)


### PR DESCRIPTION
`np.linalg.eigh` (see [documentation](https://docs.scipy.org/doc/numpy-1.10.1/reference/generated/numpy.linalg.eigh.html)) returns the eigenvalues and eigenvectors in ascending order. The sorting was therefore redundant. Also, `evecs`  and `evals` were flipped. This PR fixes both problems.
