### PR TITLE
Minor improvement to decorators and AutoBuild

### DIFF
--- a/gpflow/core/compilable.py
+++ b/gpflow/core/compilable.py
@@ -89,8 +89,7 @@ class AutoBuild(abc.ABCMeta):
             if autobuild_on and global_autobuild_on:
                 self.build()
                 self.initialize(force=True)
-        if origin_init.__doc__:
-            __init__.__doc__ = '\n'.join([origin_init.__doc__, __init__.__doc__])
+        __init__.__doc__ = origin_init.__doc__
         setattr(new_cls, '__init__', __init__)
         return new_cls
 

--- a/gpflow/core/compilable.py
+++ b/gpflow/core/compilable.py
@@ -89,6 +89,8 @@ class AutoBuild(abc.ABCMeta):
             if autobuild_on and global_autobuild_on:
                 self.build()
                 self.initialize(force=True)
+        if origin_init.__doc__:
+            __init__.__doc__ = '\n'.join([origin_init.__doc__, __init__.__doc__])
         setattr(new_cls, '__init__', __init__)
         return new_cls
 

--- a/gpflow/decors.py
+++ b/gpflow/decors.py
@@ -29,19 +29,24 @@ from .params import Parameterized
 
 def name_scope(name=None):
     """
-    Name scope decorator does little trick with scope naming. The wrapped
-    function will be run inside TensorFlow name scope with name specified
-    by either `name` option or `name` option is None then name of the
-    function will be used.
+    This decorator wraps a function so that it runs inside a TensorFlow
+    name scope. The name is given by the `name` option; if this is None,
+    then the name of the function will be used.
+    >>> @name_scope()
+    >>> def foo(...):
+    >>>     # now runs inside scope "foo"
+    >>> @name_scope('bar')
+    >>> def @baz(...):
+    >>>     # now runs inside scope "bar", not "baz"
     """
-    def name_scope_wrapper(method):
+    def name_scope_wrapper_decorator(method):
         @functools.wraps(method)
-        def runnable(*args, **kwargs):
+        def name_scope_wrapper(*args, **kwargs):
             scope_name = name if name is not None else method.__name__
             with tf.name_scope(scope_name):
                 return method(*args, **kwargs)
-        return runnable
-    return name_scope_wrapper
+        return name_scope_wrapper
+    return name_scope_wrapper_decorator
 
 
 def params_as_tensors(method):
@@ -134,9 +139,9 @@ def params_as_tensors_for(obj, convert=True):
 
 
 def autoflow(*af_args, **af_kwargs):
-    def autoflow_wrapper(method):
+    def autoflow_wrapper_decorator(method):
         @functools.wraps(method)
-        def runnable(obj, *args, **kwargs):
+        def autoflow_wrapper(obj, *args, **kwargs):
             if not isinstance(obj, Node):
                 raise GPflowError(
                     'AutoFlow works only with node-like objects.')
@@ -153,8 +158,8 @@ def autoflow(*af_args, **af_kwargs):
                     _setup_storage(store, *af_args, **af_kwargs)
                     _build_method(method, obj, store)
                 return _session_run(session, obj, store, *args, **kwargs)
-        return runnable
-    return autoflow_wrapper
+        return autoflow_wrapper
+    return autoflow_wrapper_decorator
 
 
 def _params_as_tensors_enter(obj, convert=True):

--- a/gpflow/decors.py
+++ b/gpflow/decors.py
@@ -32,12 +32,14 @@ def name_scope(name=None):
     This decorator wraps a function so that it runs inside a TensorFlow
     name scope. The name is given by the `name` option; if this is None,
     then the name of the function will be used.
+    ```
     >>> @name_scope()
     >>> def foo(...):
     >>>     # now runs inside scope "foo"
     >>> @name_scope('bar')
     >>> def baz(...):
     >>>     # now runs inside scope "bar", not "baz"
+    ```
     """
     def name_scope_wrapper_decorator(method):
         @functools.wraps(method)

--- a/gpflow/decors.py
+++ b/gpflow/decors.py
@@ -36,7 +36,7 @@ def name_scope(name=None):
     >>> def foo(...):
     >>>     # now runs inside scope "foo"
     >>> @name_scope('bar')
-    >>> def @baz(...):
+    >>> def baz(...):
     >>>     # now runs inside scope "bar", not "baz"
     """
     def name_scope_wrapper_decorator(method):


### PR DESCRIPTION
- makes sure that the AutoBuild metaclass does not overwrite the `__init__`'s docstring anymore
- makes the naming of the functions inside the decorators more consistent
- improves the name_scope() docstring