### PR TITLE
expectations: pass num hermite points to _expectation() and minor cleaning

### DIFF
--- a/gpflow/expectations.py
+++ b/gpflow/expectations.py
@@ -51,9 +51,15 @@ dispatch = partial(dispatch, namespace=gpflow_md_namespace)
 
 def quadrature_expectation(p, obj1, obj2=None, num_gauss_hermite_points=None):
     """
-    Compute the expectation <obj1(x) obj2(x)>_p(x) using quadrature
-    p can be a (mu, cov) tuple or a probability_distribution
-    obj1 and obj2 can be kernels, mean functions, (kernel, features) tuples, or None
+    Compute the expectation <obj1(x) obj2(x)>_p(x)
+    Uses Gauss-Hermite quadrature for approximate integration.
+
+    :type p: (mu, cov) tuple or a `ProbabilityDistribution` object
+    :type obj1: kernel, mean function, (kernel, features), or None
+    :type obj2: kernel, mean function, (kernel, features), or None
+    :param int num_gauss_hermite_points: passed to `_quadrature_expectation` to set
+                                         the number of Gauss-Hermite points used
+    :return: a 1-D, 2-D, or 3-D tensor containing the expectation
     """
     if isinstance(p, tuple):
         assert len(p) == 2
@@ -171,32 +177,36 @@ def _quadrature_expectation(p, obj1, feature1, obj2, feature2, num_gauss_hermite
 
 # =========================== ANALYTIC EXPECTATIONS ===========================
 
-def expectation(p, obj1, obj2=None, num_gauss_hermite_points=None):
+def expectation(p, obj1, obj2=None, nghp=None):
     """
     Compute the expectation <obj1(x) obj2(x)>_p(x)
-    p can be a (mu, cov) tuple or a probability_distribution
-    obj1 and obj2 can be kernels, mean functions, (kernel, features) tuples, or None
+    Uses multiple-dispatch to select an analytical implementation,
+    if one is available. If not, it falls back to quadrature.
 
-    Using the multiple-dispatch paradigm the function will select an
-    analytical implementation, if one is available, or fall back to quadrature
+    :type p: (mu, cov) tuple or a `ProbabilityDistribution` object
+    :type obj1: kernel, mean function, (kernel, features), or None
+    :type obj2: kernel, mean function, (kernel, features), or None
+    :param int nghp: passed to `_quadrature_expectation` to set the number
+                     of Gauss-Hermite points used: `num_gauss_hermite_points`
+    :return: a 1-D, 2-D, or 3-D tensor containing the expectation
 
     Allowed combinations:
-        .. Psi statistics
+        - Psi statistics:
         eKdiag = expectation(p, kern)  (N)  # Psi0
         eKxz = expectation(p, (kern, feat))  (NxM)  # Psi1
         exKxz = expectation(p, identity_mean, (kern, feat))  (NxDxM)
         eKzxKxz = expectation(p, (kern, feat), (kern, feat))  (NxMxM)  # Psi2
 
-        .. kernels and mean functions
+        - kernels and mean functions:
         eKzxMx = expectation(p, (kern, feat), mean)  (NxMxQ)
         eMxKxz = expectation(p, mean, (kern, feat))  (NxQxM)
 
-        .. only mean functions
+        - only mean functions:
         eMx = expectation(p, mean)  (NxQ)
         eM1x_M2x = expectation(p, mean1, mean2)  (NxQ1xQ2)
         Note: mean(x) is 1xQ (row vector)
 
-        .. different kernels
+        - different kernels:
         this occurs, for instance, when we are calculating Psi2 for Sum kernels
         eK1zxK2xz = expectation(p, (kern1, feat), (kern2, feat))  (NxMxM)
     """
@@ -221,16 +231,16 @@ def expectation(p, obj1, obj2=None, num_gauss_hermite_points=None):
         feat2 = None
 
     try:
-        return _expectation(p, obj1, feat1, obj2, feat2)
+        return _expectation(p, obj1, feat1, obj2, feat2, nghp=nghp)
     except NotImplementedError as e:
         print(str(e))
-        return _quadrature_expectation(p, obj1, feat1, obj2, feat2, num_gauss_hermite_points)
+        return _quadrature_expectation(p, obj1, feat1, obj2, feat2, nghp)
 
 
 # ================================ RBF Kernel =================================
 
 @dispatch(Gaussian, kernels.RBF, type(None), type(None), type(None))
-def _expectation(p, kern, none1, none2, none3):
+def _expectation(p, kern, none1, none2, none3, nghp=None):
     """
     Compute the expectation:
     <diag(K_{X, X})>_p(X)
@@ -242,7 +252,7 @@ def _expectation(p, kern, none1, none2, none3):
 
 
 @dispatch(Gaussian, kernels.RBF, InducingPoints, type(None), type(None))
-def _expectation(p, kern, feat, none1, none2):
+def _expectation(p, kern, feat, none1, none2, nghp=None):
     """
     Compute the expectation:
     <K_{X, Z}>_p(X)
@@ -250,7 +260,7 @@ def _expectation(p, kern, feat, none1, none2):
 
     :return: NxM
     """
-    with params_as_tensors_for(feat), params_as_tensors_for(kern):
+    with params_as_tensors_for(kern), params_as_tensors_for(feat):
         # use only active dimensions
         Xcov = kern._slice_cov(p.cov)
         Z, Xmu = kern._slice(feat.Z, p.mu)
@@ -275,7 +285,7 @@ def _expectation(p, kern, feat, none1, none2):
 
 
 @dispatch(Gaussian, mean_functions.Identity, type(None), kernels.RBF, InducingPoints)
-def _expectation(p, mean, none, kern, feat):
+def _expectation(p, mean, none, kern, feat, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <x_n K_{x_n, Z}>_p(x_n)
@@ -290,7 +300,7 @@ def _expectation(p, mean, none, kern, feat):
             message="Currently cannot handle slicing in exKxz.")]):
         Xmu = tf.identity(Xmu)
 
-    with params_as_tensors_for(feat), params_as_tensors_for(kern):
+    with params_as_tensors_for(kern), params_as_tensors_for(feat):
         D = tf.shape(Xmu)[1]
         lengthscales = kern.lengthscales if kern.ARD \
             else tf.zeros((D,), dtype=settings.float_type) + kern.lengthscales
@@ -313,7 +323,7 @@ def _expectation(p, mean, none, kern, feat):
 
 
 @dispatch(MarkovGaussian, mean_functions.Identity, type(None), kernels.RBF, InducingPoints)
-def _expectation(p, mean, none, kern, feat):
+def _expectation(p, mean, none, kern, feat, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <x_{n+1} K_{x_n, Z}>_p(x_{n:n+1})
@@ -329,7 +339,7 @@ def _expectation(p, mean, none, kern, feat):
             message="Currently cannot handle slicing in exKxz.")]):
         Xmu = tf.identity(Xmu)
 
-    with params_as_tensors_for(feat), params_as_tensors_for(kern):
+    with params_as_tensors_for(kern), params_as_tensors_for(feat):
         D = tf.shape(Xmu)[1]
         lengthscales = kern.lengthscales if kern.ARD \
             else tf.zeros((D,), dtype=settings.float_type) + kern.lengthscales
@@ -352,7 +362,7 @@ def _expectation(p, mean, none, kern, feat):
 
 
 @dispatch((Gaussian, DiagonalGaussian), kernels.RBF, InducingPoints, kernels.RBF, InducingPoints)
-def _expectation(p, kern1, feat1, kern2, feat2):
+def _expectation(p, kern1, feat1, kern2, feat2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <Ka_{Z1, x_n} Kb_{x_n, Z2}>_p(x_n)
@@ -411,7 +421,7 @@ def _expectation(p, kern1, feat1, kern2, feat2):
 # =============================== Linear Kernel ===============================
 
 @dispatch(Gaussian, kernels.Linear, type(None), type(None), type(None))
-def _expectation(p, kern, none1, none2, none3):
+def _expectation(p, kern, none1, none2, none3, nghp=None):
     """
     Compute the expectation:
     <diag(K_{X, X})>_p(X)
@@ -428,7 +438,7 @@ def _expectation(p, kern, none1, none2, none3):
 
 
 @dispatch(Gaussian, kernels.Linear, InducingPoints, type(None), type(None))
-def _expectation(p, kern, feat, none1, none2):
+def _expectation(p, kern, feat, none1, none2, nghp=None):
     """
     Compute the expectation:
     <K_{X, Z}>_p(X)
@@ -444,7 +454,7 @@ def _expectation(p, kern, feat, none1, none2):
 
 
 @dispatch(Gaussian, kernels.Linear, InducingPoints, mean_functions.Identity, type(None))
-def _expectation(p, kern, feat, mean, none):
+def _expectation(p, kern, feat, mean, none, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <K_{Z, x_n} x_n^T>_p(x_n)
@@ -467,7 +477,7 @@ def _expectation(p, kern, feat, mean, none):
 
 
 @dispatch(MarkovGaussian, kernels.Linear, InducingPoints, mean_functions.Identity, type(None))
-def _expectation(p, kern, feat, mean, none):
+def _expectation(p, kern, feat, mean, none, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <K_{Z, x_n} x_{n+1}^T>_p(x_{n:n+1})
@@ -492,7 +502,7 @@ def _expectation(p, kern, feat, mean, none):
 
 
 @dispatch((Gaussian, DiagonalGaussian), kernels.Linear, InducingPoints, kernels.Linear, InducingPoints)
-def _expectation(p, kern1, feat1, kern2, feat2):
+def _expectation(p, kern1, feat1, kern2, feat2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <Ka_{Z1, x_n} Kb_{x_n, Z2}>_p(x_n)
@@ -532,7 +542,7 @@ def _expectation(p, kern1, feat1, kern2, feat2):
 @dispatch((Gaussian, MarkovGaussian),
           mean_functions.Identity, type(None),
           kernels.Linear, InducingPoints)
-def _expectation(p, mean, none, kern, feat):
+def _expectation(p, mean, none, kern, feat, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <x_n K_{x_n, Z}>_p(x_n)
@@ -547,7 +557,7 @@ def _expectation(p, mean, none, kern, feat):
 @dispatch((Gaussian, MarkovGaussian),
           kernels.Kernel, InducingFeature,
           mean_functions.MeanFunction, type(None))
-def _expectation(p, kern, feat, mean, none):
+def _expectation(p, kern, feat, mean, none, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <K_{Z, x_n} m(x_n)>_p(x_n)
@@ -555,11 +565,28 @@ def _expectation(p, kern, feat, mean, none):
 
     :return: NxMxQ
     """
-    return tf.matrix_transpose(expectation(p, mean, (kern, feat)))
+    return tf.matrix_transpose(expectation(p, mean, (kern, feat), nghp=nghp))
+
+
+@dispatch(Gaussian, mean_functions.Constant, type(None), kernels.Kernel, InducingPoints)
+def _expectation(p, constant_mean, none, kern, feat, nghp=None):
+    """
+    Compute the expectation:
+    expectation[n] = <m(x_n)^T K_{x_n, Z}>_p(x_n)
+        - m(x_i) = c :: Constant function
+        - K_{.,.}    :: Kernel function
+
+    :return: NxQxM
+    """
+    with params_as_tensors_for(constant_mean):
+        c = constant_mean(p.mu)  # NxQ
+        eKxz = expectation(p, (kern, feat), nghp=nghp)  # NxM
+
+        return c[..., None] * eKxz[:, None, :]
 
 
 @dispatch(Gaussian, mean_functions.Linear, type(None), kernels.Kernel, InducingPoints)
-def _expectation(p, linear_mean, none, kern, feat):
+def _expectation(p, linear_mean, none, kern, feat, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <m(x_n)^T K_{x_n, Z}>_p(x_n)
@@ -571,37 +598,33 @@ def _expectation(p, linear_mean, none, kern, feat):
     with params_as_tensors_for(linear_mean):
         N = p.mu.shape[0].value
         D = p.mu.shape[1].value
-        exKxz = expectation(p, mean_functions.Identity(D), (kern, feat))
-        eKxz = expectation(p, (kern, feat))
+        exKxz = expectation(p, mean_functions.Identity(D), (kern, feat), nghp=nghp)
+        eKxz = expectation(p, (kern, feat), nghp=nghp)
         eAxKxz = tf.matmul(tf.tile(linear_mean.A[None, :, :], (N, 1, 1)),
                            exKxz, transpose_a=True)
         ebKxz = linear_mean.b[None, :, None] * eKxz[:, None, :]
         return eAxKxz + ebKxz
 
 
-@dispatch(Gaussian, mean_functions.Constant, type(None), kernels.Kernel, InducingPoints)
-def _expectation(p, constant_mean, none, kern, feat):
+@dispatch(Gaussian, mean_functions.Identity, type(None), kernels.Kernel, InducingPoints)
+def _expectation(p, identity_mean, none, kern, feat, nghp=None):
     """
-    Compute the expectation:
-    expectation[n] = <m(x_n)^T K_{x_n, Z}>_p(x_n)
-        - m(x_i) = c :: Constant function
-        - K_{.,.}    :: Kernel function
-
-    :return: NxQxM
+    This prevents infinite recursion for kernels that don't have specific
+    implementations of _expectation(p, identity_mean, None, kern, feat).
+    Recursion can arise because Identity is a subclass of Linear mean function
+    so _expectation(p, linear_mean, none, kern, feat) would call itself.
+    More specific signatures (e.g. (p, identity_mean, None, RBF, feat)) will
+    be found and used whenever available
     """
-    with params_as_tensors_for(constant_mean):
-        c = constant_mean(p.mu)  # NxQ
-        eKxz = expectation(p, (kern, feat))  # NxM
-
-        return c[..., None] * eKxz[:, None, :]
+    raise NotImplementedError
 
 
 # ============================== Mean functions ===============================
 
 @dispatch(Gaussian,
-          (mean_functions.Linear, mean_functions.Identity, mean_functions.Constant),
+          (mean_functions.Linear, mean_functions.Constant),
           type(None), type(None), type(None))
-def _expectation(p, mean, none1, none2, none3):
+def _expectation(p, mean, none1, none2, none3, nghp=None):
     """
     Compute the expectation:
     <m(X)>_p(X)
@@ -615,7 +638,7 @@ def _expectation(p, mean, none1, none2, none3):
 @dispatch(Gaussian,
           mean_functions.Constant, type(None),
           mean_functions.Constant, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -629,7 +652,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 @dispatch(Gaussian,
           mean_functions.Constant, type(None),
           mean_functions.MeanFunction, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -645,7 +668,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 @dispatch(Gaussian,
           mean_functions.MeanFunction, type(None),
           mean_functions.Constant, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -659,7 +682,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 
 
 @dispatch(Gaussian, mean_functions.Identity, type(None), mean_functions.Identity, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -667,12 +690,11 @@ def _expectation(p, mean1, none1, mean2, none2):
 
     :return: NxDxD
     """
-    with params_as_tensors_for(mean1), params_as_tensors_for(mean2):
-        return p.cov + (p.mu[:, :, None] * p.mu[:, None, :])
+    return p.cov + (p.mu[:, :, None] * p.mu[:, None, :])
 
 
 @dispatch(Gaussian, mean_functions.Identity, type(None), mean_functions.Linear, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -681,7 +703,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 
     :return: NxDxQ
     """
-    with params_as_tensors_for(mean1), params_as_tensors_for(mean2):
+    with params_as_tensors_for(mean2):
         N = tf.shape(p.mu)[0]
         e_xxt = p.cov + (p.mu[:, :, None] * p.mu[:, None, :])  # NxDxD
         e_xxt_A = tf.matmul(e_xxt, tf.tile(mean2.A[None, ...], (N, 1, 1)))  # NxDxQ
@@ -691,7 +713,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 
 
 @dispatch(Gaussian, mean_functions.Linear, type(None), mean_functions.Identity, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -700,7 +722,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 
     :return: NxQxD
     """
-    with params_as_tensors_for(mean1), params_as_tensors_for(mean2):
+    with params_as_tensors_for(mean1):
         N = tf.shape(p.mu)[0]
         e_xxt = p.cov + (p.mu[:, :, None] * p.mu[:, None, :])  # NxDxD
         e_A_xxt = tf.matmul(tf.tile(mean1.A[None, ...], (N, 1, 1)), e_xxt, transpose_a=True)  # NxQxD
@@ -710,7 +732,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 
 
 @dispatch(Gaussian, mean_functions.Linear, type(None), mean_functions.Linear, type(None))
-def _expectation(p, mean1, none1, mean2, none2):
+def _expectation(p, mean1, none1, mean2, none2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <m1(x_n)^T m2(x_n)>_p(x_n)
@@ -731,7 +753,7 @@ def _expectation(p, mean1, none1, mean2, none2):
 # ================================ Sum kernels ================================
 
 @dispatch(Gaussian, kernels.Sum, type(None), type(None), type(None))
-def _expectation(p, kern, none1, none2, none3):
+def _expectation(p, kern, none1, none2, none3, nghp=None):
     """
     Compute the expectation:
     <\Sum_i diag(Ki_{X, X})>_p(X)
@@ -740,11 +762,11 @@ def _expectation(p, kern, none1, none2, none3):
     :return: N
     """
     return functools.reduce(tf.add, [
-        expectation(p, k) for k in kern.kern_list])
+        expectation(p, k, nghp=nghp) for k in kern.kern_list])
 
 
 @dispatch(Gaussian, kernels.Sum, InducingPoints, type(None), type(None))
-def _expectation(p, kern, feat, none2, none3):
+def _expectation(p, kern, feat, none2, none3, nghp=None):
     """
     Compute the expectation:
     <\Sum_i Ki_{X, Z}>_p(X)
@@ -753,13 +775,13 @@ def _expectation(p, kern, feat, none2, none3):
     :return: NxM
     """
     return functools.reduce(tf.add, [
-        expectation(p, (k, feat)) for k in kern.kern_list])
+        expectation(p, (k, feat), nghp=nghp) for k in kern.kern_list])
 
 
 @dispatch(Gaussian,
-          (mean_functions.Linear, mean_functions.Identity, mean_functions.Constant), type(None),
-          kernels.Sum, InducingPoints)
-def _expectation(p, mean, none, kern, feat):
+          (mean_functions.Linear, mean_functions.Identity, mean_functions.Constant),
+          type(None), kernels.Sum, InducingPoints)
+def _expectation(p, mean, none, kern, feat, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <m(x_n)^T (\Sum_i Ki_{x_n, Z})>_p(x_n)
@@ -768,11 +790,11 @@ def _expectation(p, mean, none, kern, feat):
     :return: NxQxM
     """
     return functools.reduce(tf.add, [
-        expectation(p, mean, (k, feat)) for k in kern.kern_list])
+        expectation(p, mean, (k, feat), nghp=nghp) for k in kern.kern_list])
 
 
 @dispatch(MarkovGaussian, mean_functions.Identity, type(None), kernels.Sum, InducingPoints)
-def _expectation(p, mean, none, kern, feat):
+def _expectation(p, mean, none, kern, feat, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <x_{n+1} (\Sum_i Ki_{x_n, Z})>_p(x_{n:n+1})
@@ -781,11 +803,11 @@ def _expectation(p, mean, none, kern, feat):
     :return: NxDxM
     """
     return functools.reduce(tf.add, [
-        expectation(p, mean, (k, feat)) for k in kern.kern_list])
+        expectation(p, mean, (k, feat), nghp=nghp) for k in kern.kern_list])
 
 
 @dispatch((Gaussian, DiagonalGaussian), kernels.Sum, InducingPoints, kernels.Sum, InducingPoints)
-def _expectation(p, kern1, feat1, kern2, feat2):
+def _expectation(p, kern1, feat1, kern2, feat2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <(\Sum_i K1_i_{Z1, x_n}) (\Sum_j K2_j_{x_n, Z2})>_p(x_n)
@@ -797,15 +819,15 @@ def _expectation(p, kern1, feat1, kern2, feat2):
 
     if kern1 == kern2 and feat1 == feat2:  # avoid duplicate computation by using transposes
         for i, k1 in enumerate(kern1.kern_list):
-            crossexps.append(expectation(p, (k1, feat1), (k1, feat1)))
+            crossexps.append(expectation(p, (k1, feat1), (k1, feat1), nghp=nghp))
 
             for k2 in kern1.kern_list[:i]:
-                eKK = expectation(p, (k1, feat1), (k2, feat2))
+                eKK = expectation(p, (k1, feat1), (k2, feat2), nghp=nghp)
                 eKK += tf.matrix_transpose(eKK)
                 crossexps.append(eKK)
     else:
         for k1, k2 in it.product(kern1.kern_list, kern2.kern_list):
-            crossexps.append(expectation(p, (k1, feat1), (k2, feat2)))
+            crossexps.append(expectation(p, (k1, feat1), (k2, feat2), nghp=nghp))
 
     return functools.reduce(tf.add, crossexps)
 
@@ -813,7 +835,7 @@ def _expectation(p, kern1, feat1, kern2, feat2):
 # =================== Cross Kernel expectations (eK1zxK2xz) ===================
 
 @dispatch((Gaussian, DiagonalGaussian), kernels.RBF, InducingPoints, kernels.Linear, InducingPoints)
-def _expectation(p, rbf_kern, feat1, lin_kern, feat2):
+def _expectation(p, rbf_kern, feat1, lin_kern, feat2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <Ka_{Z1, x_n} Kb_{x_n, Z2}>_p(x_n)
@@ -835,8 +857,8 @@ def _expectation(p, rbf_kern, feat1, lin_kern, feat2):
     if rbf_kern.active_dims != lin_kern.active_dims:
         raise NotImplementedError("active_dims have to be the same for both kernels.")
 
-    with params_as_tensors_for(feat1), params_as_tensors_for(feat2), \
-         params_as_tensors_for(rbf_kern), params_as_tensors_for(lin_kern):
+    with params_as_tensors_for(rbf_kern), params_as_tensors_for(lin_kern), \
+         params_as_tensors_for(feat1), params_as_tensors_for(feat2):
         # use only active dimensions
         Xcov = rbf_kern._slice_cov(tf.matrix_diag(p.cov) if isinstance(p, DiagonalGaussian) else p.cov)
         Z, Xmu = rbf_kern._slice(feat1.Z, p.mu)
@@ -874,7 +896,7 @@ def _expectation(p, rbf_kern, feat1, lin_kern, feat2):
 
 
 @dispatch((Gaussian, DiagonalGaussian), kernels.Linear, InducingPoints, kernels.RBF, InducingPoints)
-def _expectation(p, lin_kern, feat1, rbf_kern, feat2):
+def _expectation(p, lin_kern, feat1, rbf_kern, feat2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = <Ka_{Z1, x_n} Kb_{x_n, Z2}>_p(x_n)
@@ -894,7 +916,7 @@ def _expectation(p, lin_kern, feat1, rbf_kern, feat2):
 #       is Diagonal
 
 @dispatch(DiagonalGaussian, kernels.Product, type(None), type(None), type(None))
-def _expectation(p, kern, none1, none2, none3):
+def _expectation(p, kern, none1, none2, none3, nghp=None):
     """
     Compute the expectation:
     <\HadamardProd_i diag(Ki_{X[:, active_dims_i], X[:, active_dims_i]})>_p(X)
@@ -908,11 +930,11 @@ def _expectation(p, kern, none1, none2, none3):
             "Product currently needs to be defined on separate dimensions.")  # pragma: no cover
 
     return functools.reduce(tf.multiply, [
-        expectation(p, k) for k in kern.kern_list])
+        expectation(p, k, nghp=nghp) for k in kern.kern_list])
 
 
 @dispatch(DiagonalGaussian, kernels.Product, InducingPoints, type(None), type(None))
-def _expectation(p, kern, feat, none2, none3):
+def _expectation(p, kern, feat, none2, none3, nghp=None):
     """
     Compute the expectation:
     <\HadamardProd_i Ki_{X[:, active_dims_i], Z[:, active_dims_i]}>_p(X)
@@ -926,11 +948,11 @@ def _expectation(p, kern, feat, none2, none3):
             "Product currently needs to be defined on separate dimensions.")  # pragma: no cover
 
     return functools.reduce(tf.multiply, [
-        expectation(p, (k, feat)) for k in kern.kern_list])
+        expectation(p, (k, feat), nghp=nghp) for k in kern.kern_list])
 
 
 @dispatch(DiagonalGaussian, kernels.Product, InducingPoints, kernels.Product, InducingPoints)
-def _expectation(p, kern1, feat1, kern2, feat2):
+def _expectation(p, kern1, feat1, kern2, feat2, nghp=None):
     """
     Compute the expectation:
     expectation[n] = < prodK_{Z, x_n} prodK_{x_n, Z} >_p(x_n)
@@ -956,7 +978,7 @@ def _expectation(p, kern1, feat1, kern2, feat2):
             "Product currently needs to be defined on separate dimensions.")  # pragma: no cover
 
     return functools.reduce(tf.multiply, [
-        expectation(p, (k, feat), (k, feat)) for k in kern.kern_list])
+        expectation(p, (k, feat), (k, feat), nghp=nghp) for k in kern.kern_list])
 
 
 # ============== Conversion to Gaussian from Diagonal or Markov ===============
@@ -965,9 +987,9 @@ def _expectation(p, kern1, feat1, kern2, feat2):
 @dispatch(DiagonalGaussian,
           object, (InducingFeature, type(None)),
           object, (InducingFeature, type(None)))
-def _expectation(p, obj1, feat1, obj2, feat2):
+def _expectation(p, obj1, feat1, obj2, feat2, nghp=None):
     gaussian = Gaussian(p.mu, tf.matrix_diag(p.cov))
-    return expectation(gaussian, (obj1, feat1), (obj2, feat2))
+    return expectation(gaussian, (obj1, feat1), (obj2, feat2), nghp=nghp)
 
 
 # Catching missing MarkovGaussian implementations by converting to Gaussian (when indifferent):
@@ -975,7 +997,7 @@ def _expectation(p, obj1, feat1, obj2, feat2):
 @dispatch(MarkovGaussian,
           object, (InducingFeature, type(None)),
           object, (InducingFeature, type(None)))
-def _expectation(p, obj1, feat1, obj2, feat2):
+def _expectation(p, obj1, feat1, obj2, feat2, nghp=None):
     """
     Nota Bene: if only one object is passed, obj1 is
     associated with x_n, whereas obj2 with x_{n+1}
@@ -983,9 +1005,9 @@ def _expectation(p, obj1, feat1, obj2, feat2):
     """
     if obj2 is None:
         gaussian = Gaussian(p.mu[:-1], p.cov[0, :-1])
-        return expectation(gaussian, (obj1, feat1))
+        return expectation(gaussian, (obj1, feat1), nghp=nghp)
     elif obj1 is None:
         gaussian = Gaussian(p.mu[1:], p.cov[0, 1:])
-        return expectation(gaussian, (obj2, feat2))
+        return expectation(gaussian, (obj2, feat2), nghp=nghp)
     else:
-        return expectation(p, (obj1, feat1), (obj2, feat2))
+        return expectation(p, (obj1, feat1), (obj2, feat2), nghp=nghp)

--- a/gpflow/expectations.py
+++ b/gpflow/expectations.py
@@ -190,25 +190,25 @@ def expectation(p, obj1, obj2=None, nghp=None):
                      of Gauss-Hermite points used: `num_gauss_hermite_points`
     :return: a 1-D, 2-D, or 3-D tensor containing the expectation
 
-    Allowed combinations:
-        - Psi statistics:
-        eKdiag = expectation(p, kern)  (N)  # Psi0
-        eKxz = expectation(p, (kern, feat))  (NxM)  # Psi1
-        exKxz = expectation(p, identity_mean, (kern, feat))  (NxDxM)
-        eKzxKxz = expectation(p, (kern, feat), (kern, feat))  (NxMxM)  # Psi2
+    Allowed combinations
+    
+    - Psi statistics:
+        >>> eKdiag = expectation(p, kern)  (N)  # Psi0
+        >>> eKxz = expectation(p, (kern, feat))  (NxM)  # Psi1
+        >>> exKxz = expectation(p, identity_mean, (kern, feat))  (NxDxM)
+        >>> eKzxKxz = expectation(p, (kern, feat), (kern, feat))  (NxMxM)  # Psi2
 
-        - kernels and mean functions:
-        eKzxMx = expectation(p, (kern, feat), mean)  (NxMxQ)
-        eMxKxz = expectation(p, mean, (kern, feat))  (NxQxM)
+    - kernels and mean functions:
+        >>> eKzxMx = expectation(p, (kern, feat), mean)  (NxMxQ)
+        >>> eMxKxz = expectation(p, mean, (kern, feat))  (NxQxM)
 
-        - only mean functions:
-        eMx = expectation(p, mean)  (NxQ)
-        eM1x_M2x = expectation(p, mean1, mean2)  (NxQ1xQ2)
-        Note: mean(x) is 1xQ (row vector)
+    - only mean functions:
+        >>> eMx = expectation(p, mean)  (NxQ)
+        >>> eM1x_M2x = expectation(p, mean1, mean2)  (NxQ1xQ2)
+        .. note:: mean(x) is 1xQ (row vector)
 
-        - different kernels:
-        this occurs, for instance, when we are calculating Psi2 for Sum kernels
-        eK1zxK2xz = expectation(p, (kern1, feat), (kern2, feat))  (NxMxM)
+    - different kernels. This occurs, for instance, when we are calculating Psi2 for Sum kernels:
+        >>> eK1zxK2xz = expectation(p, (kern1, feat), (kern2, feat))  (NxMxM)
     """
     if isinstance(p, tuple):
         assert len(p) == 2

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -18,8 +18,6 @@ import copy
 
 import pytest
 
-import gpflow
-from gpflow import test_util
 from gpflow.expectations import expectation, quadrature_expectation
 from gpflow.probability_distributions import Gaussian, DiagonalGaussian, MarkovGaussian
 from gpflow import kernels, mean_functions, features
@@ -106,6 +104,11 @@ def rbf_kern():
 @cache_tensor
 def lin_kern():
     return kernels.Linear(Data.D_in, variance=rng.rand())
+
+
+@cache_tensor
+def matern_kern():
+    return kernels.Matern32(Data.D_in, variance=rng.rand())
 
 
 @cache_tensor
@@ -208,7 +211,7 @@ def test_kernel_only_expectations(session_tf, distribution, kernel, feature, arg
 
 
 @pytest.mark.parametrize("distribution", [gauss])
-@pytest.mark.parametrize("kernel", [rbf_kern, lin_kern, rbf_lin_sum_kern])
+@pytest.mark.parametrize("kernel", [rbf_kern, lin_kern, matern_kern, rbf_lin_sum_kern])
 @pytest.mark.parametrize("mean", [lin_mean, identity_mean, const_mean, zero_mean])
 @pytest.mark.parametrize("arg_filter",
                          [lambda p, k, f, m: (p, (k, f), m),


### PR DESCRIPTION
This pull request fixes two issues:

- the signature `(Gaussian, identity_mean, None, kernel, features)` was calling itself whenever no specific implementation for `kernel` exists because `Identity` is a type of `Linear` mean function
- the default number of Hermite points (often too high) was used for nested calling of `expectation` as the `num_gauss_hermite_points` argument was not being passed beyond the first call

What is irking about the current fix for the second issue:

- `_expectation`'s should, in theory, have no knowledge of Hermite points and should not receive them as arguments
- the code is now slightly more verbose, though at least explicit
- to keep the code and signatures simple (and not changing 35 of them) the number of Hermite points argument (`nghp`) is not checked by multiple dispatch

The solution to fix all this would be to make `expectation` into a class but it is unclear at the moment whether this would have any other use cases. The Hermite points issue does not warrant, in my opinion, changing `expectation` to a class as that would imply a significant refactor and changes to code outside of the `expectations` submodule.