### PR TITLE
quickfix for bug with params_as_tensors_for

### DIFF
--- a/gpflow/decors.py
+++ b/gpflow/decors.py
@@ -135,6 +135,7 @@ def params_as_tensors_for(*objs, convert=True):
     :param convert: Flag which is used for turning tensor convertion
         feature on, `True`, or turning it off, `False`.
     """
+    objs = set(objs)  # remove duplicate objects so the tensor mode won't be changed before saving
     prev_values = [_params_as_tensors_enter(o, convert) for o in objs]
     try:
         yield


### PR DESCRIPTION
`with params_as_tensors_for(obj1, obj1):` did not return obj1 to its original state. This fixes the bug.