### PR TITLE
remove from __future__ imports and add some copyright notes

### DIFF
--- a/gpflow/__init__.py
+++ b/gpflow/__init__.py
@@ -15,8 +15,6 @@
 
 # flake8: noqa
 
-from __future__ import absolute_import
-
 from ._version import __version__
 from ._settings import SETTINGS as settings
 

--- a/gpflow/expectations.py
+++ b/gpflow/expectations.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import functools
 import warnings

--- a/gpflow/features.py
+++ b/gpflow/features.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 from abc import abstractmethod
 from functools import singledispatch

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-from __future__ import print_function, absolute_import
 from functools import reduce
 import warnings
 

--- a/gpflow/likelihoods.py
+++ b/gpflow/likelihoods.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 
-from __future__ import absolute_import
-
 import tensorflow as tf
 import numpy as np
 

--- a/gpflow/models/gplvm.py
+++ b/gpflow/models/gplvm.py
@@ -1,3 +1,17 @@
+# Copyright 2016 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import tensorflow as tf
 import numpy as np
 

--- a/gpflow/models/gpr.py
+++ b/gpflow/models/gpr.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-from __future__ import absolute_import
 import tensorflow as tf
 
 from .. import likelihoods

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, absolute_import
-
 import abc
 
 import numpy as np

--- a/gpflow/models/sgpr.py
+++ b/gpflow/models/sgpr.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-from __future__ import absolute_import
 import tensorflow as tf
 import numpy as np
 

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-from __future__ import absolute_import
 import tensorflow as tf
 import numpy as np
 

--- a/gpflow/models/vgp.py
+++ b/gpflow/models/vgp.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 import tensorflow as tf
 import numpy as np
 

--- a/gpflow/params/__init__.py
+++ b/gpflow/params/__init__.py
@@ -14,8 +14,6 @@
 
 # flake8: noqa
 
-from __future__ import absolute_import
-
 from .parameter import Parameter
 from .dataholders import DataHolder
 from .dataholders import Minibatch

--- a/gpflow/priors.py
+++ b/gpflow/priors.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-from __future__ import absolute_import
 import tensorflow as tf
 import numpy as np
 

--- a/gpflow/probability_distributions.py
+++ b/gpflow/probability_distributions.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 # Eventually, it would be nice to not have to have our own classes for
 # proability distributions. The TensorFlow "distributions" framework would

--- a/gpflow/quadrature.py
+++ b/gpflow/quadrature.py
@@ -1,4 +1,16 @@
-from __future__ import print_function, absolute_import
+# Copyright 2017-2018 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import itertools
 from collections import Iterable

--- a/gpflow/transforms.py
+++ b/gpflow/transforms.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import numpy as np
 import tensorflow as tf
 import itertools

--- a/tests/test_autoflow.py
+++ b/tests/test_autoflow.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 

--- a/tests/test_conditionals.py
+++ b/tests/test_conditionals.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 
 # pylint: disable=W0212

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 

--- a/tests/test_coregion.py
+++ b/tests/test_coregion.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 import numpy as np

--- a/tests/test_data_object.py
+++ b/tests/test_data_object.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 

--- a/tests/test_dataholders.py
+++ b/tests/test_dataholders.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 import numpy as np

--- a/tests/test_expectations.py
+++ b/tests/test_expectations.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import numpy as np
 import tensorflow as tf

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import numpy as np
 import tensorflow as tf

--- a/tests/test_gplvm.py
+++ b/tests/test_gplvm.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 import numpy as np

--- a/tests/test_hmc.py
+++ b/tests/test_hmc.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 

--- a/tests/test_kerns.py
+++ b/tests/test_kerns.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 

--- a/tests/test_kldiv.py
+++ b/tests/test_kldiv.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 # -*- coding: utf-8 -*-
 

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import six
 import tensorflow as tf

--- a/tests/test_logdensities.py
+++ b/tests/test_logdensities.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import numpy as np
 from numpy.random import randn

--- a/tests/test_mean_functions.py
+++ b/tests/test_mean_functions.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import itertools
 import tensorflow as tf

--- a/tests/test_method_equivalence.py
+++ b/tests/test_method_equivalence.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 import numpy as np

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import traceback
 import sys

--- a/tests/test_param.py
+++ b/tests/test_param.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 # pylint: disable=E1123
 

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 import numpy as np

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import glob
 import os

--- a/tests/test_quadrature.py
+++ b/tests/test_quadrature.py
@@ -1,3 +1,17 @@
+# Copyright 2018 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import pytest
 import tensorflow as tf

--- a/tests/test_saver.py
+++ b/tests/test_saver.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import copy
 import os

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 
 # pylint: disable=W0212

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import warnings
 import tensorflow as tf

--- a/tests/test_triang.py
+++ b/tests/test_triang.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 

--- a/tests/test_uncertain_conditional.py
+++ b/tests/test_uncertain_conditional.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 from collections import namedtuple
 

--- a/tests/test_variational.py
+++ b/tests/test_variational.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from __future__ import print_function
+# limitations under the License.
 
 import tensorflow as tf
 


### PR DESCRIPTION
With support for python2 dropped, we can remove the `from __future__ import ...` lines.
There were also some that had ended up in the copyright notes.
I also added copyright note to a few files.