### PR TITLE
Pytest used by test_util module

### DIFF
--- a/gpflow/_version.py
+++ b/gpflow/_version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ requirements = [
     'numpy>=1.10.0',
     'scipy>=0.18.0',
     'pandas>=0.18.1',
+    'pytest>=3.5.0',
     'multipledispatch>=0.4.9'
 ]
 
@@ -53,7 +54,6 @@ setup(name='gpflow',
       url="http://github.com/GPflow/GPflow",
       packages=packages,
       install_requires=requirements,
-      tests_require=['pytest'],
       package_data=package_data,
       include_package_data=True,
       test_suite='tests',


### PR DESCRIPTION
Hello everyone,

Quick fix for `pytest` import issue. Apparently, GPflow imports it in test_util.py module. Therefore it must go into requirements list.
