### PR TITLE
Separate K_r and K_r2 for stationary kernels

### DIFF
--- a/gpflow/conditionals.py
+++ b/gpflow/conditionals.py
@@ -133,11 +133,11 @@ def _conditional(Xnew, X, kern, f, *, full_cov=False, q_sqrt=None, white=False):
 @name_scope("sample_conditional")
 def _sample_conditional(Xnew, feat, kern, f, *, full_output_cov=False, q_sqrt=None, white=False):
     """
-    `sample_conditional` will return a sample from the conditinoal distribution.
+    `sample_conditional` will return a sample from the conditional distribution.
     In most cases this means calculating the conditional mean m and variance v and then
     returning m + sqrt(v) * eps, with eps ~ N(0, 1).
     However, for some combinations of Mok and Mof more efficient sampling routines exists.
-    The dispatcher will make sure that we use the most efficent one.
+    The dispatcher will make sure that we use the most efficient one.
 
     :return: N x P (full_output_cov = False) or N x P x P (full_output_cov = True)
     """

--- a/gpflow/expectations.py
+++ b/gpflow/expectations.py
@@ -413,7 +413,7 @@ def _expectation(p, kern1, feat1, kern2, feat2, nghp=None):
 
         # Compute sqrt(self.K(Z)) explicitly to prevent automatic gradient from
         # being NaN sometimes, see pull request #615
-        kernel_sqrt = tf.exp(-0.25 * kern.square_dist(Z, None))
+        kernel_sqrt = tf.exp(-0.25 * kern.scaled_square_dist(Z, None))
         return kern.variance ** 2 * kernel_sqrt * \
                tf.reshape(dets, [N, 1, 1]) * exponent_mahalanobis
 

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -306,7 +306,7 @@ class Stationary(Kernel):
     def k_r2(self, r2):
         """
         Returns the kernel evaluated on `r2`, which is the scaled squared distance.
-        Will call k_r(r=sqrt(r2)), or can be overwritten directly.
+        Will call self.k_r(r=sqrt(r2)), or can be overwritten directly.
         """
         r = self._clipped_sqrt(r2)
         return self.k_r(r)

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -292,6 +292,15 @@ class Stationary(Kernel):
 
     @params_as_tensors
     def K(self, X, X2=None, presliced=False):
+        """
+        Calculates the kernel matrix K(X, X2) (or K(X, X) if X2 is None).
+        Handles the slicing as well as scaling and computes k(x, x') = k(r),
+        where r² = ((x - x')/lengthscales)².
+        Internally, this calls self.k_r2(r²), which in turn computes the
+        square-root and calls self.k_r(r). Classes implementing stationary
+        kernels can either overwrite `k_r2(r2)` if they only depend on the
+        squared distance, or `k_r(r)` if they need the actual radial distance.
+        """
         if not presliced:
             X, X2 = self._slice(X, X2)
         return self.k_r2(self.scaled_square_dist(X, X2))

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -294,7 +294,7 @@ class Stationary(Kernel):
     def K(self, X, X2=None, presliced=False):
         if not presliced:
             X, X2 = self._slice(X, X2)
-        return self.Kr(self.scaled_euclid_dist(X, X2))
+        return self.k_r2(self.scaled_square_dist(X, X2))
 
     @params_as_tensors
     def k_r(self, r):

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -296,30 +296,30 @@ class Stationary(Kernel):
         Calculates the kernel matrix K(X, X2) (or K(X, X) if X2 is None).
         Handles the slicing as well as scaling and computes k(x, x') = k(r),
         where r² = ((x - x')/lengthscales)².
-        Internally, this calls self.k_r2(r²), which in turn computes the
-        square-root and calls self.k_r(r). Classes implementing stationary
-        kernels can either overwrite `k_r2(r2)` if they only depend on the
-        squared distance, or `k_r(r)` if they need the actual radial distance.
+        Internally, this calls self.K_r2(r²), which in turn computes the
+        square-root and calls self.K_r(r). Classes implementing stationary
+        kernels can either overwrite `K_r2(r2)` if they only depend on the
+        squared distance, or `K_r(r)` if they need the actual radial distance.
         """
         if not presliced:
             X, X2 = self._slice(X, X2)
-        return self.k_r2(self.scaled_square_dist(X, X2))
+        return self.K_r2(self.scaled_square_dist(X, X2))
 
     @params_as_tensors
-    def k_r(self, r):
+    def K_r(self, r):
         """
         Returns the kernel evaluated on `r`, which is the scaled Euclidean distance
         Should operate element-wise on r
         """
         raise NotImplementedError
 
-    def k_r2(self, r2):
+    def K_r2(self, r2):
         """
         Returns the kernel evaluated on `r2`, which is the scaled squared distance.
-        Will call self.k_r(r=sqrt(r2)), or can be overwritten directly (and should operate element-wise on r2).
+        Will call self.K_r(r=sqrt(r2)), or can be overwritten directly (and should operate element-wise on r2).
         """
         r = self._clipped_sqrt(r2)
-        return self.k_r(r)
+        return self.K_r(r)
 
 
 class SquaredExponential(Stationary):
@@ -328,7 +328,7 @@ class SquaredExponential(Stationary):
     """
 
     @params_as_tensors
-    def k_r2(self, r2):
+    def K_r2(self, r2):
         return self.variance * tf.exp(-r2 / 2.)
 
 RBF = SquaredExponential
@@ -354,7 +354,7 @@ class RationalQuadratic(Stationary):
                                dtype=settings.float_type)
 
     @params_as_tensors
-    def k_r2(self, r2):
+    def K_r2(self, r2):
         return self.variance * (1 + r2 / (2 * self.alpha)) ** (- self.alpha)
 
 
@@ -434,7 +434,7 @@ class Exponential(Stationary):
     """
 
     @params_as_tensors
-    def k_r(self, r):
+    def K_r(self, r):
         return self.variance * tf.exp(-0.5 * r)
 
 
@@ -444,7 +444,7 @@ class Matern12(Stationary):
     """
 
     @params_as_tensors
-    def k_r(self, r):
+    def K_r(self, r):
         return self.variance * tf.exp(-r)
 
 
@@ -454,7 +454,7 @@ class Matern32(Stationary):
     """
 
     @params_as_tensors
-    def k_r(self, r):
+    def K_r(self, r):
         sqrt3 = np.sqrt(3.)
         return self.variance * (1. + sqrt3 * r) * tf.exp(-sqrt3 * r)
 
@@ -465,7 +465,7 @@ class Matern52(Stationary):
     """
 
     @params_as_tensors
-    def k_r(self, r):
+    def K_r(self, r):
         sqrt5 = np.sqrt(5.)
         return self.variance * (1.0 + sqrt5 * r + 5. / 3. * tf.square(r)) * tf.exp(-sqrt5 * r)
 
@@ -476,7 +476,7 @@ class Cosine(Stationary):
     """
 
     @params_as_tensors
-    def k_r(self, r):
+    def K_r(self, r):
         return self.variance * tf.cos(r)
 
 

--- a/gpflow/kernels.py
+++ b/gpflow/kernels.py
@@ -309,13 +309,14 @@ class Stationary(Kernel):
     def k_r(self, r):
         """
         Returns the kernel evaluated on `r`, which is the scaled Euclidean distance
+        Should operate element-wise on r
         """
         raise NotImplementedError
 
     def k_r2(self, r2):
         """
         Returns the kernel evaluated on `r2`, which is the scaled squared distance.
-        Will call self.k_r(r=sqrt(r2)), or can be overwritten directly.
+        Will call self.k_r(r=sqrt(r2)), or can be overwritten directly (and should operate element-wise on r2).
         """
         r = self._clipped_sqrt(r2)
         return self.k_r(r)


### PR DESCRIPTION
Some stationary kernels are based on the squared radial distance, others need the radial distance itself. This allows both to be implemented as naturally as possible while avoiding the inefficiency of square(sqrt(r2)).