### PR TITLE
Support Python 3.5.2 in typing checks (Ubuntu 16.04 default python3)

### DIFF
--- a/gpflow/saver/coders.py
+++ b/gpflow/saver/coders.py
@@ -717,6 +717,6 @@ def _convert_to_string(value: Union[AnyStr, np.ndarray]):
 
 def _get_type_args(union_type):
     if hasattr(union_type, '__args__'):
-        return type_object.__args__
+        return union_type.__args__
     if hasattr(union_type, '__union_params__'):
-        return type_object.__union_params__
+        return union_type.__union_params__

--- a/gpflow/saver/coders.py
+++ b/gpflow/saver/coders.py
@@ -134,7 +134,7 @@ class PrimitiveTypeCoder(BaseCoder):
 
     @classmethod
     def _types(cls):
-        return PrimitiveType.__args__
+        return _get_type_args(PrimitiveType)
 
 
 class TensorFlowCoder(BaseCoder):
@@ -143,7 +143,7 @@ class TensorFlowCoder(BaseCoder):
 
     @classmethod
     def support_encoding(cls, item):
-        supported_types = TensorType.__args__
+        supported_types = _get_type_args(TensorType)
         return isinstance(item, supported_types)
 
     @classmethod
@@ -713,3 +713,10 @@ def _convert_to_string(value: Union[AnyStr, np.ndarray]):
     if isinstance(value, np.ndarray):
         value = np.string_(value)
     return value.decode('utf-8')
+
+
+def _get_type_args(union_type):
+    if hasattr(union_type, '__args__'):
+        return type_object.__args__
+    if hasattr(union_type, '__union_params__'):
+        return type_object.__union_params__


### PR DESCRIPTION
# Support Python 3.5.2 in typing checks

## Description

The model `gpflow/saver/coder.py` makes use of the private API for the `typing` module, and due to internal changes the current code does not support Python 3.5.2 (the default python3 for Ubuntu 16.04 LTS). This change adds support for the private API for Python 3.5.2 as well as Python 3.5.3+