### PR TITLE
Parameter.trainable was not properly a property and Parameterized.trainable did not special-case DataHolders

### DIFF
--- a/gpflow/params/parameter.py
+++ b/gpflow/params/parameter.py
@@ -246,6 +246,14 @@ class Parameter(Node):
             return Build.NO
         return Build.YES
 
+    @property
+    def trainable(self):
+        return self._trainable
+
+    @trainable.setter
+    def trainable(self, value):
+        self.set_trainable(value)
+
     def set_trainable(self, value):
         if not isinstance(value, bool):
             raise ValueError('Fixed property value must be boolean.')
@@ -263,7 +271,7 @@ class Parameter(Node):
             else:
                 misc.remove_from_trainables(self.parameter_tensor, graph)
 
-        object.__setattr__(self, 'trainable', value)
+        self._trainable = value
 
     def assign(self, value, session=None, dtype=None, force=True):
         if self._externally_defined:

--- a/gpflow/params/parameterized.py
+++ b/gpflow/params/parameterized.py
@@ -196,8 +196,7 @@ class Parameterized(Node):
 
     @trainable.setter
     def trainable(self, value):
-        for param in self.params:
-            param.trainable = value
+        self.set_trainable(value)
 
     def fix_shape(self, parameters=True, data_holders=True):
         if parameters:


### PR DESCRIPTION
```python
sm = gpflow.models.SVGP(np.array([[1.0]]), np.array([[1.0]]), gpflow.kernels.RBF(1),
    gpflow.likelihoods.Gaussian(), np.array([[1.0]]),
    q_diag=False, whiten=False, minibatch_size=None)
sm.trainable = False  # does not work
sm.set_trainable(False)  # does work
```

The reason was that while in Parameterized, trainable was a property, this was not the case in Parameter. This is fixed by this PR.
Also, there was code duplication in Parameterized between trainable.setter and set_trainable(); in this PR, trainable.setter simply calls set_trainable.