### PR TITLE
Adds rational-quadratic kernel and minor clean-up of notation

### DIFF
--- a/gpflow/_settings.py
+++ b/gpflow/_settings.py
@@ -54,26 +54,26 @@ class _SettingsManager(object):
 
     @property
     def tf_float(self):
-        warnings.warn('The tf_float is depricated and will be removed at '
-                      'GPflow 1.2.0 version. Use float_type.', DeprecationWarning)
+        warnings.warn('tf_float is deprecated and will be removed at GPflow '
+                      'version 1.2.0. Use float_type.', DeprecationWarning)
         return self.float_type
 
     @property
     def tf_int(self):
-        warnings.warn('The tf_int is depricated and will be removed at '
-                      'GPflow 1.2.0 version. Use int_type.', DeprecationWarning)
+        warnings.warn('tf_int is deprecated and will be removed at GPflow '
+                      'version 1.2.0. Use int_type.', DeprecationWarning)
         return self.int_type
 
     @property
     def np_float(self):
-        warnings.warn('The np_float is depricated and will be removed at '
-                      'GPflow 1.2.0 version. Use float_type.', DeprecationWarning)
+        warnings.warn('np_float is deprecated and will be removed at GPflow '
+                      'version 1.2.0. Use float_type.', DeprecationWarning)
         return self.float_type
 
     @property
     def np_int(self):
-        warnings.warn('The np_int is depricated and will be removed at '
-                      'GPflow 1.2.0 version. Use int_type.', DeprecationWarning)
+        warnings.warn('np_int is deprecated and will be removed at GPflow '
+                      'version 1.2.0. Use int_type.', DeprecationWarning)
         return self.int_type
 
     @property

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -231,6 +231,21 @@ class Stationary(Kernel):
             self.lengthscales = Parameter(lengthscales, transform=transforms.positive)
             self.ARD = False
 
+
+    def square_dist(self, X, X2):
+        warnings.warn('square_dist is deprecated and will be removed at '
+                      'GPflow version 1.2.0. Use scaled_square_dist.',
+                      DeprecationWarning)
+        return self.scaled_square_dist(X, X2)
+
+
+    def euclid_dist(self, X, X2):
+        warnings.warn('euclid_dist is deprecated and will be removed at '
+                      'GPflow version 1.2.0. Use scaled_euclid_dist.',
+                      DeprecationWarning)
+        return self.scaled_euclid_dist(X, X2)
+
+
     @params_as_tensors
     def scaled_square_dist(self, X, X2):
         """

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -232,14 +232,14 @@ class Stationary(Kernel):
             self.ARD = False
 
 
-    def square_dist(self, X, X2):
+    def square_dist(self, X, X2):  # pragma: no cover
         warnings.warn('square_dist is deprecated and will be removed at '
                       'GPflow version 1.2.0. Use scaled_square_dist.',
                       DeprecationWarning)
         return self.scaled_square_dist(X, X2)
 
 
-    def euclid_dist(self, X, X2):
+    def euclid_dist(self, X, X2):  # pragma: no cover
         warnings.warn('euclid_dist is deprecated and will be removed at '
                       'GPflow version 1.2.0. Use scaled_euclid_dist.',
                       DeprecationWarning)

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -264,7 +264,7 @@ class Stationary(Kernel):
         return tf.fill(tf.stack([tf.shape(X)[0]]), tf.squeeze(self.variance))
 
 
-class RBF(Stationary):
+class SquaredExponential(Stationary):
     """
     The radial basis function (RBF) or squared exponential kernel
     """
@@ -274,6 +274,8 @@ class RBF(Stationary):
         if not presliced:
             X, X2 = self._slice(X, X2)
         return self.variance * tf.exp(-self.scaled_square_dist(X, X2) / 2)
+
+RBF = SquaredExponential
 
 
 class RationalQuadratic(Stationary):

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -276,6 +276,32 @@ class RBF(Stationary):
         return self.variance * tf.exp(-self.scaled_square_dist(X, X2) / 2)
 
 
+class RationalQuadratic(Stationary):
+    """
+    Rational Quadratic kernel,
+
+    k(r) = σ² (1 + r² / 2αℓ²)^(-α)
+
+    σ² : variance
+    ℓ  : lengthscales
+    α  : alpha, determines relative weighting of small-scale and large-scale fluctuations
+
+    For α→ ∞, the RQ kernel becomes equivalent to the squared exponential.
+    """
+
+    def __init__(self, input_dim, variance=1.0, lengthscales=None, alpha=1.0,
+                 active_dims=None, ARD=False, name=None):
+        super().__init__(input_dim, variance, lengthscales, active_dims, ARD, name)
+        self.alpha = Parameter(alpha, transform=transforms.positive)
+
+    @params_as_tensors
+    def K(self, X, X2=None, presliced=False):
+        if not presliced:
+            X, X2 = self._slice(X, X2)
+        return self.variance * (1 + self.scaled_square_dist(X, X2) /
+                                (2 * self.alpha)) ** (- self.alpha)
+
+
 class Linear(Kernel):
     """
     The linear kernel

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -305,7 +305,7 @@ class RationalQuadratic(Stationary):
     ℓ  : lengthscales
     α  : alpha, determines relative weighting of small-scale and large-scale fluctuations
 
-    For α →  ∞, the RQ kernel becomes equivalent to the squared exponential.
+    For α → ∞, the RQ kernel becomes equivalent to the squared exponential.
     """
 
     def __init__(self, input_dim, variance=1.0, lengthscales=None, alpha=1.0,

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -250,7 +250,9 @@ class Stationary(Kernel):
     def scaled_square_dist(self, X, X2):
         """
         Returns ((X - X2ᵀ)/lengthscales)².
-        Due to the implementation, the result may actually be negative.
+        Due to the implementation and floating-point imprecision, the
+        result may actually be very slightly negative for entries very
+        close to each other.
         """
         X = X / self.lengthscales
         Xs = tf.reduce_sum(tf.square(X), axis=1)
@@ -303,7 +305,7 @@ class RationalQuadratic(Stationary):
     ℓ  : lengthscales
     α  : alpha, determines relative weighting of small-scale and large-scale fluctuations
 
-    For α→ ∞, the RQ kernel becomes equivalent to the squared exponential.
+    For α →  ∞, the RQ kernel becomes equivalent to the squared exponential.
     """
 
     def __init__(self, input_dim, variance=1.0, lengthscales=None, alpha=1.0,

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -264,7 +264,7 @@ class Stationary(Kernel):
         return tf.fill(tf.stack([tf.shape(X)[0]]), tf.squeeze(self.variance))
 
 
-class SquaredExponential(Stationary):
+class RBF(Stationary):
     """
     The radial basis function (RBF) or squared exponential kernel
     """
@@ -275,7 +275,7 @@ class SquaredExponential(Stationary):
             X, X2 = self._slice(X, X2)
         return self.variance * tf.exp(-self.scaled_square_dist(X, X2) / 2)
 
-RBF = SquaredExponential
+SquaredExponential = RBF
 
 
 class RationalQuadratic(Stationary):

--- a/tests/test_kerns.py
+++ b/tests/test_kerns.py
@@ -43,6 +43,28 @@ class TestRbf(GPflowTestCase):
             self.assertTrue(np.allclose(gram_matrix, reference_gram_matrix))
 
 
+class TestRQ(GPflowTestCase):
+    def setUp(self):
+        self.test_graph = tf.Graph()
+
+    def test_1d(self):
+        with self.test_context() as session:
+            lengthscale = 1.4
+            variance = 2.3
+            kSE = gpflow.kernels.RBF(1, lengthscales=lengthscale, variance=variance)
+            kRQ = gpflow.kernels.RationalQuadratic(1, lengthscales=lengthscale, variance=variance, alpha=1e8)
+            rng = np.random.RandomState(1)
+
+            X = tf.placeholder(gpflow.settings.float_type)
+            X_data = rng.randn(6, 1).astype(gpflow.settings.float_type)
+
+            kSE.compile()
+            kRQ.compile()
+            gram_matrix_SE = session.run(kSE.K(X), feed_dict={X: X_data})
+            gram_matrix_RQ = session.run(kRQ.K(X), feed_dict={X: X_data})
+            np.testing.assert_allclose(gram_matrix_SE, gram_matrix_RQ)
+
+
 class TestArcCosine(GPflowTestCase):
     def setUp(self):
         self.test_graph = tf.Graph()


### PR DESCRIPTION
- renames square_dist and euclid_dist to scaled_square_dist and scaled_euclid_dist to be more consistent about what they actually return, and adds docstrings
- adds SquaredExponential as alias to RBF
- adds RationalQuadratic kernel
- includes a test for Rational Quadratic (\alpha->\infty) -> Squared Exponential