### PR TITLE
Fix bug in ndiag_mc re multi-dimensional kwargs

### DIFF
--- a/gpflow/quadrature.py
+++ b/gpflow/quadrature.py
@@ -182,10 +182,9 @@ def ndiag_mc(funcs, S: int, Fmu, Fvar, logspace: bool=False, epsilon=None, **Ys)
     mc_Xr = tf.reshape(mc_x, (S * N, D))
 
     for name, Y in Ys.items():
-        Y = tf.reshape(Y, (-1, 1))
-        mc_Yr = tf.tile(Y, [S, 1])  # broadcast Y to match X
-        # without the tiling, some calls such as tf.where() (in bernoulli) fail
-        Ys[name] = mc_Yr  # now S * N x 1
+        D_out = tf.shape(Y)[1]
+        mc_Yr = tf.tile(Y[None, ...], [S, 1, 1])  # S x N x P
+        Ys[name] = tf.reshape(mc_Yr, (S * N, D_out))  # S * N x P
 
     def eval_func(func):
         feval = func(mc_Xr, **Ys)

--- a/gpflow/quadrature.py
+++ b/gpflow/quadrature.py
@@ -183,8 +183,9 @@ def ndiag_mc(funcs, S: int, Fmu, Fvar, logspace: bool=False, epsilon=None, **Ys)
 
     for name, Y in Ys.items():
         D_out = tf.shape(Y)[1]
-        mc_Yr = tf.tile(Y[None, ...], [S, 1, 1])  # S x N x P
-        Ys[name] = tf.reshape(mc_Yr, (S * N, D_out))  # S * N x P
+        # we can't rely on broadcasting and need tiling
+        mc_Yr = tf.tile(Y[None, ...], [S, 1, 1])  # S x N x D_out
+        Ys[name] = tf.reshape(mc_Yr, (S * N, D_out))  # S * N x D_out
 
     def eval_func(func):
         feval = func(mc_Xr, **Ys)


### PR DESCRIPTION
# ndiag_mc bug fix

### Description
The current implementation of `ndiag_mc` didn't handle multi-dimensional kwargs `Ys` and failed accordingly. This hotfix-PR resolves the problem.

### MWE
This minimal example shows a possible use-case
```python
import tensorflow as tf
from gpflow.quadrature import ndiag_mc

N = 10
X_dim = 2
Z_dim = 2
Y_dim = 4

def func(Z, X=None, Y=None):
    XZ = tf.concat([X, Z], axis=1)  # N x (X_dim + Z_dim)
    return tf.reduce_sum(XZ - Y, axis=1)  # N x 1

Z_mu = tf.zeros((N, Z_dim), dtype=tf.float64)
Z_var = tf.ones((N, Z_dim), dtype=tf.float64)

X = tf.random_normal((N, X_dim), dtype=tf.float64)
Y = tf.random_normal((N, Y_dim), dtype=tf.float64)

Ez = ndiag_mc(func, 1000, Z_mu, Z_var, logspace=False, X=X, Y=Y)

print(tf.Session().run(Ez))
```
With the current implementation this fails:
```
ValueError: Dimension 0 in both shapes must be equal, but are 20000 and 10000. Shapes are [20000] and [10000]. for concat (op: ConcatV2) with input shapes: [20000,1], [10000,2], [] and with computed input tensors: input[2] = <1>
```
The PR fixes the problem.

