### PR TITLE
Bugfix control dependencie in likelihoods

### DIFF
--- a/gpflow/likelihoods.py
+++ b/gpflow/likelihoods.py
@@ -53,7 +53,7 @@ class Likelihood(Parameterized):
 
         and the predictive variance
 
-           \int\int y^2 p(y|f)q(f) df dy  - [ \int\int y^2 p(y|f)q(f) df dy ]^2
+           \int\int y^2 p(y|f)q(f) df dy  - [ \int\int y p(y|f)q(f) df dy ]^2
 
         Here, we implement a default Gauss-Hermite quadrature routine, but some
         likelihoods (e.g. Gaussian) will implement specific cases.
@@ -616,7 +616,7 @@ class MonteCarloLikelihood(Likelihood):
 
         and the predictive variance
 
-           \int\int y^2 p(y|f)q(f) df dy  - [ \int\int y^2 p(y|f)q(f) df dy ]^2
+           \int\int y^2 p(y|f)q(f) df dy  - [ \int\int y p(y|f)q(f) df dy ]^2
 
         Here, we implement a default Monte Carlo routine.
         """

--- a/gpflow/likelihoods.py
+++ b/gpflow/likelihoods.py
@@ -685,8 +685,12 @@ class SoftMax(MonteCarloLikelihood):
         self.num_classes = num_classes
 
     def logp(self, F, Y):
-        with tf.control_dependencies([tf.assert_equal(tf.shape(Y)[1], 1),
-                                      tf.assert_equal(tf.shape(F)[1], self.num_classes)]):
+        with tf.control_dependencies(
+                [
+                    tf.assert_equal(tf.shape(Y)[1], 1),
+                    tf.assert_equal(tf.cast(tf.shape(F)[1], settings.int_type),
+                                    tf.cast(self.num_classes, settings.int_type))
+                ]):
             return -tf.nn.sparse_softmax_cross_entropy_with_logits(logits=F, labels=Y[:, 0])[:, None]
 
     def conditional_mean(self, F):


### PR DESCRIPTION
Hi all,

There is a bug in the current gpflow code re the saving and loading of models. 
The bug only occurs when the model has a softmax likelihood.

## Minimal failing example

```python
import numpy as np
import gpflow

N, Nc = 20, 10
X = np.random.randn(N, 5)
Y = np.random.randint(Nc, size=(N, 1))
like = gpflow.likelihoods.SoftMax(Nc)
kern = gpflow.kernels.RBF(5)

m = gpflow.models.SVGP(X, Y, kern, likelihood=like, Z=X.copy(), num_latent=Nc)

gpflow.Saver().save("model.gpf", m)
```
Close the session and reopen a new one
```python
import gpflow

m = gpflow.Saver().load("model.gpf")  # CRASHES
```

This breaks with:
```
Input 'y' of 'Equal' Op has type int64 that does not match type int32 of argument 'x'
```

The problem is that the type of tf.shape and self.num_classes in the softmax likelihood is different and as a result an assert failes. This PR fixes the problem.

## Also,
There was a minor (math) typo in the docstrings of `predit_mean_and_var`, which has now been corrected.
