### PR TITLE
Fixed `gauss_kl` when the shape of the Gaussian parameters is unknown

### DIFF
--- a/gpflow/kullback_leiblers.py
+++ b/gpflow/kullback_leiblers.py
@@ -70,7 +70,7 @@ def gauss_kl(q_mu, q_sqrt, K=None):
     mahalanobis = tf.reduce_sum(tf.square(alpha))
 
     # Constant term: - B * M
-    constant = - tf.size(q_mu, out_type=settings.float_type)
+    constant = tf.cast(-tf.size(q_mu, out_type=tf.int64), dtype=settings.float_type)
 
     # Log-determinant of the covariance of q(x):
     logdet_qcov = tf.reduce_sum(tf.log(tf.square(Lq_diag)))

--- a/tests/test_kldiv.py
+++ b/tests/test_kldiv.py
@@ -145,5 +145,15 @@ def test_oned(session_tf, white, mu, sqrt, K_batch):
     np.testing.assert_allclose(kl.eval(), kl_tf.eval())
 
 
+def test_unknown_size_inputs(session_tf):
+    mu_ph = tf.placeholder(settings.float_type, [None, None])
+    sqrt_ph = tf.placeholder(settings.float_type, [None, None, None])
+    mu = np.ones([1, 4], dtype=settings.float_type)
+    sqrt = np.ones([4, 1, 1], dtype=settings.float_type)
+    np.testing.assert_allclose(
+        session_tf.run(gauss_kl(*map(tf.constant, [mu, sqrt]))),
+        session_tf.run(gauss_kl(mu_ph, sqrt_ph), {mu_ph: mu, sqrt_ph: sqrt}))
+
+
 if __name__ == "__main__":
     tf.test.main()

--- a/tests/test_kldiv.py
+++ b/tests/test_kldiv.py
@@ -146,13 +146,19 @@ def test_oned(session_tf, white, mu, sqrt, K_batch):
 
 
 def test_unknown_size_inputs(session_tf):
+    """
+    Test for #725 and #734. When the shape of the Gaussian's mean had at least
+    one unknown parameter, `gauss_kl` would blow up. This happened because
+    `tf.size` can only output types `tf.int32` or `tf.int64`.
+    """
     mu_ph = tf.placeholder(settings.float_type, [None, None])
     sqrt_ph = tf.placeholder(settings.float_type, [None, None, None])
     mu = np.ones([1, 4], dtype=settings.float_type)
     sqrt = np.ones([4, 1, 1], dtype=settings.float_type)
+    feed_dict = {mu_ph: mu, sqrt_ph: sqrt}
     np.testing.assert_allclose(
         session_tf.run(gauss_kl(*map(tf.constant, [mu, sqrt]))),
-        session_tf.run(gauss_kl(mu_ph, sqrt_ph), {mu_ph: mu, sqrt_ph: sqrt}))
+        session_tf.run(gauss_kl(mu_ph, sqrt_ph), feed_dict=feed_dict))
 
 
 if __name__ == "__main__":

--- a/tests/test_kldiv.py
+++ b/tests/test_kldiv.py
@@ -155,10 +155,15 @@ def test_unknown_size_inputs(session_tf):
     sqrt_ph = tf.placeholder(settings.float_type, [None, None, None])
     mu = np.ones([1, 4], dtype=settings.float_type)
     sqrt = np.ones([4, 1, 1], dtype=settings.float_type)
+    
     feed_dict = {mu_ph: mu, sqrt_ph: sqrt}
-    np.testing.assert_allclose(
-        session_tf.run(gauss_kl(*map(tf.constant, [mu, sqrt]))),
-        session_tf.run(gauss_kl(mu_ph, sqrt_ph), feed_dict=feed_dict))
+    known_shape_tf = gauss_kl(*map(tf.constant, [mu, sqrt]))
+    unknown_shape_tf = gauss_kl(mu_ph, sqrt_ph)
+    
+    known_shape = session_tf.run(known_shape_tf)
+    unknown_shape = session_tf.run(unknown_shape_tf, feed_dict=feed_dict)
+    
+    np.testing.assert_allclose(known_shape, unknown_shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Also added a test to prevent future regressions.

This addresses the bug in both #734 and #725  .