### PR TITLE
name gaussian likelihoods

### DIFF
--- a/gpflow/likelihoods.py
+++ b/gpflow/likelihoods.py
@@ -141,8 +141,8 @@ class Likelihood(Parameterized):
 
 
 class Gaussian(Likelihood):
-    def __init__(self, var=1.0):
-        super().__init__()
+    def __init__(self, var=1.0, name=None):
+        super().__init__(name=name)
         self.variance = Parameter(
             var, transform=transforms.positive, dtype=settings.float_type)
 


### PR DESCRIPTION
added name argument to `class Gaussian(Likelihood)`, this prevented storing and loading models to and from files. I am pretty sure that there are more of the same, but I am not familiar enough with the code base to point them out. See #689.