### PR TITLE
Adding widedeepnetworks repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A few projects building on GPflow and demonstrating its usage are listed below.
 | [Doubly-Stochastic-DGP](https://github.com/ICL-SML/Doubly-Stochastic-DGP)| Deep Gaussian Processes with Doubly Stochastic Variational Inference.|
 | [BranchedGP](https://github.com/ManchesterBioinference/BranchedGP) | Gaussian processes with branching kernels.|
 | [gpflow-monitor](https://github.com/markvdw/gpflow-monitor) | Tools for monitoring and checkpoining optimisation. |
-| [widedeepnetworks](https://github.com/widedeepnetworks/widedeepnetworks) | Measuring the relationship between random wide deep neural networks and GPs. 
+| [widedeepnetworks](https://github.com/widedeepnetworks/widedeepnetworks) | Measuring the relationship between random wide deep neural networks and GPs.| 
 
 Let us know if you would like your project listed here.
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A few projects building on GPflow and demonstrating its usage are listed below.
 | [Doubly-Stochastic-DGP](https://github.com/ICL-SML/Doubly-Stochastic-DGP)| Deep Gaussian Processes with Doubly Stochastic Variational Inference.|
 | [BranchedGP](https://github.com/ManchesterBioinference/BranchedGP) | Gaussian processes with branching kernels.|
 | [gpflow-monitor](https://github.com/markvdw/gpflow-monitor) | Tools for monitoring and checkpoining optimisation. |
+| [widedeepnetworks](https://github.com/widedeepnetworks/widedeepnetworks) | Measuring the relationship between random wide deep neural networks and GPs. 
 
 Let us know if you would like your project listed here.
 


### PR DESCRIPTION
I implemented the deep arcosine kernel in the code that accompanies this paper using GPflow:

https://arxiv.org/abs/1804.11271

I've added a link to the README of the project. 

Particular effort has gone into numerical stability, which allowed us to backpropagate. 

The code uses an old version of GPflow, has only basic unit test framework and would probably benefit from an option to use multiple parameters. That said it is still useful to link it in my opinion. 