### PR TITLE
Optimizers incompatibility with TensorFlow >= 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 
 install:
   - pip install numpy scipy pandas pytest nbformat nbconvert jupyter_client jupyter matplotlib pytest-xdist pytest-cov codecov multipledispatch
-  - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.0-cp36-cp36m-linux_x86_64.whl
+  - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.6.0-cp36-cp36m-linux_x86_64.whl
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 
 install:
   - pip install numpy scipy pandas pytest nbformat nbconvert jupyter_client jupyter matplotlib pytest-xdist pytest-cov codecov multipledispatch
-  - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.0-cp36-cp36m-linux_x86_64.whl
+  - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.0-cp36-cp36m-linux_x86_64.whl
   - python setup.py install
 
 script:

--- a/gpflow/training/tensorflow_optimizer.py
+++ b/gpflow/training/tensorflow_optimizer.py
@@ -53,7 +53,7 @@ class _TensorFlowOptimizer(optimizer.Optimizer):
         with session.as_default():
             minimize = self.optimizer.minimize(objective, var_list=full_var_list, **kwargs)
             model.initialize(session=session)
-            self._initialize_optimizer(session, full_var_list)
+            self._initialize_optimizer(session)
             return minimize
     
     def make_optimize_action(self, model, session=None, var_list=None, **kwargs):
@@ -117,21 +117,9 @@ class _TensorFlowOptimizer(optimizer.Optimizer):
         if anchor:
             opt.model.anchor(session)
 
-    def _initialize_optimizer(self, session, var_list):
-        """
-        TODO(@awav): AdamOptimizer creates beta1 and beta2 variables which are
-        not included in slots.
-        """
-        def get_optimizer_slots():
-            for name in self.optimizer.get_slot_names():
-                for var in var_list:
-                    slot = self.optimizer.get_slot(var, name)
-                    if slot is not None:
-                        yield slot
-        extra_vars = [v for v in self.optimizer.__dict__.values() if isinstance(v, tf.Variable)]
-        optimizer_vars = list(get_optimizer_slots())
-        full_var_list = list(set(optimizer_vars + extra_vars))
-        misc.initialize_variables(full_var_list, session=session, force=False)
+    def _initialize_optimizer(self, session: tf.Session):
+        var_list = self.optimizer.variables()
+        misc.initialize_variables(var_list, session=session, force=False)
 
     @property
     def minimize_operation(self):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = [
     'multipledispatch>=0.4.9'
 ]
 
-min_tf_version = '1.4.0'
+min_tf_version = '1.5.0'
 tf_cpu = 'tensorflow>={}'.format(min_tf_version)
 tf_gpu = 'tensorflow-gpu>={}'.format(min_tf_version)
 


### PR DESCRIPTION
Hello all!

Current GPflow is broken for tensorflow >= 1.6. This is very sad as TensorFlow has advanced to 1.7 version. The issue was caused by uninitialized variables error:

```
FailedPreconditionError (see above for traceback): Attempting to use uninitialized value beta1_power
	 [[Node: beta1_power/read = Identity[T=DT_FLOAT, _class=["loc:@RBF-d9f4a003-0/lengthscales/unconstrained"], _device="/job:localhost/replica:0/task:0/device:CPU:0"](beta1_power)]]
```

To reproduce the error you can install GPflow master with tensorflow >= 1.6 and run this MWE:

```
   ...: import warnings
   ...: import numpy as np
   ...: import tensorflow as tf
   ...: import gpflow as gp
   ...:
   ...: np.random.seed(0)
   ...:
   ...: N, D = 100, 2
   ...: M = 10
   ...: X = np.random.uniform(size=(N, D))
   ...: Y = np.sin(10 * X)
   ...: Z = np.random.uniform(size=(M, D))
   ...: learning_rate = 0.01
   ...: iterations = 5
   ...:
   ...: m = gp.models.VGP(X, Y, kern=gp.kernels.RBF(2), likelihood=gp.likelihoods.Bernoulli())
   ...: o = gp.train.AdamOptimizer(0.01)
   ...: a = o.minimize(m)
```

This fix makes it work!