### PR TITLE
Add logger to settings

### DIFF
--- a/gpflow/_settings.py
+++ b/gpflow/_settings.py
@@ -92,11 +92,12 @@ class _SettingsManager(object):
         return self.logging.level
 
     def logger(self):
-        frm = inspect.stack()[1]
-        mod = inspect.getmodule(frm[0])  # calling module
-        level = getattr(logging, self.logging.level)
-        logging.basicConfig(level=level)
-        return logging.getLogger(mod.__name__)
+        frame = inspect.currentframe().f_back
+        module = inspect.getmodule(frame)
+        level = logging.getLevelName(self.logging.level)
+        log = logging.getLogger(module.__name__)
+        log.setLevel(level)
+        return log
 
 
 class _MutableNamedTuple(OrderedDict):

--- a/gpflow/_settings.py
+++ b/gpflow/_settings.py
@@ -95,6 +95,7 @@ class _SettingsManager(object):
         frame = inspect.currentframe().f_back
         module = inspect.getmodule(frame)
         level = logging.getLevelName(self.logging.level)
+        logging.basicConfig()
         log = logging.getLogger(module.__name__)
         log.setLevel(level)
         return log

--- a/gpflow/_settings.py
+++ b/gpflow/_settings.py
@@ -94,9 +94,10 @@ class _SettingsManager(object):
     def logger(self):
         frame = inspect.currentframe().f_back
         module = inspect.getmodule(frame)
+        name = 'gpflow' if module is None else module.__name__
         level = logging.getLevelName(self.logging.level)
         logging.basicConfig()
-        log = logging.getLogger(module.__name__)
+        log = logging.getLogger(name)
         log.setLevel(level)
         return log
 

--- a/gpflow/_settings.py
+++ b/gpflow/_settings.py
@@ -2,12 +2,15 @@ import os
 import copy
 import collections
 import warnings
+import logging
+import inspect
 
 from collections import OrderedDict
 from six.moves import configparser
 
 import numpy as np
 import tensorflow as tf
+
 
 
 class _SettingsContextManager(object):
@@ -83,6 +86,17 @@ class _SettingsManager(object):
     @property
     def int_type(self):
         return self.dtypes.int_type
+
+    @property
+    def logging_level(self):
+        return self.logging.level
+
+    def logger(self):
+        frm = inspect.stack()[1]
+        mod = inspect.getmodule(frm[0])  # calling module
+        level = getattr(logging, self.logging.level)
+        logging.basicConfig(level=level)
+        return logging.getLogger(mod.__name__)
 
 
 class _MutableNamedTuple(OrderedDict):

--- a/gpflow/gpflowrc
+++ b/gpflow/gpflowrc
@@ -1,3 +1,7 @@
+[logging]
+# possible levels: CRITICAL, ERROR, WARNING, INFO, DEBUG, NOSET
+level = INFO
+
 [verbosity]
 tf_compile_verb = False
 hmc_verb = True

--- a/gpflow/gpflowrc
+++ b/gpflow/gpflowrc
@@ -1,6 +1,6 @@
 [logging]
 # possible levels: CRITICAL, ERROR, WARNING, INFO, DEBUG, NOSET
-level = INFO
+level = WARNING
 
 [verbosity]
 tf_compile_verb = False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@
 import os
 import numpy as np
 import tensorflow as tf
+import logging
 
 import gpflow
 from gpflow.test_util import GPflowTestCase
@@ -111,6 +112,7 @@ class TestSettingsManager(GPflowTestCase):
             _ = s.np_float
         with self.assertWarns(DeprecationWarning):
             _ = s.np_int
+    
 
     def testMutability(self):
         orig = gpflow.settings.verbosity.hmc_verb
@@ -130,6 +132,20 @@ class TestSettingsManager(GPflowTestCase):
             self.assertEqual(gpflow.settings.verbosity.hmc_verb, False)
         self.assertEqual(gpflow.settings.verbosity.hmc_verb, True)
         gpflow.settings.verbosity.hmc_verb = orig
+
+def test_logging():
+    def level_name(log):
+        return logging.getLevelName(log.level)
+
+    warning = 'WARNING'
+    assert gpflow.settings.logging_level == warning
+    logger = gpflow.settings.logger()
+    assert level_name(logger) == warning
+
+    debug = 'DEBUG'
+    gpflow.settings.logging.level = debug
+    logger = gpflow.settings.logger()
+    assert level_name(logger) == debug
 
 
 if __name__ == '__main__':

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,13 +15,15 @@
 
 # pylint: disable=W0212
 
-import os
-import numpy as np
-import tensorflow as tf
+import inspect
 import logging
+import os
 
 import gpflow
+import numpy as np
+import tensorflow as tf
 from gpflow.test_util import GPflowTestCase
+
 
 CONFIG_TXT = """
 [first_section]
@@ -112,7 +114,6 @@ class TestSettingsManager(GPflowTestCase):
             _ = s.np_float
         with self.assertWarns(DeprecationWarning):
             _ = s.np_int
-    
 
     def testMutability(self):
         orig = gpflow.settings.verbosity.hmc_verb
@@ -146,6 +147,8 @@ def test_logging():
     gpflow.settings.logging.level = debug
     logger = gpflow.settings.logger()
     assert level_name(logger) == debug
+    module_name = inspect.getmodule(inspect.currentframe()).__name__
+    assert logger.name == module_name
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Logging capabilities

Recently, we needed to inform a user about specific functions being called inside GPflow.
For example, in the expectations framework when quadrature is used and in the multi-output framework to indicate which conditional is used.
We did this using simple print-statements, but this isn't a good practice.
This PR adds a standard Python `logger` to GPflow which can be used for these use-cases.

### Minimal working example

```python
from gpflow import settings
logger = settings.logger()
...
logger.debug("Quadrature is used to calculate the kernel expectation for Matern-1/2")
...
```

The debugging level `(CRITICAL, WARNING, INFO, etc.)` is set in the RC-file and can be changed to a one's needs.

