### PR TITLE
as_pandas_table: copy value before adding to DataFrame

### DIFF
--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -293,7 +293,7 @@ class Parameter(Node):
     def as_pandas_table(self):
         column_names = ['class', 'prior', 'transform', 'trainable', 'shape', 'fixed_shape', 'value']
         column_values = [self.__class__.__name__, str(self.prior), str(self.transform),
-                         self.trainable, self.shape, self.fixed_shape, self.value]
+                         self.trainable, self.shape, self.fixed_shape, self.value.copy()]
         column_values = [[value] for value in column_values]
         df = misc.pretty_pandas_table([self.pathname], column_names, column_values)
         return df

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -1209,5 +1209,14 @@ def test_parentable_set_parent_self_reference(params_tree):
         params_tree.a.set_parent(params_tree)
 
 
+def test_as_pandas_table_static(params_tree):
+    pt1 = params_tree.as_pandas_table()
+    pt2 = params_tree.as_pandas_table()
+    assert pt1.equals(pt2)
+    params_tree.a = params_tree.a.value + 5.0
+    pt3 = params_tree.as_pandas_table()
+    assert not pt1.equals(pt3)
+
+
 if __name__ == '__main__':
     tf.test.main()


### PR DESCRIPTION
Currently, as_pandas_table() added the values of parameters as *references*; i.e., when updating the model, all previously generated tables would change. I think the key reason for using as_pandas_table() is to obtain a static copy of the parameters (e.g. to compare how they changed as the model is updated). This PR fixes that by adding a .copy().

MWE: `test_as_pandas_table_static()` fails without 7720633, passes afterwards.