### PR TITLE
Mitigate ScipyOptimizer graph expansion by initializing optimize_tensor only once

### DIFF
--- a/gpflow/training/scipy_optimizer.py
+++ b/gpflow/training/scipy_optimizer.py
@@ -80,11 +80,11 @@ class ScipyOptimizer(optimizer.Optimizer):
 
         session = model.enquire_session(session)
         self._model = model
-        optimizer = self.make_optimize_tensor(model, session,
-            var_list=var_list, maxiter=maxiter, disp=disp)
-        self._optimizer = optimizer
+        if initialize or self._optimizer is None:
+            self._optimizer = self.make_optimize_tensor(model, session,
+                      var_list=var_list, maxiter=maxiter, disp=disp)
         feed_dict = self._gen_feed_dict(model, feed_dict)
-        optimizer.minimize(session=session, feed_dict=feed_dict, **kwargs)
+        self._optimizer.minimize(session=session, feed_dict=feed_dict, **kwargs)
         if anchor:
             model.anchor(session)
 


### PR DESCRIPTION
# Mitigate graph expansion by initializing optimize_tensor only once

## Description
While investigating the cause of #756 , we found that the primary suspect of the slow down is expanding computation graph which grows by ~380 operations on every run of `optimizer.minimize()`. The cause of the expansion is a repeated instantiation of the optimize_tensor on every `minimize()` call even if the `ScipyOptimizer` instance is not recreated.
By creating a new optimize_tensor instance only once (and then on demand) as in the actions framework examples, the graph grows only by 11 operations on each run. While this does not fix the problem described in #756 completely, it mitigates it substantially.

## Minimal example
Using a modified example from #756 with a seed for reproducibility
```
import gpflow
import numpy as np

opt = gpflow.train.ScipyOptimizer()
mean = gpflow.mean_functions.Constant()
k = gpflow.kernels.Matern52(1) 

np.random.seed(42)
x = np.atleast_2d(np.random.rand(100))
y = np.atleast_2d(np.random.rand(100))

m = gpflow.models.GPR(x, y, kern=k, mean_function=mean)

def optimize(iterations):
    for i in range(iterations):
        opt.minimize(m)
    return

%time optimize(100)
```

Before the change, the computation takes ~4 minutes. After the change, it takes ~10 seconds to finish while reaching the same objective.

### Disclaimer
The loop above is meant only to showcase the slow down of repeated computations, not as the primary use case of repeated calls of the `optimizer.minimize()` function. The use case of running the `minimize()` function repeatedly can range from reusing the same model with different data to loading a saved model and running further optimization.