### PR TITLE
Fix failing unittest under TensorFlow 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 
 install:
   - pip install numpy scipy pandas pytest nbformat nbconvert jupyter_client jupyter matplotlib pytest-xdist pytest-cov codecov multipledispatch
-  - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.6.0-cp36-cp36m-linux_x86_64.whl
+  - pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp36-cp36m-linux_x86_64.whl
   - python setup.py install
 
 script:

--- a/tests/test_saver.py
+++ b/tests/test_saver.py
@@ -174,14 +174,13 @@ def test_loading_without_autocompile(session_tf, filename, model):
 
 
 def test_loading_into_specific_session(session_tf, filename, model):
-    gp.Saver().save(filename, model)
-    with session_context() as session:
-        pass
-    context = gp.SaverContext(session=session)
-    loaded = gp.Saver().load(filename, context=context)
     x_new = Data.x_new()
     predict_origin = model.predict_f(x_new)
-    predict_loaded = loaded.predict_f(x_new, session=session)
+    gp.Saver().save(filename, model)
+    with session_context() as session:
+        context = gp.SaverContext(session=session)
+        loaded = gp.Saver().load(filename, context=context)
+        predict_loaded = loaded.predict_f(x_new, session=session)
     assert_allclose(predict_origin, predict_loaded)
 
 


### PR DESCRIPTION
# GPFlow with TensorFlow 1.8

## Description

The current unit tests failed under TensorFlow 1.8. This PR fixes this and makes GPFlow compatible with the latest TensorFlow release. @awav @markvdw on travis TF1.6 is still used, shouldn't we switch to the latest version?

### System
- TensorFlow 1.8
- Python **3.6.5**
