### PR TITLE
Likelihood/students t variance scaling

### DIFF
--- a/gpflow/likelihoods.py
+++ b/gpflow/likelihoods.py
@@ -219,7 +219,7 @@ class StudentT(Likelihood):
 
     @params_as_tensors
     def conditional_variance(self, F):
-        return F * 0.0 + (self.deg_free / (self.deg_free - 2.0))
+        return F * 0.0 + self.scale**2 * (self.deg_free / (self.deg_free - 2.0))
 
 
 def probit(x):

--- a/gpflow/likelihoods.py
+++ b/gpflow/likelihoods.py
@@ -207,7 +207,8 @@ class StudentT(Likelihood):
     def __init__(self, deg_free=3.0):
         Likelihood.__init__(self)
         self.deg_free = deg_free
-        self.scale = Parameter(1.0, transform=transforms.positive)
+        self.scale = Parameter(1.0, transform=transforms.positive,
+            dtype=settings.float_type)
 
     @params_as_tensors
     def logp(self, F, Y):
@@ -219,7 +220,8 @@ class StudentT(Likelihood):
 
     @params_as_tensors
     def conditional_variance(self, F):
-        return F * 0.0 + self.scale**2 * (self.deg_free / (self.deg_free - 2.0))
+        var = self.scale**2 * (self.deg_free / (self.deg_free - 2.0))
+        return tf.fill(tf.shape(F), tf.squeeze(var))
 
 
 def probit(x):


### PR DESCRIPTION
### Student's T Distribution: Scaling in `condtional_variance` method

#### Description
The current implementation of the `conditional_variance` method for the `StudentT` class in `likelihoods.py` is independent of the `scale` parameter, when it should be proportional to the `scale` parameter squared. See [here](https://en.wikipedia.org/wiki/Student%27s_t-distribution#In_terms_of_scaling_parameter_σ,_or_σ2).

The **bug is fixed** by multiplying the current formula by the `scale` parameter squared.

This **bug** results in erroneous variations being predicted by a model using the `StudentT` likelihood.

#### Minimal working example

```
import tensorflow as tf
import gpflow

l = gpflow.likelihoods.StudentT(3.0)
scales = range(1,5)
F = tf.constant(0.)
with tf.Session() as sess:
    for s in scales:
        l.scale = s
        l.compile()
        var = sess.run(l.conditional_variance(F))
        print('Scale = {0}, Var. = {1}'.format(s, var))
```

**Before:**
Scale = 1, Var. = 3.0
Scale = 2, Var. = 3.0
Scale = 3, Var. = 3.0
Scale = 4, Var. = 3.0

**After:**
Scale = 1, Var. = 3.0
Scale = 2, Var. = 12.0
Scale = 3, Var. = 27.0
Scale = 4, Var. = 48.0
