### PR TITLE
added kwargs in _expectations to pass around gauss_hermite points. Al…

### DIFF
--- a/gpflow/expectations.py
+++ b/gpflow/expectations.py
@@ -105,7 +105,7 @@ def _quadrature_expectation(p, obj1, feature1, obj2, feature2, num_gauss_hermite
     General handling of quadrature expectations for Gaussians and DiagonalGaussians
     Fallback method for missing analytic expectations
     """
-    num_gauss_hermite_points = 1 if num_gauss_hermite_points is None else num_gauss_hermite_points
+    num_gauss_hermite_points = 100 if num_gauss_hermite_points is None else num_gauss_hermite_points
 
     warnings.warn("Quadrature is used to calculate the expectation. This means that "
                   "an analytical implementations is not available for the given combination.")

--- a/gpflow/expectations.py
+++ b/gpflow/expectations.py
@@ -105,7 +105,7 @@ def _quadrature_expectation(p, obj1, feature1, obj2, feature2, num_gauss_hermite
     General handling of quadrature expectations for Gaussians and DiagonalGaussians
     Fallback method for missing analytic expectations
     """
-    num_gauss_hermite_points = 100 if num_gauss_hermite_points is None else num_gauss_hermite_points
+    num_gauss_hermite_points = 1 if num_gauss_hermite_points is None else num_gauss_hermite_points
 
     warnings.warn("Quadrature is used to calculate the expectation. This means that "
                   "an analytical implementations is not available for the given combination.")
@@ -221,7 +221,7 @@ def expectation(p, obj1, obj2=None, num_gauss_hermite_points=None):
         feat2 = None
 
     try:
-        return _expectation(p, obj1, feat1, obj2, feat2)
+        return _expectation(p, obj1, feat1, obj2, feat2, num_gauss_hermite_points=num_gauss_hermite_points)
     except NotImplementedError as e:
         print(str(e))
         return _quadrature_expectation(p, obj1, feat1, obj2, feat2, num_gauss_hermite_points)
@@ -230,7 +230,7 @@ def expectation(p, obj1, obj2=None, num_gauss_hermite_points=None):
 # ================================ RBF Kernel =================================
 
 @dispatch(Gaussian, kernels.RBF, type(None), type(None), type(None))
-def _expectation(p, kern, none1, none2, none3):
+def _expectation(p, kern, none1, none2, none3, **kwargs):
     """
     Compute the expectation:
     <diag(K_{X, X})>_p(X)
@@ -242,7 +242,7 @@ def _expectation(p, kern, none1, none2, none3):
 
 
 @dispatch(Gaussian, kernels.RBF, InducingPoints, type(None), type(None))
-def _expectation(p, kern, feat, none1, none2):
+def _expectation(p, kern, feat, none1, none2, **kwargs):
     """
     Compute the expectation:
     <K_{X, Z}>_p(X)
@@ -275,7 +275,7 @@ def _expectation(p, kern, feat, none1, none2):
 
 
 @dispatch(Gaussian, mean_functions.Identity, type(None), kernels.RBF, InducingPoints)
-def _expectation(p, mean, none, kern, feat):
+def _expectation(p, mean, none, kern, feat, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <x_n K_{x_n, Z}>_p(x_n)
@@ -313,7 +313,7 @@ def _expectation(p, mean, none, kern, feat):
 
 
 @dispatch(MarkovGaussian, mean_functions.Identity, type(None), kernels.RBF, InducingPoints)
-def _expectation(p, mean, none, kern, feat):
+def _expectation(p, mean, none, kern, feat, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <x_{n+1} K_{x_n, Z}>_p(x_{n:n+1})
@@ -352,7 +352,7 @@ def _expectation(p, mean, none, kern, feat):
 
 
 @dispatch((Gaussian, DiagonalGaussian), kernels.RBF, InducingPoints, kernels.RBF, InducingPoints)
-def _expectation(p, kern1, feat1, kern2, feat2):
+def _expectation(p, kern1, feat1, kern2, feat2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <Ka_{Z1, x_n} Kb_{x_n, Z2}>_p(x_n)
@@ -411,7 +411,7 @@ def _expectation(p, kern1, feat1, kern2, feat2):
 # =============================== Linear Kernel ===============================
 
 @dispatch(Gaussian, kernels.Linear, type(None), type(None), type(None))
-def _expectation(p, kern, none1, none2, none3):
+def _expectation(p, kern, none1, none2, none3, **kwargs):
     """
     Compute the expectation:
     <diag(K_{X, X})>_p(X)
@@ -428,7 +428,7 @@ def _expectation(p, kern, none1, none2, none3):
 
 
 @dispatch(Gaussian, kernels.Linear, InducingPoints, type(None), type(None))
-def _expectation(p, kern, feat, none1, none2):
+def _expectation(p, kern, feat, none1, none2, **kwargs):
     """
     Compute the expectation:
     <K_{X, Z}>_p(X)
@@ -444,7 +444,7 @@ def _expectation(p, kern, feat, none1, none2):
 
 
 @dispatch(Gaussian, kernels.Linear, InducingPoints, mean_functions.Identity, type(None))
-def _expectation(p, kern, feat, mean, none):
+def _expectation(p, kern, feat, mean, none, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <K_{Z, x_n} x_n^T>_p(x_n)
@@ -467,7 +467,7 @@ def _expectation(p, kern, feat, mean, none):
 
 
 @dispatch(MarkovGaussian, kernels.Linear, InducingPoints, mean_functions.Identity, type(None))
-def _expectation(p, kern, feat, mean, none):
+def _expectation(p, kern, feat, mean, none, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <K_{Z, x_n} x_{n+1}^T>_p(x_{n:n+1})
@@ -492,7 +492,7 @@ def _expectation(p, kern, feat, mean, none):
 
 
 @dispatch((Gaussian, DiagonalGaussian), kernels.Linear, InducingPoints, kernels.Linear, InducingPoints)
-def _expectation(p, kern1, feat1, kern2, feat2):
+def _expectation(p, kern1, feat1, kern2, feat2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <Ka_{Z1, x_n} Kb_{x_n, Z2}>_p(x_n)
@@ -532,7 +532,7 @@ def _expectation(p, kern1, feat1, kern2, feat2):
 @dispatch((Gaussian, MarkovGaussian),
           mean_functions.Identity, type(None),
           kernels.Linear, InducingPoints)
-def _expectation(p, mean, none, kern, feat):
+def _expectation(p, mean, none, kern, feat, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <x_n K_{x_n, Z}>_p(x_n)
@@ -545,9 +545,9 @@ def _expectation(p, mean, none, kern, feat):
 
 
 @dispatch((Gaussian, MarkovGaussian),
-          kernels.Kernel, InducingFeature,
+          (kernels.Combination, kernels.RBF, kernels.Linear), InducingFeature,
           mean_functions.MeanFunction, type(None))
-def _expectation(p, kern, feat, mean, none):
+def _expectation(p, kern, feat, mean, none, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <K_{Z, x_n} m(x_n)>_p(x_n)
@@ -555,11 +555,12 @@ def _expectation(p, kern, feat, mean, none):
 
     :return: NxMxQ
     """
-    return tf.matrix_transpose(expectation(p, mean, (kern, feat)))
+    return tf.matrix_transpose(expectation(p, mean, (kern, feat), **kwargs))
 
 
-@dispatch(Gaussian, mean_functions.Linear, type(None), kernels.Kernel, InducingPoints)
-def _expectation(p, linear_mean, none, kern, feat):
+@dispatch(Gaussian, mean_functions.Linear, type(None),
+          (kernels.Combination, kernels.RBF, kernels.Linear), InducingPoints)
+def _expectation(p, linear_mean, none, kern, feat, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <m(x_n)^T K_{x_n, Z}>_p(x_n)
@@ -571,16 +572,17 @@ def _expectation(p, linear_mean, none, kern, feat):
     with params_as_tensors_for(linear_mean):
         N = p.mu.shape[0].value
         D = p.mu.shape[1].value
-        exKxz = expectation(p, mean_functions.Identity(D), (kern, feat))
-        eKxz = expectation(p, (kern, feat))
+        exKxz = expectation(p, mean_functions.Identity(D), (kern, feat), **kwargs)
+        eKxz = expectation(p, (kern, feat), **kwargs)
         eAxKxz = tf.matmul(tf.tile(linear_mean.A[None, :, :], (N, 1, 1)),
                            exKxz, transpose_a=True)
         ebKxz = linear_mean.b[None, :, None] * eKxz[:, None, :]
         return eAxKxz + ebKxz
 
 
-@dispatch(Gaussian, mean_functions.Constant, type(None), kernels.Kernel, InducingPoints)
-def _expectation(p, constant_mean, none, kern, feat):
+@dispatch(Gaussian, mean_functions.Constant, type(None),
+          (kernels.Combination, kernels.RBF, kernels.Linear), InducingPoints)
+def _expectation(p, constant_mean, none, kern, feat, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <m(x_n)^T K_{x_n, Z}>_p(x_n)
@@ -591,7 +593,7 @@ def _expectation(p, constant_mean, none, kern, feat):
     """
     with params_as_tensors_for(constant_mean):
         c = constant_mean(p.mu)  # NxQ
-        eKxz = expectation(p, (kern, feat))  # NxM
+        eKxz = expectation(p, (kern, feat), **kwargs)  # NxM
 
         return c[..., None] * eKxz[:, None, :]
 
@@ -601,7 +603,7 @@ def _expectation(p, constant_mean, none, kern, feat):
 @dispatch(Gaussian,
           (mean_functions.Linear, mean_functions.Identity, mean_functions.Constant),
           type(None), type(None), type(None))
-def _expectation(p, mean, none1, none2, none3):
+def _expectation(p, mean, none1, none2, none3, **kwargs):
     """
     Compute the expectation:
     <m(X)>_p(X)
@@ -615,7 +617,7 @@ def _expectation(p, mean, none1, none2, none3):
 @dispatch(Gaussian,
           mean_functions.Constant, type(None),
           mean_functions.Constant, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -629,7 +631,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 @dispatch(Gaussian,
           mean_functions.Constant, type(None),
           mean_functions.MeanFunction, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -645,7 +647,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 @dispatch(Gaussian,
           mean_functions.MeanFunction, type(None),
           mean_functions.Constant, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -659,7 +661,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 
 
 @dispatch(Gaussian, mean_functions.Identity, type(None), mean_functions.Identity, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -672,7 +674,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 
 
 @dispatch(Gaussian, mean_functions.Identity, type(None), mean_functions.Linear, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -691,7 +693,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 
 
 @dispatch(Gaussian, mean_functions.Linear, type(None), mean_functions.Identity, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -710,7 +712,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 
 
 @dispatch(Gaussian, mean_functions.Linear, type(None), mean_functions.Linear, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -731,7 +733,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 # ================================ Sum kernels ================================
 
 @dispatch(Gaussian, kernels.Sum, type(None), type(None), type(None))
-def _expectation(p, kern, none1, none2, none3):
+def _expectation(p, kern, none1, none2, none3, **kwargs):
     """
     Compute the expectation:
     <\Sum_i diag(Ki_{X, X})>_p(X)
@@ -740,11 +742,11 @@ def _expectation(p, kern, none1, none2, none3):
     :return: N
     """
     return functools.reduce(tf.add, [
-        expectation(p, k) for k in kern.kern_list])
+        expectation(p, k, **kwargs) for k in kern.kern_list])
 
 
 @dispatch(Gaussian, kernels.Sum, InducingPoints, type(None), type(None))
-def _expectation(p, kern, feat, none2, none3):
+def _expectation(p, kern, feat, none2, none3, **kwargs):
     """
     Compute the expectation:
     <\Sum_i Ki_{X, Z}>_p(X)
@@ -753,13 +755,13 @@ def _expectation(p, kern, feat, none2, none3):
     :return: NxM
     """
     return functools.reduce(tf.add, [
-        expectation(p, (k, feat)) for k in kern.kern_list])
+        expectation(p, (k, feat), **kwargs) for k in kern.kern_list])
 
 
 @dispatch(Gaussian,
           (mean_functions.Linear, mean_functions.Identity, mean_functions.Constant), type(None),
           kernels.Sum, InducingPoints)
-def _expectation(p, mean, none, kern, feat):
+def _expectation(p, mean, none, kern, feat, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <m(x_n)^T (\Sum_i Ki_{x_n, Z})>_p(x_n)
@@ -768,11 +770,11 @@ def _expectation(p, mean, none, kern, feat):
     :return: NxQxM
     """
     return functools.reduce(tf.add, [
-        expectation(p, mean, (k, feat)) for k in kern.kern_list])
+        expectation(p, mean, (k, feat), **kwargs) for k in kern.kern_list])
 
 
 @dispatch(MarkovGaussian, mean_functions.Identity, type(None), kernels.Sum, InducingPoints)
-def _expectation(p, mean, none, kern, feat):
+def _expectation(p, mean, none, kern, feat, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <x_{n+1} (\Sum_i Ki_{x_n, Z})>_p(x_{n:n+1})
@@ -781,11 +783,11 @@ def _expectation(p, mean, none, kern, feat):
     :return: NxDxM
     """
     return functools.reduce(tf.add, [
-        expectation(p, mean, (k, feat)) for k in kern.kern_list])
+        expectation(p, mean, (k, feat), **kwargs) for k in kern.kern_list])
 
 
 @dispatch((Gaussian, DiagonalGaussian), kernels.Sum, InducingPoints, kernels.Sum, InducingPoints)
-def _expectation(p, kern1, feat1, kern2, feat2):
+def _expectation(p, kern1, feat1, kern2, feat2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <(\Sum_i K1_i_{Z1, x_n}) (\Sum_j K2_j_{x_n, Z2})>_p(x_n)
@@ -797,15 +799,15 @@ def _expectation(p, kern1, feat1, kern2, feat2):
 
     if kern1 == kern2 and feat1 == feat2:  # avoid duplicate computation by using transposes
         for i, k1 in enumerate(kern1.kern_list):
-            crossexps.append(expectation(p, (k1, feat1), (k1, feat1)))
+            crossexps.append(expectation(p, (k1, feat1), (k1, feat1), **kwargs))
 
             for k2 in kern1.kern_list[:i]:
-                eKK = expectation(p, (k1, feat1), (k2, feat2))
+                eKK = expectation(p, (k1, feat1), (k2, feat2), **kwargs)
                 eKK += tf.matrix_transpose(eKK)
                 crossexps.append(eKK)
     else:
         for k1, k2 in it.product(kern1.kern_list, kern2.kern_list):
-            crossexps.append(expectation(p, (k1, feat1), (k2, feat2)))
+            crossexps.append(expectation(p, (k1, feat1), (k2, feat2), **kwargs))
 
     return functools.reduce(tf.add, crossexps)
 
@@ -813,7 +815,7 @@ def _expectation(p, kern1, feat1, kern2, feat2):
 # =================== Cross Kernel expectations (eK1zxK2xz) ===================
 
 @dispatch((Gaussian, DiagonalGaussian), kernels.RBF, InducingPoints, kernels.Linear, InducingPoints)
-def _expectation(p, rbf_kern, feat1, lin_kern, feat2):
+def _expectation(p, rbf_kern, feat1, lin_kern, feat2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <Ka_{Z1, x_n} Kb_{x_n, Z2}>_p(x_n)
@@ -874,7 +876,7 @@ def _expectation(p, rbf_kern, feat1, lin_kern, feat2):
 
 
 @dispatch((Gaussian, DiagonalGaussian), kernels.Linear, InducingPoints, kernels.RBF, InducingPoints)
-def _expectation(p, lin_kern, feat1, rbf_kern, feat2):
+def _expectation(p, lin_kern, feat1, rbf_kern, feat2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = <Ka_{Z1, x_n} Kb_{x_n, Z2}>_p(x_n)
@@ -894,7 +896,7 @@ def _expectation(p, lin_kern, feat1, rbf_kern, feat2):
 #       is Diagonal
 
 @dispatch(DiagonalGaussian, kernels.Product, type(None), type(None), type(None))
-def _expectation(p, kern, none1, none2, none3):
+def _expectation(p, kern, none1, none2, none3, **kwargs):
     """
     Compute the expectation:
     <\HadamardProd_i diag(Ki_{X[:, active_dims_i], X[:, active_dims_i]})>_p(X)
@@ -908,11 +910,11 @@ def _expectation(p, kern, none1, none2, none3):
             "Product currently needs to be defined on separate dimensions.")  # pragma: no cover
 
     return functools.reduce(tf.multiply, [
-        expectation(p, k) for k in kern.kern_list])
+        expectation(p, k, **kwargs) for k in kern.kern_list])
 
 
 @dispatch(DiagonalGaussian, kernels.Product, InducingPoints, type(None), type(None))
-def _expectation(p, kern, feat, none2, none3):
+def _expectation(p, kern, feat, none2, none3, **kwargs):
     """
     Compute the expectation:
     <\HadamardProd_i Ki_{X[:, active_dims_i], Z[:, active_dims_i]}>_p(X)
@@ -926,11 +928,11 @@ def _expectation(p, kern, feat, none2, none3):
             "Product currently needs to be defined on separate dimensions.")  # pragma: no cover
 
     return functools.reduce(tf.multiply, [
-        expectation(p, (k, feat)) for k in kern.kern_list])
+        expectation(p, (k, feat), **kwargs) for k in kern.kern_list])
 
 
 @dispatch(DiagonalGaussian, kernels.Product, InducingPoints, kernels.Product, InducingPoints)
-def _expectation(p, kern1, feat1, kern2, feat2):
+def _expectation(p, kern1, feat1, kern2, feat2, **kwargs):
     """
     Compute the expectation:
     expectation[n] = < prodK_{Z, x_n} prodK_{x_n, Z} >_p(x_n)
@@ -956,7 +958,7 @@ def _expectation(p, kern1, feat1, kern2, feat2):
             "Product currently needs to be defined on separate dimensions.")  # pragma: no cover
 
     return functools.reduce(tf.multiply, [
-        expectation(p, (k, feat), (k, feat)) for k in kern.kern_list])
+        expectation(p, (k, feat), (k, feat), **kwargs) for k in kern.kern_list])
 
 
 # ============== Conversion to Gaussian from Diagonal or Markov ===============
@@ -965,9 +967,9 @@ def _expectation(p, kern1, feat1, kern2, feat2):
 @dispatch(DiagonalGaussian,
           object, (InducingFeature, type(None)),
           object, (InducingFeature, type(None)))
-def _expectation(p, obj1, feat1, obj2, feat2):
+def _expectation(p, obj1, feat1, obj2, feat2, **kwargs):
     gaussian = Gaussian(p.mu, tf.matrix_diag(p.cov))
-    return expectation(gaussian, (obj1, feat1), (obj2, feat2))
+    return expectation(gaussian, (obj1, feat1), (obj2, feat2), **kwargs)
 
 
 # Catching missing MarkovGaussian implementations by converting to Gaussian (when indifferent):
@@ -975,7 +977,7 @@ def _expectation(p, obj1, feat1, obj2, feat2):
 @dispatch(MarkovGaussian,
           object, (InducingFeature, type(None)),
           object, (InducingFeature, type(None)))
-def _expectation(p, obj1, feat1, obj2, feat2):
+def _expectation(p, obj1, feat1, obj2, feat2, **kwargs):
     """
     Nota Bene: if only one object is passed, obj1 is
     associated with x_n, whereas obj2 with x_{n+1}
@@ -983,9 +985,9 @@ def _expectation(p, obj1, feat1, obj2, feat2):
     """
     if obj2 is None:
         gaussian = Gaussian(p.mu[:-1], p.cov[0, :-1])
-        return expectation(gaussian, (obj1, feat1))
+        return expectation(gaussian, (obj1, feat1), **kwargs)
     elif obj1 is None:
         gaussian = Gaussian(p.mu[1:], p.cov[0, 1:])
-        return expectation(gaussian, (obj2, feat2))
+        return expectation(gaussian, (obj2, feat2), **kwargs)
     else:
-        return expectation(p, (obj1, feat1), (obj2, feat2))
+        return expectation(p, (obj1, feat1), (obj2, feat2), **kwargs)


### PR DESCRIPTION
Hi guys a simple pull request for fixing the following minor issues in `expectations.py`:

1) Added `kwargs` arguments in all `_expectation` signatures in order to correctly be able to pass around the `num_gauss_hermite_points`. In the old code if we are falling back to quadrature by a nested call of expectation, e.g. calling `expectation` inside one of the dispatched versions of `_expectation`, we loose track of the user defined `num_guass_hermite_points` and we revert to the default value. This is now handled

2) Computation of exKxz kernels was handled in the dispatcher by the general type `kernels.Kernel`. This type results in infinite loops (dispatcher chasing its tail) when calling it with an arbitrary kernel, e.g., Matern. I changed the type to `(kernels.Combination, kernels.RBF, kernels.Linear)`, so if the signature is not found it correctly falls back to quadrature.