### PR TITLE
updating readthedocs link in readme to point at master

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The full list of [contributors](http://github.com/GPflow/GPflow/graphs/contribut
 
 [![Python3.5 Status](https://travis-ci.org/GPflow/GPflow.svg?branch=master)](https://travis-ci.org/GPflow/GPflow)
 [![Coverage Status](http://codecov.io/github/GPflow/GPflow/coverage.svg?branch=master)](http://codecov.io/github/GPflow/GPflow?branch=master)
-[![Documentation Status](https://readthedocs.org/projects/gpflow/badge/?version=master)](http://gpflow.readthedocs.io/en/latest/?badge=master)
+[![Documentation Status](https://readthedocs.org/projects/gpflow/badge/?version=master)](http://gpflow.readthedocs.io/en/master/?badge=master)
 
 ## What does GPflow do?
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The full list of [contributors](http://github.com/GPflow/GPflow/graphs/contribut
 
 [![Python3.5 Status](https://travis-ci.org/GPflow/GPflow.svg?branch=master)](https://travis-ci.org/GPflow/GPflow)
 [![Coverage Status](http://codecov.io/github/GPflow/GPflow/coverage.svg?branch=master)](http://codecov.io/github/GPflow/GPflow?branch=master)
-[![Documentation Status](https://readthedocs.org/projects/gpflow/badge/?version=latest)](http://gpflow.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/gpflow/badge/?version=master)](http://gpflow.readthedocs.io/en/latest/?badge=master)
 
 ## What does GPflow do?
 


### PR DESCRIPTION


* [Title] Change readthedocs to point at master
* [Description] the link to the docs from the readme page should point at the master version of the docs
* [Minimal working example] n/a

