### PR TITLE
Optimizer's callback accept step number.

### DIFF
--- a/gpflow/training/natgrad_optimizer.py
+++ b/gpflow/training/natgrad_optimizer.py
@@ -66,10 +66,8 @@ class NatGradOptimizer(optimizer.Optimizer):
             :param anchor: Synchronize updated parameters for a session with internal
                 parameter's values.
             :param step_callback: A callback function to execute at each optimization step.
-                The function should accept variable argument list. Currently the function is called
-                with no arguments but this may change in the future. For instance the values of
-                trainable variables may be provided.
-            :type step_callback: Callable[[], None]
+                Callback accepts an optimization step number as a first argument.
+            :type step_callback: Callable[[int], None]
             :param kwargs: Extra parameters passed to session run's method.
         """
 
@@ -80,10 +78,10 @@ class NatGradOptimizer(optimizer.Optimizer):
         session = model.enquire_session(session)
         opt = self.make_optimize_action(model, session=session, var_list=var_list, **kwargs)
         with session.as_default():
-            for _i in range(maxiter):
-                result = opt()
+            for step in range(maxiter):
+                opt()
                 if step_callback is not None:
-                    step_callback(result)
+                    step_callback(step)
         if anchor:
             model.anchor(session)
 

--- a/gpflow/training/natgrad_optimizer.py
+++ b/gpflow/training/natgrad_optimizer.py
@@ -66,8 +66,9 @@ class NatGradOptimizer(optimizer.Optimizer):
             :param anchor: Synchronize updated parameters for a session with internal
                 parameter's values.
             :param step_callback: A callback function to execute at each optimization step.
-                Callback accepts an optimization step number as a first argument.
-            :type step_callback: Callable[[int], None]
+                The callback should accept variable argument list, where first argument is
+                optimization step number.
+            :type step_callback: Callable[[], None]
             :param kwargs: Extra parameters passed to session run's method.
         """
 

--- a/gpflow/training/optimizer.py
+++ b/gpflow/training/optimizer.py
@@ -49,9 +49,8 @@ class Optimizer:
         :param anchor: If `True` trained variable values computed during optimization at
             particular session will be synchronized with internal parameter values.
         :param step_callback: A callback function to execute at each optimization step.
-            It must take an arbitrary list of arguments. The optimiser may pass to the callback
-            function some data it thinks might be of interest to the calling code. For instance,
-            this can be the current values of trainable variables.
+            Callback takes an arbitrary list of arguments. Input arguments depend on
+            interface implementation.
         :param kwargs: This is a dictionary of extra parameters for session run method.
 
         """

--- a/gpflow/training/scipy_optimizer.py
+++ b/gpflow/training/scipy_optimizer.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..core.errors import GPflowError
+from . import external_optimizer, optimizer
 from ..core.compilable import Build
+from ..core.errors import GPflowError
 from ..models.model import Model
-
-from . import optimizer
-from . import external_optimizer
 
 
 class ScipyOptimizer(optimizer.Optimizer):
@@ -72,7 +70,7 @@ class ScipyOptimizer(optimizer.Optimizer):
         :param step_callback: A function to be called at each optimization step;
             arguments are the current values of all optimization variables
             flattened into a single vector.
-        :type step_callback: Callable[[ndarray], None]
+        :type step_callback: Callable[[np.ndarray], None]
         :param kwargs: This is a dictionary of extra parameters for session run method.
         """
         if model is None or not isinstance(model, Model):

--- a/gpflow/training/tensorflow_optimizer.py
+++ b/gpflow/training/tensorflow_optimizer.py
@@ -96,8 +96,9 @@ class _TensorFlowOptimizer(optimizer.Optimizer):
         :param anchor: If `True` trained variable values computed during optimization at
             particular session will be synchronized with internal parameter values.
         :param step_callback: A callback function to execute at each optimization step.
-            Callback accepts an optimization step number as a first argument.
-        :type step_callback: Callable[[int], None]
+            The callback should accept variable argument list, where first argument is
+            optimization step number.
+        :type step_callback: Callable[[], None]
         :param kwargs: This is a dictionary of extra parameters for session run method.
         """
 

--- a/gpflow/training/tensorflow_optimizer.py
+++ b/gpflow/training/tensorflow_optimizer.py
@@ -95,11 +95,9 @@ class _TensorFlowOptimizer(optimizer.Optimizer):
             initialized before for gotten session.
         :param anchor: If `True` trained variable values computed during optimization at
             particular session will be synchronized with internal parameter values.
-        :param step_callback: A callback function to execute at each optimization step. The
-            function should accept variable argument list. Currently the function is called with
-            no arguments but this may change in the future. For instance the values of trainable
-            variables may be provided.
-        :type step_callback: Callable[[], None]
+        :param step_callback: A callback function to execute at each optimization step.
+            Callback accepts an optimization step number as a first argument.
+        :type step_callback: Callable[[int], None]
         :param kwargs: This is a dictionary of extra parameters for session run method.
         """
 
@@ -110,16 +108,16 @@ class _TensorFlowOptimizer(optimizer.Optimizer):
             session=session,
             var_list=var_list,
             feed_dict=feed_dict, **kwargs)
-        
+
         self._model = opt.model
         self._minimize_operation = opt.optimizer_tensor
-        
+
         session = model.enquire_session(session)
         with session.as_default():
-            for _ in range(maxiter):
-                result = opt()
+            for step in range(maxiter):
+                opt()
                 if step_callback is not None:
-                    step_callback(result)
+                    step_callback(step)
 
         if anchor:
             opt.model.anchor(session)


### PR DESCRIPTION
Hello everyone,

Reasons for this PR:

- `step_callback` docstring states that optimizer doesn't pass arguments to the function and function can have as many arguments as user wants including nil arguments, but an optimizer pass results of `session.run` operation to the `step_callback`, therefore causes failures. [update] Function must be with signature `fun(*args, **kwargs)`, but it is still confusing that nothing is passed into callback.
- Optimizer minimize returns tensorflow operation, which after running this tf.Operation though `session.run` returns `None`.
- It would be nice to expose step number to callback explicitly.

Thanks!