### PR TITLE
Added MixedKernelSeparateMof

### DIFF
--- a/doc/source/notebooks/multioutput.ipynb
+++ b/doc/source/notebooks/multioutput.ipynb
@@ -85,7 +85,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:58:45.195606Z",
      "start_time": "2018-06-19T10:58:44.172232Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -109,7 +110,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:58:46.500202Z",
      "start_time": "2018-06-19T10:58:46.486870Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -136,7 +138,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:58:48.106040Z",
      "start_time": "2018-06-19T10:58:48.092379Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -172,7 +175,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:58:48.863635Z",
      "start_time": "2018-06-19T10:58:48.766655Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -287,7 +291,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:58:53.293025Z",
      "start_time": "2018-06-19T10:58:53.290410Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -349,7 +354,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:58:58.849062Z",
      "start_time": "2018-06-19T10:58:58.840498Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -363,7 +369,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:58:59.599039Z",
      "start_time": "2018-06-19T10:58:59.546311Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -489,7 +496,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:59:09.467172Z",
      "start_time": "2018-06-19T10:59:09.459302Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -503,7 +511,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:59:11.113435Z",
      "start_time": "2018-06-19T10:59:11.001429Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -661,7 +670,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:59:21.702858Z",
      "start_time": "2018-06-19T10:59:21.673859Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -675,7 +685,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:59:22.210502Z",
      "start_time": "2018-06-19T10:59:22.089982Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -820,7 +831,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:59:34.470299Z",
      "start_time": "2018-06-19T10:59:34.439405Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -834,7 +846,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:59:35.106186Z",
      "start_time": "2018-06-19T10:59:34.971615Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1008,7 +1021,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T10:59:48.838797Z",
      "start_time": "2018-06-19T10:59:48.808721Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1022,7 +1036,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T11:00:14.728947Z",
      "start_time": "2018-06-19T11:00:14.543249Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1191,7 +1206,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T11:00:24.912718Z",
      "start_time": "2018-06-19T11:00:24.896649Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1205,7 +1221,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T11:00:25.585881Z",
      "start_time": "2018-06-19T11:00:25.489128Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1378,7 +1395,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T11:00:35.438985Z",
      "start_time": "2018-06-19T11:00:35.422006Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1392,7 +1410,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T11:00:35.866898Z",
      "start_time": "2018-06-19T11:00:35.769898Z"
-    }
+    },
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1476,7 +1495,8 @@
     "ExecuteTime": {
      "end_time": "2018-06-19T11:00:39.947168Z",
      "start_time": "2018-06-19T11:00:39.474197Z"
-    }
+    },
+    "scrolled": true
    },
    "outputs": [
     {
@@ -1503,6 +1523,174 @@
    "source": [
     "plot_model(m)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Mixed Kernel & Separate independent features (OPTIMAL)\n",
+    "\n",
+    "Remember: $f(x) = W g(x)$, where $g(x) \\in \\mathbb{R}^L$, $f(x) \\in \\mathbb{R}^P$ and $W \\in \\mathbb{R}^{P \\times L}$.\n",
+    "We assume that the outputs of $g$ are uncorrelated, and by *mixing* them with $W$ they become correlated.\n",
+    "With this setup we perform the optimal routine to calculate the conditional. Namely, calculate the conditional of the uncorrelated latent $g$ and afterwards project the mean and variance using the mixing matrix: $\\mu_f = W \\mu_g$ and $\\Sigma_f = W~\\Sigma_g W^\\top$\n",
+    "\n",
+    "\n",
+    "- $ K_{uu} = L \\times M \\times M $\n",
+    "- $ K_{uf} = L \\times M \\times N $\n",
+    "\n",
+    "We'll use `base_conditional`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gpf.reset_default_graph_and_session()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/net/lofar1/data1/albert/miniconda3/envs/kerastf/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
+      "  from ._conv import register_converters as _register_converters\n",
+      "/net/lofar1/data1/albert/miniconda3/envs/kerastf/lib/python3.6/site-packages/multipledispatch-0.4.9-py3.6.egg/multipledispatch/dispatcher.py:24: AmbiguityWarning: \n",
+      "Ambiguities exist in dispatched function _expectation\n",
+      "\n",
+      "The following signatures may result in ambiguous behavior:\n",
+      "\t[Gaussian, Identity, NoneType, Kernel, InducingPoints], [Gaussian, Linear, NoneType, Sum, InducingPoints]\n",
+      "\n",
+      "\n",
+      "Consider making the following additions:\n",
+      "\n",
+      "@dispatch(Gaussian, Identity, NoneType, Sum, InducingPoints)\n",
+      "def _expectation(...)\n",
+      "  warn(warning_text(dispatcher.name, ambiguities), AmbiguityWarning)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-3.4041344381903564\n",
+      "0.13859998443104302\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import gpflow as gp\n",
+    "\n",
+    "import gpflow.multioutput.kernels as mk\n",
+    "import gpflow.multioutput.features as mf\n",
+    "\n",
+    "\n",
+    "D = 1  # number of input dimensions\n",
+    "M = 20  # number of inducing points\n",
+    "L = 2  # number of latent GPs\n",
+    "P = 5  # number of observations = output dimensions\n",
+    "\n",
+    "noise = 0.1\n",
+    "\n",
+    "X = np.tile(np.linspace(0,1,M*2)[:,None],(1,D))\n",
+    "Y = np.concatenate([p*np.sin(10*X) + noise*np.random.normal(size=X.shape) for p in range(1,P+1)],axis=1)\n",
+    "\n",
+    "def _kern():\n",
+    "    return gp.kernels.Matern32(D)\n",
+    "    \n",
+    "with gp.defer_build():\n",
+    "\n",
+    "    W = np.random.normal(size=(P,L))\n",
+    "\n",
+    "    kern = mk.SeparateMixedMok([_kern() for _ in range(L)], W)\n",
+    "\n",
+    "    feature_list = [gp.features.InducingPoints(X[:M,:]) for l in range(L)]\n",
+    "    feature = mf.MixedKernelSeparateMof(feature_list)\n",
+    "\n",
+    "    q_mu = np.zeros((M, L))\n",
+    "    q_sqrt = np.repeat(np.eye(M)[None, ...], L, axis=0) * 1.0\n",
+    "\n",
+    "    likelihood = gp.likelihoods.Gaussian()\n",
+    "    likelihood.variance = noise\n",
+    "    likelihood.variance.trainable = False\n",
+    "\n",
+    "    model = gp.models.SVGP(X, Y, kern, likelihood, \n",
+    "                feat = feature,\n",
+    "                minibatch_size=None,\n",
+    "                num_data = X.shape[0],\n",
+    "                whiten=False,\n",
+    "              q_mu = q_mu,\n",
+    "              q_sqrt = q_sqrt)\n",
+    "    model.compile()\n",
+    "\n",
+    "opt = gp.train.AdamOptimizer(1e-2)\n",
+    "print(model.predict_density(X,Y).mean())\n",
+    "opt.minimize(model, maxiter=10000)\n",
+    "print(model.predict_density(X,Y).mean())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "ystar,varstar = model.predict_f(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXYAAAD8CAYAAABjAo9vAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJzsvWlsHHeap/lE5H0fzOR9i4dE3bcs\nW7JOly1btktVdrl3q/rYwXTvYjHoBXYwg9lPC/QAjRlMNxY1qO7tY9EzO9tTVe0uq3xLsiXLsmTd\nFiVKonjfZDIzmfd9ROyHoJKiKcmyRdllMh4gIDKPiEgq4pfv/z0FWZZRUVFRUVk6iN/1CaioqKio\nLC6qsKuoqKgsMVRhV1FRUVliqMKuoqKissRQhV1FRUVliaEKu4qKisoSQxV2FRUVlSWGKuwqKioq\nSwxV2FVUVFSWGNrv4qAej0dubGz8Lg6toqKi8r3l6tWrQVmWvV/1uu9E2BsbG7ly5cp3cWgVFRWV\n7y2CIIw8yutUV4yKiorKEkMVdhUVFZUlhirsKioqKksMVdhVVFRUlhiqsKuoqKgsMVRhV1FRUVli\nqMKuoqKissRQhV1FRUVlifGdFCipqKgsT/K5Iv7hGIIAVSucCKLwXZ/SkkQV9m+JeChDMS9hKzOi\n0aoLJZXlRSaZxzcYJTiWQCpKAISmUjSt92BxGL7js1t6qML+BMnnisyMJwiMxknHcwAIooDVZcDu\nMeHwmrA4DKrVorJkSYSzTA1ECPtSIMvznktFs9w+O0l1i5OqVieieh8sGqqwLzKyLBMLZgiMxgn7\nksjS/ItZlmTiMxniMxkmesJodCL2MhOOchPlDfbv6KxVVBaXyHSKqYEI8ZnMQ18nSzITvWHC06r1\nvpiowr5IyLKMbyCKfzRONpl/5PcV8xJhX5KwL0mxIFO1wvEEz1JF5cmSjGYZvRUiPpP+Wu+7a71X\ntTipVq33x0YV9kViojfCZG/4sfYxfieExaHH7jEt0lmpqHw75DIFxu+ECY4nFrhcHhVZkpnsDROZ\nTrFqZ5Uai3oM1L/cIhCaSjLZF3ns/ciSTP9VP9l0YRHOSkXlySMVJSb7I3SdHic4Fv/Gon4vqWh2\nUe6n5YxqsT8mqViOwc7AolzQAIVckf4r06zaWYWoUb93VX53CU0mGesOkU3Ndz1O9IaZHopjsumw\nug3YXEYsLgM6veaR9+0bjOKtt2G06Bb7tJcFqrA/Bvlckb7L00gF6b7PS0WZdCJHKqZshZyEKAoI\nopIdIwgCgiggzv5eVm3FYNaSjGQZ7pqhecNXDkpRUflOGOwMKBb6l5jsizDZF8XuMVIsyEwPxvDJ\nMQCMFi1WlxGry4DVbcRo0SII9/ely5LM6K0Z2rZVPtHPsVRRhf0bIksyA1f9JWtFlmTi4SypWLYk\n5Jl4vmTIixoBnV6DJMvIkowsK++5+zPAzHiCjmeq0WhFgmNxLE4DFY1qpozK7xaR6dR9Rd03FGWi\nN0JZjYWm9R4EQUAqSiSjORLhLIlQRnnveAIArV7E5jZiKzNicxsx2XTzhD4ynSIyncJZYf7WPttS\nQRX2b8jIrRliQSXyL8syfVf9RP3K7zqDBrNdj9NrxmzXY7brMTzMOpGVFMiei9OM3g7RtM4DwOit\nGcx2PTa38dv5UCoqX0GxIDFyc2bB44HROGO3w7gqzTSt85SudVEzK95uI6xwIMsymWSBRChDfHYL\n+1IAaHQitllrvqzGgt6oZfT2DHavSc2S+Zqowv4NCIzG8Q/HSr9P9EaI+tPUtDvx1lrRGb/en1UQ\nBOweE1UrHEwNRHF4TLirLaVg6upd1ei/5j5VVJ4EEz3hBT71mYkEw10zOLwmmjd6H1pwJwgCJqsO\nk1WHt94GQDZVKIl8PJQh4k8TGI3T8XQVmQRMD0apanE+0c+11FCjc1+TeCjDcFew9HtoKslUfxRP\nnZWqFY4HirrRqsfwFYGg6jYnFqee4a5g6ebJZwr0X/UjSYsTnFVR+aYko1mm7zFoAMK+JIPXg9jc\nRlo2e7+RZW0wa/HUWmla52HdnlpWPlVJLlOg/4sAkiQz2R8hl1Ezxb4OqrB/DXLpAv1X/KVq0nQ8\nx9D1IBannobV7vu6WqxuI61bK1i7p4Z1e2pp3liOyaa/7/5FUaB5oxcZGOwMlo6TCGUY7w49sc+l\novJVyJLM8I3gvErqqD/FwBcBLA4DrVvLS1lcokakrqOM8gY75m/QMsPmNtK41kN8JsPY7RDFvMR4\n9+PViCw31PX912CwM0A+q1gOhXyRvqt+RK1Ay+by+amJgoCzwkTVCud8/7gAnlorZTWWkqWfimbn\nHcNo1tG4pozBziCT/RFq2lwA+IZiOCvN2MvU4iWVb5/p4RjJyNy1GpvJ0Hc1gMmmp21b+VwxkSDQ\ntMFDWbW19FqpKJGK5UhEsiQjWZKRHJlk/qEpwp5aK+l4Dt9gTDGEBIHyRhtWlxpvehRUYX9EooHU\nvGDp4LUguVSB9h2VJf+3IAqU1SgumQdZ5aD4GcuqrbirLESmU0z2RebdNGU1VqKB9GzamEn5cpAV\ni2n17ho0an67yrdINl1gvGfOYk5Fs/RdnsZg1tK2rQKtbi4/vabVOU/UQbHglTTHOVGOhzKMdAVJ\nxXIPPG7tShfpeJ7RWzOYrDpGbs7Q8Uz1A5MQVOZQFeIRGb8zd2FP9EaIBtLUd7hLFrnBrGPdvjqa\nN3gfKur3IggCrkoLq3fV0LatEq1h7gZpWFOGwaxl8FqAQq4IQCaRZ6JHXZKqfLuM3AyWajXyWWWl\nqtGJtG+vQHfPNeuutlLd9mhBTpvbyOpdNdStcj+wEE8QFNekwayl/ws/ockEwbHE43+gZYAq7I9A\n2JcsWdSlYGmtFW+DEtXX6ERat1ZgMH3zBZCzwsyqnVXoZ/eh0Yo0b/SSzxYZ7ppBnl22+gZjJMIP\n75inorJYhCaTRGbTESVJpv8LP/msROuW8nmZWhangaYNnq9lTQuiQFWLk7V7anBW3j9XXasTad1S\ngSxB3xU/wzeDFPLFx/tQywBV2L8CWZZLVvK8YOma2WCpILBiYzlm+6NZ6Q/DZNXT8XR1yeK3Og3U\ntLsI+1IE7loqsszQ9WBpWIGKypOimJcYuTWXsz56K0QilKVpXdm89ro6o5bWLRXf2EVoMOto21pJ\ny5aKkmFzL0arjhWbvKTjeXovTs9zC6ncH1XYv4LQZFJpB5CXlGCpRqBl01ywtG6Ve1Er4/QmLSt3\nVmFxKjdOZbMdu8fI2K1QaVhHOp5jQm2SpPKEGbsTIj+bZugfiREYjVPZbKesZs6HLmoEWh8gyF8X\nd5WFtXtqqWxe2Lra4TVR1+EiMp3i2olRMolHb429HFGF/SEoQwAUAZ3oCZNNFmjZXF66iD11tifS\nP12n17DyqSrsXhOCINC03oOoERjsDJby2X0DUZJfyqhRUVkskpEs/hGlbUA8lGH0VgiH10TtSte8\n1zWt92J1Ld5wDI1WpH51GXWr3Aueq2i046m1Mtkb4YsTw4t2zKWIKuwPITiRIJPIkYrn8I/EKW+w\nlYKlVreRxtnS/yeBRivStq0SV5VSWt2wtoxULFdqZypLsy4ZtXBJ5QngG4yCLJNNKQVyBrOW5o3z\nfejVrc551vujUIxESF68RPLSJaTcgzNiqlqcVH7JaBIEgYY1ZehNWgauBkpZaioLUdMdH4AkyUz2\nRpBlmbHbITRasRTxN5h1tG6peOQqu7zfT25oGDmfR1dRjraiAo39q5t7iaKSIz/cpfg5o7Vppvqj\nOMtNWF1GUtEsU/fkuquoLAb5XJHQVJJiUaL/qlKQ17Jlflqjq9JCTfujXXdSOk22r49MTw8F33Tp\n8cyNG5g2bca0bi2CdqEU1a1yU8hJ8xqOiRoBb52Vid4IPZd8bHmhUU1/vA+LJuyCIGiAK8CELMsv\nLdZ+vysCo3GyqTwRf5pYMEN9hxudXlPKgLk3zevLyJJEfnKS3OAguaEhirG5C/OujSGaTWjLK9BW\nlKOrqEBbUYFoXFh8IQgCTesUV0wxLxGbSTPYGWT1LqUL5GRfBFelZVGCtyoqAMGxBFJRYvi6kmfe\nurUck3WuHYZWr6Fx/cMzYORCgezgINmeXnJjo3CfYL+UzpA8d4709euYt2zBuLoDQZxzIty99gv5\nYikzB5TipYneCGO3QjSu8ZR6zqjMsZgW+58C3cD3vs9ssSgx2RdBKirWutGqU1IbvyIDJjs4SHZg\ngNzwMHLm4f5vKZUmNzxMbnhYeUAjYv/BDzCsWHHf19eudBGaSNK83sudCz7GukM0rvXMumQCdDxd\n/bVLt1VUvowsywRGY0wNRAlNpahd6cJZPj85oH512QOHZhQTCdKd18ncvo2cfbQYkJRIkDh9mvS1\na5i3b8fQ1lr60hBEgRWbyum96CsNxtabtDjKTQTHE4zdDuGutqhj9L7Eovw1BEGoBV4E/n4x9vdd\n4x+Ok88UmB6OkU0VqO9wI4oCte3OB2bAJD47S+z9D8je6Vkg6rIskx0cJH3jBrmREYqRCHLxS7m4\nRYnY8eNkBwbuu3+NRqS61YmtzEhls53AaILItGLF3BvoUlF5HOIzSs/0iZ4I7moLlc3z7TSH14Sn\ndqFfPe/3Ezt+gtB//a+kr117ZFG/l2I0SvzECSK//jVSas5C12iUVfK9BpW3zko+WyQ4HmeqX80Q\n+zKLZbH/X8C/AR64JhIE4Y+BPwaor69fpMMuPsWCxNRAhHy2yGR/BEe5CYfXhMGso3LFwqo6WZZJ\nfPopma6b930uNzBA6vJliqEvNfESBESbDY3DUdr0ra3Ejh9/oOXubbDhG4xS0+YiGkgz1BVkjbMG\nnUHD9HCU8kab6m9UeSz8I3ECo3EQoG6Va971JGpEGtbOTxjIDQ+TutZJfnx80c6hEAgS//hj7IcP\nl46v1Wlo215J97kpsqk8jnIzWoNIYCyObzCGt8H+WAWCS43H/ksIgvAS4Jdl+aogCHse9DpZlv8W\n+FuALVu2/M6mckwPRSlki4z3hJGLMvWzaVfVbc4FwVJZlkl88gmZW7cXPJ4bHFQEfWYGjcuF7eBB\ndDU1FGMxitEoxWgUafbfbF8fcjZLurMT+8svEzt2DPvzzy8Qd1EUqG51MnQ9QPMGL7fPTTLcNUPL\nZi+ZRJ5YMI3Dq06bUflm5LNFZibiBMcSuCrMC2YA1LS7SjNIs4NDJC+cpzizsOtobnSUbG8votmM\naLMhWq1obDblZ8OjpUbmRkZJf/EF5s2bS4/pjVradyjins8W8NRa8Q3GyCRzjHeHWLGp/DE+/dJi\nMb7ingZeFgThEGAE7IIg/H+yLP90Efb9rVLIFZmazQ8PjiWoaLJjtOow2fQLlp+yJBH/+GOyPb1z\nj8kyuaEhUpcuKYLudGI9eBBDS0spKCRaLOiqqhYeOxAg9t57RN96C/tLLz1Q3D21VqYGlKVnTZuL\n8TthZsYTeOps+IfjqrCrfGMCY3FmJpIU8lKpXcZdLE4DlU2KWyY/OUns2IcLAqJysUjqwgXSnZ0I\nBgNyPg/S/NcIer0i9HY7Gqdz3iaYzfNWCMkLF9BVV8+7X4wWpQr1zvkpvHU2fAMxguMJ9CYdFU3Z\nRc2p/z7z2MIuy/K/A/4dwKzF/q+/j6IOSmvSQq7I6K0QWr1IdauSR1u7cv6SVJYk4idOkO3rLz2W\nn5wk8dlnFINBRIcD64EDGFpb50X5H4bW68Vx5AjRd94h+vbb2A8duq+4C6JATZuLgS/8VDbbifpT\njNwOYSszEvGnyKYL6pJU5WujBE0VN4zBosVeNpehJYgCjes8CKJAMZEk9uGxBaJ+1z9e8PsxrlmD\n5emnQaNBTqUoJhJI8TjFeBxpdivGYuTGxuCeWJOg1ysi73Bg6OhAX1tL7PhxXG+8MS9jzO4xYZ5t\naWBzGwiOJaha4WD09gwdT1c/4b/U9wNVAWaRJeXCDk+lSISzNKwtQ6vTYHUZcVVa5l5XLBI7dozc\n4JDyuyyTuX6d5OefI9psWPfvx9DW9siCfi8ahwPnkSNE332X2HvvYTt4kBgsEHd3tYWpfj2pWI6m\n9V5ufjbB4PUgK3dUEhiJUbtyYdWeisrDiAXThKeSJMLZBb71yiYHFocBuVgkfuzDeYFNgGxvL4nT\np0EUsX3ZELFYEC0WqKhYcExZkpASCYqRyLwtNz5OdnAQx8svo6uuJn7yJI4XX5z33vIGG8M3snjq\nbAxdDxKfySAIAjOTiQVtg5cjiyrssiyfBk4v5j6/LaKBNJlEjrE7IUx2Hd465eK4t4RaLhSIffgh\nueER5fd8nsQnn5Dt60Pf1IT1wAFE/fxUSEGvx7CiGcPKlSBJZG7fJjc0hFy4f4c60WLB8eqrxD74\ngPiJE6XsgnvFXRAEatpdpZ7Y9R1uhm/MEJlOoTfqqG5zqcN/Vb4W/pE4/pE4gsg8t6PBoqO6XUka\nSHx6hvyUr/ScnM+T+Owzst3daCsrsR08WCq809fXUYwnKEYj8IDqaEEUFZeM3Q73JFRImQzRt94i\n9v77OI4cASDd2Ylpw4bSa8qqrYzeDuGuMjN6SyQwlsDuMTHeHcZVYX5gK+Dlgmqxz+IfieEbjJFL\nF2mfLb5weE3YPXMTi2LHj5dEvRiNEvvwQ4ozM5i3b8e0efOclSMK6OvrMbS1Y2huQtDNFXfo6+uR\nMhmyPT1kurspBIJ8GdFoxHH4MLFjx0icPo2UzSKIIuIPf4iushJQKv8sTgPJSBZPjZXJvgi+oRiu\nSgvhqeTXLvVWWb7kMgVmJhLMTCRwV1nQ3pOj3rjWg0Yjkr55i8ytW6XHC8Eg8RMnKIbDmDZvxrxt\nm7JKFQSse/ZgWrMaUFa4xUiEYihEIRSmGA5RCIUohsMPFHzRaMR++DDR3/yG2Dvv4PjRj0h8/jna\nqmp0FUqAVKMT8dRY8Y/EKKuxEBiLU8gpK9Xp4fgT6eH0fUIVdpRZpsHxBFMDUVz3jJ+716WR6e4u\nuV9yIyPEP/oIAPvhw+hnrQ2t14Nx5UoMra3K8vMBiEYjpvXrMa1fT97vJ9vdTaa3d17+u6DTYT90\niMTJk6TOn0fOZECnx/WT19HYbLPn56Lngg9BFKhotDPWHSYZzc5e7KqwqzwawbEEwbE4UlGm/J6g\nqafOhsNrIu/zkTjzaenx/NQU0bffRjAYsL/8Mvq6OuUJUcB24ADG9vbSawWNBm1ZGdqyMu4NaxYj\nEVJXr5Lp6blvVarGZlPE/ehRYu++i+PIEeLHj+N84yelVbG3wYZ/JIa33oZ/RAn8VjTZCYzGlr2w\nL+/1yiyB0Tj+4RhSUS71v3BVWUqtc6VkksTZs8iyTOryZWLvvYdoteJ87bWSqJs2rMf5k59g2rDh\noaL+ZXTl5ViffZayP/xDjGvXzHtO0GiwHjyIcc0a0teuKcd+/wMl2wBweM3YZr+EPHU2RI2AbzBG\nfCbz0JFjKip3kWUZ/0gM/0gcs11fuua1Bg31HW6k5PxgqZzPE//4Y0SzGddPfjIn6hoR+wsvzBP1\nh6FxOrHt34/7pz/FuGY13Md1oi0rw/7iixTjcWLvvUchECBx6pPS8xaHAavLiNmux+zQExiLKzGv\nRJ54aHkPo1n2wi5LMv7RGIGxOPYyIyarDkEU5vnW46dPI8XixD/8kNSlSxja2nD+6EdoHIpVYN66\nBeuuXY9VHCTodNj27MF+6AUE45xtIwgClt270VZVkb58mfzUFPGPPipNVLp7nlqdiLfOSngqSS5T\nwD8S+8bnorJ8iAbShCYTpON5vA1zBW617S40GogdO46UmBtHl/z8c6RYDNv+/YhmJbVW0GlxvPQS\nhubmr318jd2Obe9e3L//+5jWr0PQzm9VoKuqwvaDHyjpwMeOkblzh/TNOZfQ3bRMb52NdDxPMqoY\nNPc2DluOLHthj/hTBEbi5NLF0kVSVmPFZFWWe9m+PnKDQyQvXiQ3PIzlmWewHjhQ8ptbdj6FZceO\nRTsfw4oVuN54A131XNqWIAhYduxASqVId3WRHRgkdfEioMyOdMz28ihvsiPLSkuEmYkExbw6ZUnl\n4QRmg6aiVqCsWllpGq06vHU2kmfPkp+cLL02NzZG5uZNjOvXo6upAZTkAMc97shvisZqxbp7tyLw\nGzbAPcF/Q1MT1j17yI+NkTh5ksRnZyjMVnKXVSsxgbJqC6JGIDiqCPrd7pTLlWUv7IHROP7RODqD\nBmeFGVEjlNwxUjpN4oxyEWW6ujB2dGBav740Es+659l5lXGLhcZmw/HDVzFv21a6wHXV1ejq60lf\nvYqUy5G6fIXMbHFU7UoXCAJGsw5nhRn/aJxcpkBwQh38q/JgcpkCgfE4oakknhprqZFWTZuL3OAA\n6RtdpddK2SyJU6fQOJ0lQ0YwGnC8+mpJ5BcD0WLBuusZHC+9hHBPhpmxowPzjh1k+/pInP6U2PHj\nyMUiokakrNaKRifirrIwM5mkWJAo5qV5HSGXG8ta2LNpxWUR9afx1lkRRYHye3pOJM58hpRKkzx3\nDkGnw7x9u/JGUcB2YD+mtWuf2LkJoohl+zacr76KaFUCoZbt20utBwASp06Sn57G4jDgmh0GXNls\np5iXmBlP4B9W3TEqDyYwGicwEkeW5lwaZocBV6WJ5PkL816bPHsWKZlUVqtaLaLZjPPIkVKWymKj\nb2jA+aMjiLa5JADTpk0Y161T6kY+PUPy8/MApYCvp86KVJQJTSWB5e2OWdbCHhyN4x9W/vM99TY0\nOpGqViVnNzs4RLa3l9zwMPnRUcxbtyKaTKX2usaVK7+Vc9TV1OD6vTfQNzaiLS9Hv2IFmc5OpHQa\nuVAk9v4HFBMJqmfP2+oyYHbomR6KkYplic2oU2ZUFnI3aBoYjSvXzOwA9dqVLnK9vRQjcx0Ts0ND\nZO/cwbR5M7qKCgSdDscrL6MtK3ui56j1eHD++DW0Xi8w65J85hl0tbUkz50jce4cudFRTFY9do8J\nq8uA0aIjMKqsVKPBDLl04Yme4+8qy1bYZUlmekQJmjrLTRhMWsob7ej0GmXZefo0crFI8tw5NE4n\nxrVrlSDRiy9iaGn5Vs9VNBqx/+A5NA475m3bkAsF0l98ASgZO7H33sdsFnHMzkitbLKTSRaIBtKl\nLy4VlXuJTKcIjiXIpgoli9dWZsLhMZK6fKX0OimdJvHJJ2jKyjBv2aK8bv8+tJ4nNxbyXjRWC84j\nP0Tf2Ago4m7dswdZlkmeOUP845NI6XQp8Outt5KMZJXB77JMcHx5uiOXrbBH/Cn8QzEKOak0RKN8\ndhLL3WVnpquLYiSC5emnEbRa7M8/j76h4Ts5X0Gvx7pvH1q3G0N7O+muLoqz2QqFQIDk+fNUtShW\nu6vKgs6oYXooRtinZMmoqNyLf1hJcdTqxVLLjLpVLjLd3RSjUWCuJbWczWI7cABBo8G8ZTOG1tZv\ndExJlvAlfVz2Xeay7zLx3KMZHYJej/3FQ5jWKa5PjcOBeetWcoODpLu6iJ88havSgs6gpazGiiBA\nYEy5N4Ljy9OwWbYFSoFRJRtAb9Li8M71XM+NjpK53Y2UTpO6fBldfT26hgaMqztKVsOjki1m8SV9\nTCWn8CV9FKQCLoMLp9GJy+DCZXThMDgQhUf7ftXX1mJcvZpiLEa2t5f0lStY9+wBIH3zJu4NG7C6\njCTCGSoabIz3REhGsgTH4lS3qnNRVRTSiRyBsQQRf4rKJjuiRlAqme06wu/MWeu5vj5yAwOYd+xA\n6/Ggb2zE/DUzwMKZMOPxccYT40wkJsgV5+orrviuUGevo8PdQYO9AY344HGTgihiffZZNA4HibPn\nMK1fT7a3l+SZM+hqa9E3NOCpr2aqr4Cz0szMeILadlcpp/3uEPrlwrIU9my6gG8wSjyUobbdiSAI\nlDfYkHI54qdOAZC6eBE5n8fy9NNoHXasTz/9lfuN5+JMJiZLYh7OhClIBQLpAL6kDxkZr8mL1+zF\noFFy1UVBxK634za52V65HZfx4QJseeZpcqMjGFevJnPrFqYNG9A4nVCUSF26RNWap+i7nMFbb2Oy\nP8r0UAxnhZmqFU51dJ4KANNDMQKjMZAprVZrV7rI3O4uzectJpMkzpxBW1GBaeNGZabAcwe/slaj\nKBUZi48xFB1iLD5GIj/fFVKQCiTyCQwaAyatidHYKKOxUcxaM23uNjrcHTiNCwfa3MW0YQOCyUz8\nxAmse/cS/ed/JnXhAhqLGffhI0wJAt46G+GpFOHpFGXVFoLjCVXYlwN3K00FQanY1Ju0OCvMSvFF\nPEEhGCRz+zbGtWvRlpVh3b9/XurVlylKRS5MXeBG4AapQgpf0lfaAukARXlhwy+73k65uRyPyVMS\n+7HYGLtrd9PufnD1nqjXY9uzh4Jvmkx3N6nLl7EdPAhApqcH58aNmGx60vEcZTVWguNxkpEsEX9q\nXpdKleVJMS8RHIsTGEvg8JowmnV4aq0YTSKhK4q1fneAjFwsYjtwQInxvHjogUMyJFliPD5Of6Sf\noegQ8Vy8JOrxXJxEPkEilyCej5MpKBWhWkHLtqptrPWsRRREUoUUnf5OOv2dVFur2Ve/D7v+/uOT\nje1tZG4qqZjGdevI3LiBoa0NzWencDTsRpYk9CYNwbE4ZdUWQpMJ6le70SyjxmDLTthlSWZ6KEpw\nPKn4og0avPU25FSKTFeXEpQ5exZBr8e8dSvGNavR19Y+cH+RTITjw8c5PX6arkAX0ZzinxQFEa/J\nyxrPGirNlVRaKhEEgUAqQCCtbNPJafojcz3d21xtJPNJJhIT7KrdhU7U3feY+sZGTJs3Ybpxg/QX\nX2DatEnJUJBk0pcuUbX2GQavBWb7ZsTxj8Qob7Srwq6i5K1PJslninhXW5W6jTYnmVu3ShWmma4u\n8iMjWHbtKlnqWtf8laQkS0zEJxQxjw2RKWSQZZmh2BBnJ86SzCsph1pRi01nw6q34jV5seqtWHVW\nBiIDfD75OYORQfbU7Zm3Up1MTPJO/zu80vIKNv39p22at+8gevQo5u3byQ0OkvjkE7ReL1bbAFGh\nBk+djcneCNlUHoNZR8SXWlb9k5adsEf8KXyDUYoFCW+9DUEU8NbbSF0+j5wvkBsaIj8xgWX3bnQV\n5Vh37nzgvrpnuvl45GM+GvmJHOUhAAAgAElEQVSIodgQVZYqVpWtotJcidfsRSsu/PPW2+upt89V\n6aULaQKpAOOJcW4EbjCdmiaWizGdmuYHjT/Abbx/b3Xrrl1ke3rJ3LxJ6uJF7IcOAZAdGMSxYRMG\ns/Kl4Cg34R+JE5pMkM95HjhdXmXpI8uyEjSdLchzlJvxNtjR6wVCV5Usq0IgQPLcOXSNjRjXrsWy\nfRuGpqZ5+4nn4rw78C6RbGTeY2cnzjIcG6bMWMa+un14TV70Gv193TdtrjZ6w72cmzzHm71vsrVy\nK+u960vxplguxtv9bz9Q3PW1NejqasmPjWPZvZv4Bx+QvnYNk0aLpsqBp9bKZG+EwJjiaw+OxZeV\nsC+ftcksd6fEGK06bG4DzgozmkKWzM2bc+mNbjfGNWuw7ru/CyZbzHJi+AS/6vkVv+z5JSOxEXZW\n7+SVFa+wsXwjVdaq+4r6/TBpTdTb69lZvZOXV7xMvpjnrb63ODtxljd73qR7pvu+7xONRuyHXsC0\ncaPyZeSb7ZMty6QvX6SyWeljU9lkp5CTCI4nmFmmqV8qCtFAmlggTdSfxlNrRavXUN3iJN3VhZRM\nIuVyxI4fRzSZsO3bh7G1BfPWrfP2EclEONp3tCTqkixxPXCdX/X8ivHEOE9VPcWP2n5Era0Wg9bw\nQJ+8IAi0u9v5SftPqLPVcWHqAkf7jxLKzM1QvSvuidz9r1vLbMGgoakJ/YoVpK5cQYqEsQZ6Mcwm\nRQTHE8iSvOxy2peVsGfTBSb7IiQjOcrrbaWgafrqFeRCkfT160ixGJZnnsG8fh362oWl0r6kj1/f\n+TW/6fsNv+3/LbIs80rLK6z3rn/oRVxhrsBr9iLw4OBTtbWa19peo9pSzZnxMxwbPsbx4eOcHDlJ\nvphf8HpDczOOI0cQTKZS7xhQBgE7xBhagwZbmRGTTacEzJZxJZ6KkuJ4N6/bU2+lstmBVpRKNRHJ\nM2eUBl8HD6KrrcG2f/+89wfTQY72Hy0FRKdT0/ym9zd8Pvk5NZYa3mh/gw3lG9AIj74qtOgsPN/4\nPAfqDxDLxniz902uTl9FkpU+L7FcjLcH7i/uuqoq9I1K+rF11y4EjYbE6dNYM9MUoxG89VbymSLR\nQHrZ5bQvK1fM3TJ7URQoq7VgsOiwGItEbt9GSiZJX7mi+K/XrMby1FML3t/p7+STsU84NXqK4dgw\njfZG9tbtxahdGHG36W3U2eqos9VRY60pvSaVTzEaVzIBxuJjZIvZee8z68y82Pwi1/zXuOS7RCAV\nIJqNEkgHeLH5xQXLUvvBA8SPHyNxSpnkdDfHOHPlIpXr9jF+J0xFo53hrhkCI3GS0SwWhzrwd7mR\nSeYJT6eULqYeI1ankapmB+muTqRUmsydO2R7ejBv3Yquvg77wYPzVqu+pI/3Bt8jV8yRK+a4OHWR\nmzM3sWgtPNfwHM2O5pJh0+ZqY2vlVtKFNLFcTAmc5uLKz7MB1YI0Zz0LgkCrq5Uaaw1nJ85yyXeJ\n4dgwzzU8h01vI5qN8vbA27za8ioW3fw4kXn7dnIjo4gWC5adO0mcPo2h7zZGbR1C/Wq0elEpQqww\nExyfq9Be6iwrYZ8eijIzmcRdbUGr01BebyN99SpyoUjy88+Ri0UszzyD7T5ZMLeCtzjad5SPRj4i\nWUiys3on6zzrShezgECDvYF6ez11tjochvs3+jfrzKx0r2SleyWSLDGdnGY0PspIbIRgWpmmJAgC\nmyo2UWWp4qPRj3ir/y2ern6aTCHD4RWHKTPNlXKLZjOef/WvyNy6TeLTT9FWVaGxWslPTuFYF2JK\np8FdZWH0VojgeJzgWEIV9mWIfzhGzJ8ily5St9KNq9KMICsVzIVwWLl2qqsxbdmCecuWUhk/wFhs\njA+HP6QgFRiKDvHZxGck80nWetayrXIbeo1yr+g1enbX7qbN1QaAw+Cg0lJ53/MJpoP0hnrpi/SV\nAq1mnZnnGp+jP9zP6fHTvNn7Jvvq99FobySajfLb/t8uEHddeTmG5iayA4MYOjrI9PSQPHcOW3Ub\nmWQDnlorvqFYqUhvueS0LxtXTCqWY7wnXJoSI4gCLhdkbt8mPzlJtrcX08aNWHfvWtCtbjg6zN93\n/T2/7f8tCPBqy6vzXC8WnYWXVrzEoeZDrPGseaCofxlREKmyVrG9ajuvt7/O4ebDeExzpdpV1ipe\na3uNWmstn018xvmp8xztP8pkYnLefkyrVuH+oz9ELhZJnDxZ6tWeu3oZ72wPHFeVmdBkEv9IDOkB\nI8lUlibFgkRgNsVRqxdxVppxV1vIXL9OMZ4gfuIEglaruGAqKkqtAwAGIgO8P/Q+0WyUY8PHODZ8\nDIPGwJHWIzxT80xJ1KssVfyk/SclUf8qPCYPO2t28rOOn/FS80u0udpKcakWVwuvtb2GTWfjw6EP\n+Xzyc4pyUbHc+98ufRHcxbx9OwiC0m7g2WeRs1m0gzeQ/ZN462wgU4ovLRd3zLIR9uCYEjQ1O5Qp\nMa5KC/nr15DzBRJnziBardj27VvggvGn/Pzna/+Zk6MnqbRW8lrra1SY5yauNzubSwGgx6XOXsdr\nba+xv35/yeVi0po41HSIJnsTF6YuMJmY5N2BdxmMDM57r/NHP8K651ny4+Nkrl8HoBAI4pQCiBoB\nT52VYkEmOBYnMr1825kuR2YmEmTiOSLTKTy1VvRGLVarSKqzk+Tnn1MMBrHt34/GYcd2YL8yuxQl\n6+v48HG6gl386s6vGI2Nsr1yOz9u+3HpHhAFke1V23m15dUHpiY+DFEQqbfXc6DhAH+0+o/YV7+P\nGmsNDoODH7b+kNVlq7keuM47/e+QyCWIZCO83f82qfzcNawtKyu5ILVlZWgrKsj19GBL+9AJOWxu\nA4GxBLIsE5pMIC2DPu3LQthlWWasO6RMialTUp7KygQyd7qVfjAzM8oAjb175g2ejmaj/KfL/4mP\nRj6iylrFoaZDGLSKG0Mn6thbt5fnG5+/r4/9m3I3W+D3Vv4eO6t3YtAomQXP1j2LUWPk49GPyRaz\nHB8+zs3gzdL7NDYb7t//ffRNTSTPn6cwMwNA4doVymos2NxGDGYtgbHEsu2fsVyZHlKCprKsTBpy\nVpjJdF4jc1u5/o3r16NvbMSydWupuVdPqIejfUc52n+UM+Nn8Jg9vN7+OpsqNpWCow6DgyOtR9hc\nsfkrK1IfBZ1Gx0r3Sl5peYXDzYdxGV3srt3NgfoDzGRmeLP3TUZiI0SyEd4deLdU7ARg3ra1NLvA\n0N5OcWYGe3KMwtQUnjob2VSBeChDMS8RXgaGzbIQ9ngow/RQDARwVVow2fRoB24gxROkLl1CV1eH\neceOeaO9MoUM/+HSf+DD4Q+ptlZzqOlQqWCowlzB6+2vs6ps1RM7Z62oZUP5Bn7a8VM2lm/EqrOy\nt24v4UyYi1MXkZE5M36GC1NzfbPNmzbhePllBINBGZ9XKFCMRHAVphE1Ip5aK/GZDP7hmNoYbJkQ\nC6ZJxbIExhLY3AaMVh1Op0jis89InDqF1uvF8tRTaMvLMc0OjYlmo/zF1b/g172/JpwJs7duLy83\nv4zTMBd4bHe183rb65Sbn0w/9jp7HW+0v8E67zraXG38uO3HWHQWPhj6gAtTFwikA6VgLoDW5Sq1\n0ja0toIoIvd3o4/7cbo0aLRCqZ1veEoV9iVBcDxBaCqJvcyIzqChzC2QuXOH5PnzyIUCll27sO7Y\nXnp9QSrw5xf/nHcH36XGWsMLTS+gE3UIgsCWii38sPWHj+xHf1wMGgNPVT/F6+2v0+ZuY61nLTeC\nNxiLjwHwxfQXnBo9hSRLSgfKF57Htm8fxZmZUgpksesqjjIDZbXKaiUwqkx0V1n6TA8rw82zqQLe\nehtavQaxr5P48RMgSdieew7RoMd28ACCKCLLMj//4uecnzxPo72RN9rfYKV75TyLfGP5RvY37Een\nuX9l9GKh0+h4puYZjrQeYYVjBUdaj9Dh7uCa/xqnx04znZzm/cH3yUtKKrB561bQiIhGI/qGBjK9\nvTj1KYp+H2U1VsK+JIV8kWggteTjTEte2CVJZvxOmGyqgLvKgqgRMU91k5+cUoYHbNiAqWNVqXOj\nLMv8x8v/kbf635on6hpBw+Hmw2yr2vbI3RgXE5fRxaGmQzxd/TQug4tPRj8pLUXvhO5weuw0oLQb\nsO7di3HNGtKdneTGxpDiCawZHwaTFrvHSHA8oTSBUlnSZNMFItMpAqNxJYBeacZulUie+pj8xATm\nHTvQOJ2Yt21D61YqnM9PnefdwXfxmrwcbDiIWWeet8+d1Tt5qnphKvCTpMJSwY/bfsxT1U+xt34v\nWyq20BPuoTPQyVRyimNDxyhIBTR2O8aODgAMK1cip1KYA33IoQBlVUZkCWbGkxTzErHg0h5As+SF\nPepPERhRGn65Ks047DK53m4Sn36KaLVi3rx5XivSv7zyl/zyzi/nW+oIHGw4SK3twT1jvg0qLZU8\n36QUc6SLaT4d/7SUAXMndIeByAAA1l3PYN29C43TSeLkSaRMBv1wFxqtEkTNpYv4h2MkI9mHHU7l\ne45/OEYuXSDsS+GpUYwa42QP6ctXEEwmjB0daCuV7o2gtNj9+Rc/J1PI8Gzts/MMGEEQ2Fu3lw3l\nG76Tz6IRNWyt3Mrr7a/zUvNLrHCs4MLUBYajw4zFxzgxfAJJljBv2Yqg06JvaEAwGMj39mDXZdAn\nZzA79ATG4siyvOTnoS55YVfcMCnsHhNavQZrsI9M102KwSCWnTvRNzeXmnz9dedf819u/xdqrbUl\nUQfYXbubZmfzww7zrbHCuYJXWl9hW+U2BqOD9IR7Ss99Ov4pyXxSGUSwfQe2gweVCTiffooUi2Et\nRnBVmNFoRQJjCbUSdQkjS/Ksy202aFpvQ8ikEDrPkR8fx7RhA6LRoAzQEEUkWeIfbv4Dt2Zusc67\nDq95Lo9dI2j4QeMPnmhM6VFxG9283PIyr7a8itfk5ePRj5lJzzAcG+bjkY8RLWaMq9cgaDQYWlvJ\nDg3h1EQp+AN4a8yk43mS0Rzh6VTJKFqKLGlhL+YlJnrC5NIF3FVmDNoCYt8NUhcvoqupQd/SgmX7\nNgDOjZ/jr67/FbXWWp5ver4k6psrNrPas/q7/BgLWO9dz886fka1pZqzE2eJZRW3SqaQ4dToKWRZ\nxrx5E4bZXh+5/n4lT9/Xg6ARKauxEPal8A/HlkXq13IkGkyTzxZKM01NNj3GmSEyX1xFMBgwrlmD\nefuOUtfGi1MXOdp/FJvextaKuf4weo2eF5tfpNnxu2HYgJKR9kLTCxxqPoRe1PPh0Iek8in6I/2c\nGjuFaeMGBJ0WQ3s7FApoRnvRCzlsYhxRIxAci5PPFJb0ivWxhV0QhDpBED4RBOG2IAi3BEH408U4\nscUg5EsSHE8gCOCsNGONjysVpvk8lt27MTQ2oKuupiAV+LOLf4ZFq/StuCvqq9yr2F61/SuOskhI\nX09gd9Xs4g/X/CECAidHT5Z6a4zFx+gKdiFotVie2aW09K2qInnmDPrwBJpkBE+tFVmS8Y/El0Xq\n13IkPJUkEcqSSRbw1lkpRiKYRrvIDQ1hXLcOfXUVpo2KWyWYDvJ3XX9HJBthd83uUlDUqDXy8oqX\nF88FWchBdAImrylbKvTV73kAFZYKdtfs5vmm50kX0hwfPk5RKtIT6uFSrEtxM1VUIDocZHt6cJky\nyMEArkoTMxNJikWJ8BJ2xyxGS4EC8L/LsvyFIAg24KogCB/Jsnx7Efb9WMyMxwlPJbF7TWgEGd2N\nMyS7uzFt2IDW7VYq1oBfXPsFE4kJ9tfPRfob7A08W/fs1z+oLEM2BqkZ5cKNjsHgpzB6QXlMlma3\nIkgFKBaUf+UirHsDXv45aL+65F8QBF5re43eUC//3PfPXPNfY3OFkq52fvI8tbZa3M1NGJqbsO7a\nReSf/ols1w3MliaKtesx2XSlFgNl1cunnelyQJZkwj6lL4xGK+CstlDsuYXQdRG0Wkzr1mFcq7TD\nKEpFfn3n11ydvkqLs6XUUtqis/Dyipe/cqLXfYn7YLITnA2QnoGEX9kyEeX+uBejA1yNs1sD6B99\nZsCWyi2MxEeI5+KcGDnB6fHT7KvbR2egk+ZVL6C5dQtjezupS5ew5/1MFy04bXlmijJRfxqLI0Xd\nqvu3xf6+89jCLsvyFDA1+3NcEIRuoAb4ToU9lykw2R8llylS025BH/eTPfMJotmMaetW9E1N6Coq\nGI2N8t/v/HcqzBW0OpXqtQpzBc81Pvfo2S/FAviuw9QNRbxzSZjph8AdmBlQRFtvA3sViFoQNCDO\nbnd/zqfhxq8g2AM/fQvMX33BaUUt/3bbv+V26DaXfZfxmrzU2+spykU+HvmYH7X+COuuXeTHx9E3\nNZG+fh1Lx0aisSY8tVbGusP4hqI0rfegNy6rtkFLmthMhkwiR2gqqZTUh0NYw8Pk+vswrV+PxuHA\n2K6U/l/0XeTtgbfRiTqerlbGP9611B9Z1IsFSPhg+Cx88f8qRoxcBJMb6p+C8g7lGr8fmShMXVc2\nQQCLV3lf87NfeQ+Igsj++v2E0iHCmTCXpy/jNrrZWL6RT0OXeH7lSgqhMKlLlyj09WBvrUFOBNDq\n3YSnkrirLKQTOUzWB09H+76yqHezIAiNwEbg4n2e+2PgjwHq6+u//PSiE5pMEppIIIjg9BoxX3yb\ngt+Pde9eRIMBy47tSLLEv7/w70kVUrzQ9AKCIOAwODjUfOiB04vmUcwrlsnYBUhHINiniHloQLHC\n9Vao3gDeVWCvUS7ch+FsgDvvwS+2wZG/gxV7v/IUjFojf/nsX/KzD3/G8ZHjHG4+TKWlkmA6yEXf\nRXZW78S0cSP5ySkib74J3Z1ojC2U1bYzfidMYCSudL1rWR5d75YD4akkMxNJZAk8dVbyw3cw3TmH\nJAgYN2zAuGolgk6HL+njl3d+yVRyij21ezDrzGhFLYeaDn21qIeGIDwEkTFFyEcvQHgQRB1UrQdb\nFUxchp73YeQs1O2AyrWKYXM/sjEI9Cj3T2wCzGXww7+B1oMPPQ230c2O6h0UpALhbJgLUxdKhVT9\n9dXUdTvRVleT7enBsWYH0ZgBh0Mk7E8jzbpjTC2qsD8QQRCswG+A/02W5QVJ0rIs/y3wtwBbtmx5\n4uHo4Hic0FQKh9cMsTDijc+RTSYMbW0YWlag9Xh4b+A9Lvou0u5qp9xcjkVn4fCKw5i0pofvvJBT\nfIRjFxXrPDoGPR9AOqwsJSvXKWLuqP1qMb+X8lVgsMHN38Cvfg+2/8+w6Q/A3fTQt9XYavjF/l/w\nL0/8S94fep9XV7xKmamM6/7rNNgbqN68mcydO+gaGkh3dmJt2U40V4ej3MzMRAL/SFwV9iWCLMmE\nfElmJhOY7Xr06TByxI/UewvjqlVorFZMa9eSl/K8M/AOn09+TrWlulSE9FzDcw/syAhAJgZ9J8B/\nBwLdMHYJkn7QWaBxN1RvBN3s/VOxRjFyRj6HvuMwcg7qtkHVBtDoIRtXhPyumANYyqHuKZi6Bv/0\nB7D7Xyv3gd78wFNa51nHSGyEvXV7iWVjfDz6Ma+1vcYV8TY1K+oxtreT+OQTLJEJdFo7NhLMFI1E\n/GlsU8klee0vSlaMIAg6FFH/R1mW31qMfT4OmUSe6aEY+WwRV5UZw/ANCiPDGFevRtDpMG/bRiAV\n4G9u/A0aQcP2qu0ICBxoOPDAAboAFLLKRXrhr2DglCLk/R9B5z8qfvM1P4Yd/yu0PgfOOkXUDTYo\na4GGp6B+hyLSD7lIcdTCxp+B1gjnfg4f/5/wxX+D8MhDP/OqslX82TN/hk7Q8d7ge8SyMWRkTo6c\nJCdKmDdswLxlC3I2i7H/CoWpSbx1Vgo5ienB6JLOEFhOxEMZ0rEcyUgOZ7lRad88cA5kGdPGjejr\n69A4nZybOMeHQ0or3t21u5V+RLXP0uhovP+OZRnGr8Llv4M7H8Cl/1tZXcpFaHsBdvwv0LBTEXVR\no1zHtnLFet/0B0r8yFym3DcX/xqu/Te48AsYOKmsfBt3w9Y/hi3/k+KG2fBTZT+n/xw+/DcQ6H3g\nZ76bY2/WmXm+6XlERD4b/4x8Mc/ligT61hbQaMj1KkFUUzGOVicQ9qVIRnNLsr3GY1vsglJr/P8A\n3bIs/+Xjn9LjMzORIDSZRBQFbMY85pufgChiWrMGQ1srOO387aX/wHBsmB1VO7DoLKzzrqPGunBi\nUonwMNx+R7HQASIj0POhEhCq3gTNe5SL2Voxu3kV6+NBIp6JQWJaCTTd/Tc7m1dudivifvMtuP1b\nxc0TGYOKVbBiPxjv/+Wzt24vf7rpT/mLq3/Bu4Pv8sOWHwJwZvwMBzqeRd/QgK6+ntyNaxgadqKp\nqkFn0Cirm8kkFqfap/37TmgqScSvZHtYhCQkY2j7rmFobVV862vWMhgZ5NjQMfoj/Wyt2IrL6GJb\n5TY6yjruv9NEAHo/VNwvA6dgqlO5tlufB3fz3KpU1CpCXr9dCYreRZahkIFcSjGMLv2Ncr13vKLc\nM/frCmnxKPdA15uK4ZSagQ3/A7QcBN39B9vsqtnFydGTbKvaxtmJswxGBxGcAi1NZeibmsj29eHY\nsYuAYMZulYlMp5AKRcK+FBWNDzHovocshivmaeBnQJcgCJ2zj/0fsix/sAj7/kYEx+OEfEkc5SaE\nyRHou4mhpQXRZsWybRufT57n+PBx7Ho76zzrcBvdD05rlGUYPQ9DnylWeSELQ6cVV4zRCRv+R2g5\noFgrtocsYb+M0a5snta5x2JTMH0Tpm8pv69/A+68rxwvE1GOPzMAjbugdiuICxdcr7e/TiAd4B9u\n/QPvDb7HKy2v0Bfuo9nRTOWa1eSGh4m+9Rb2ocsEXHWU1bjxDcXwDUWp61iaGQLLBVlWsmGi/jQ6\ngwZd1I+1/wIUCpg2b0Zjt5Gr8fBxzy/5bOIznAYnG8s3ssazhi2VWxbusFhQ3CdjFxXD4s67yiq1\nbrtyDd71l2v1igumdhsY7pNhJQiKJa8zQcdhZbuLJCmB18gYREYVt2ZhdvVosCn3162jiqszm4DQ\nMKx6UflC+RLt7naGYkNIskT3TDfnJs9Rb6vnUmWCZ9tbyfX3w/gQFrcTWyFGqGgnGkgT8SVVYf8y\nsiyfhYcM8vyWSYSzBEbjFLISTrcW68VPIJ/HuG4dhtZWAroM/9j9j4SzYSVnXaNjf/3++w+fzqeh\n+z0lwwUUq73nAyXQU7sNtv+JYqlbPAvf+02wVynbin2KgE93Kb7IASeMnVeO37Rb8fH7bkDbD8A5\nPxCtETX8i7X/gnAmzFv9b/HB4Ae8tOIlPhv/jNdXH0bX2YmutpbCzctIdU9T1laJbxAm+yIkwhms\nrqU/XWapEg9lyCbzRANpXC4RIZfC3H8RfXMzWrcbw5o1fDR2kuuB68RyMQ41HaLV3cquml0Ldxab\nhO53IRlUDJvhs4rQrv89JcgPiuVcswVqt8z51b8uogj2amWr364YUolpxcCZUuYKsPY15b4bPqPc\ne9m44qtv3gOa+ffts7XP4kv42FW7i9/2/5ar/qvsqNrB2IZKPKdMZHt6cO5dRTyrR6OF0FQKd3WG\nQr6IVvfos1p/11lyOW4zk0onR1EjYMmFMPReRltZia6iAt261bw78C6XfZeps9bRaG9kc8XmeeXT\nJeI+xVJIhRRhn/gCIsOKn/Dgn8Gm3wfTEwq6iBrwtilbPg2tB+D6r+HWW9D9jmJBNe9VbrrKNcoX\nwT35vxadhT9Z/yfE83GODx/nxPAJnm98novRG2xubcW8dSvRo0dxjl4iVlGNxWkkNJlkZjKpCvv3\nmPBUingog1SUsRLHPHAFIZfFtGkTglbDHU+W0ZlRrk5fpdJcyY6qHRyoP7Cwl3pkDG78Wsk9v/Oe\nEtgs71BiR1ojaHTKCvX/Z++9w+M6y/z9+0zvfSTNjLpkdbnLdmzHLXaK0xPjECCEsIS6LPBbWGCB\n3aUs3y0ssBvaQkgghXRIAqQ5hTjuslxkS5Zl9TIqUzW9z++P49h4gThx3GTmvq65xpLmnHmPrzOf\ned6nuhaL1vrZRBDEna++RPS7T3bC2F5ouE78YhndBakIZFNiVk7TjaA72TpYLVOzumw1sUyMenM9\nBz0HqTfXc6RCxaqaClLdvZjyM8gkOgyqDMHpGNl0lpnpOFbXpVPPcUkJez6XxzcaITAZw2hToujZ\nCuEZ1JctRe50cCA3wssjL5POpVnuWk6JtuREUc8puPdD1zPg3if+Oxk6bq28DzZ8Q/Sfny/kanAt\nEv34DRthz70w+LqY826uhPAaMc1yzpWiyB+nRFvCXc13kcgkeH3sdV4bfQ2JIKFmzirUPU5x/F/3\nTjIVyzDZ6xg/Fmaif4byJstZGZpQ4PwiumGiBKdiCBJQZ4Noju1EVlqGvLiYWJmdPcGDdPu6iaaj\nXF99PRurN/7pTjU4Ap2Pw3gH9L0MCNBwPRQfb6thrRVTEM+VUfPHyBTibsC1SNzBWqpAaYC+l2D3\nj8TPRHBMdM2Utp3w9VcZq5hjnkMsHWNwZpBt49u4rvo6hhc4KTvcQ7q/D2OFjZlkhEDGxIwnQWAy\nVhD2i5UZTxyfO0ImlcOoSqHv24lEp0NRXU26oYpXRp7jiO8ILbYWijRFXFF+xalFSJmUmPFy6HEx\nnSufFbedDRvh8r8H29ub53hOEITjAdoycScxvEN87PuFmFoZmYLWzVB68ouq2dbMprpNxDNx9kzu\noURbgkll4poyF+rFi0k/8wzagQ6yZgcgjg8M+xMYrGe4rS5wwYgEkiRjaYLTcXTqHNqh/UgTUbSL\nN5DNZ9lp8pDKpNg3vQ+XzsXtDbejlP6fYHlgWAxWDm8Xg6TGMtFSVhlF33ntejEl93wjCGCrFR+1\n6+HgI7D/IdFFNLpHjEE13wxtfyMaYMBK10rGwmOnBFIVKypx/VYvthion48vpkYqFQPOtuM92iWS\nS8OouaSE/c2BGhKpgCdCORAAACAASURBVH6yC+nkMKply5CajGyTD/PG2BsopUraittY5liGSfVH\nVod/EB64Ucx2kSrE6L5zIbgWQOMNfzET5bxjrYEld4t+/ZJW8cYe2yNWrI7vgzVfhtp1J15+uety\nPDEPk9FJdrh3UKIt4ZhrHlUuFzKHA93RbUSr21ConMxMxfC7owVhn4X4J6LEI2lS8QxWXQRt324E\newkyp5M+uR+fzs7h6cPEM3GuqbzmT7uVBoZEUR/bK4q6rQ6abhLdgs4FolHxNlpdnHN0dljxd6Il\n3/W0eP9PdoqZOgcfFfPeWzehlqm53HU50XT0ZCC1/namW52UvHEUzeQgaq0evSJBcEogncgQ8sQx\nFb9FKvIs4pLp7phJZ/FPHHfDGAV0vdtBJkPV3Iyv0sK2iR24o27aStqoMdfQams9eXBoEu6/BsIT\nYjrVsk+JgcnG60T3y8Ui6m+iMoqpYBUrxGDqko+LxSBje+Cx98OLX4FcFhCDqRurN3Jt1bUopUq2\nDG9ht3SYpEmNpq0NIRZGPbgPgy5PyJfAMxYmf4lPl7nUyOfzBCaizBxv6GaODCAL+9C0NuFL+Djm\nhGQ2yf7p/ZTry7m98fZTT/CmqLsPQu8LYsZJ442in3vBHeJn4WIQ9T+mYjm03CqubdknoXy56HN/\n6m/gR8shMk2tuZZacy2Xl4oC3zHdwcDmpWQMGiKvvopJGsKgEGMSIW/ikmqId8kIu29cvLGz6RyG\ntAfVyCFUdXWgVbNDP8nuid0YlUbmFc1jXdm6k37keBB+sVF0ZTTfIvrz1CYxEl+z9s+mFF4USKRQ\ndyU03QAaM9RvhIUfEnPgd/4A7lkoZjIgBlPXV65nfcV6gskgb4y9wYHiOLJSF7LiYnQ9b6DJBsll\n8wTcUUK+xFu/d4GLimgwKQ7UmI6jkmcwDuwmL1dCVSlDKTexUiudnk6S2SSb6jadOqfUPyiK+lS3\nGCg1lkHzrVCzBhbdBca3qO240JQvFf39Cq1o4Cz7pFjn4emBJ+8CYJVrFVXGqhOB1El9jpErW8lF\nIij2v4pOnkIqyYv5/5OXTo/2i1S13jm+4wM1pFKwDb6BkM2gmjuXkWIJe4OdBJIBljmWsaZ0DTrF\n8SBJMgq/vF4se264XgxGGl2w+C7R5TEbKG6GRR8Ss3X0JTDv/aK1FfPDL66Fx+6AwBB15jqWlCxh\nUfEiegI9vCLrY1oIo2lrQxqbwTqyC4kEZqbj+N2RC31VBd4B/oko6VSWaCCJXhJFNdaNtLaeoego\nwQoL8XyKg56D1Jhq2FS36Y8OHIDDT4LnGHQ/I/Z3WfQhWHgHVK48Y6NmLBDj6f3j50ckSxeLBo4g\niC7U0jaxwntoG+y4B41cwwrnCpY5liETZGwb34Z7bSOx+jJSXYcxB3vRK8TgaTKWJhK4NCqwLwlh\nj0dShHxxApMx9Ko0uv5dyEpLyZi07LWFaZ9sp0RTwtrStdRb6sWDUnF45DbRP1dzhRgUci0US5lV\n52dQ9VlDaxPTLy1V4g1e1Ahtd4tFJL0vwg+WwOv/wSrX5SwpWUKJtoSt7jd4wx4g5ypGYitC37sd\nrVJM//JPRC/5Yb+XEoEJsSgJwObtRMhlyM4pJpKJEq4u5sD0AdK5NB9s+iD6N6s8ff1w6CnwDULX\nU6JhsOrzYmsAc8UZr2XXgI/r79nGZx87wNeeOXx+7iPXIqi7+mQFbPlloDbDG9+F4R3UW+pptDay\nxLGEscgYPdJphlfNAYMe5e7fY5BFj7tj4pfMyLxLQti9oxFC3jjZTA6rvxtpPIxm3jz6tBH2Jo4S\ny8RY4VrBytKV4gHphOiLG3oDSpeK3/JlS0R/3cXqejkdcpWYFeNaKP4slYs++LaPiB0mX/tXzAce\nYUHRAjaUb0AiSHhS6KAvMYqmtRlZ2Isx4SYVzxLxJwh5Lu1hv5cK0aCYDRNwh5FJslj7XiVrKcat\nihFzmAkpshzyHqLR0sj11ccrPqe6xUZzM6Nw+AkxhfC674t9Wt5BP/T/yyN7RvjAvbsxaxW8f2k5\nD+0aOX/i7pwvuiMFQayIrb0S4n547dsw0cnq0tUsKFqAVWVlu3s7Uy0leBdXQziEo+c5JEIO/0SU\nwFT03K/1PDBLVewk+Vwe71iEwEQMiSRPce+LCAYToWId3c4c+6f3U2Ws4uqqqzEqjaKo/+6zYjvR\nomYx2l++DGqvuNCX8u6RSMQvpzkb4M00TqUeqtaIX14vfZW2SIgSbQlry9biSXh5yDlAxGUmL5VR\nNLYTgOB0HL/70rjBL3X8bnF3FfIlMeQCKGamSdZWkMqmCdUUs296H9l8lo/N/Zg4RMa9XyxyC0+K\nRUhyDdz+qJgLfob1C5lsjn95tosv//oQy2tt/OaTK/jWTS18fHUND+8e4avnS9wdc8X0TEEi7l7t\nDWJK8IFfoZsZZ6VrJatKVxFNR9mePYqnzka+aQ7avt0Y8z6Ck1FioRSxUOrcr/UcM+uFfcYbFy2W\nySjGfACVbxjV3GaGBD/b8r1kchnWlq1lUdEiUdRf+qqYFmWuEr/hK1e8rb7ns4rSxdC66WRVoCCI\nbhljGbKn7matupQqYxWttlb2MMSL8h6kVdUYhnajkqYJToqWS2Ee6sWPfzJK2BsjlwPb9D5yMjme\nEkjrVXjNErp8Xcyzz2Nd+ToY2Q1HX4CoT/wMyJRw1/NiEPIMmYmluesX7fxixxB/s7KK++5cjFEt\nRxAEvnh1PZ9cU8Ovdo/wlafPk7iXtEDj9aK411whJhn0vghdT9MkqGgraaPJ0kSnp5PeGg0TDTYE\ngwFn7/NksxDyxvFeAkPeZ72we0cjhL1xspk8RRO7ycsV+MuM9FbK6fYdodHayMaqjcgRYOt/Qsf9\nYvfFppvE9qDVZzD+7gw5rxF3aw0s+ODJeIFUIX6RAWW//wI1SivLHMuwqWz8qniQqWodknQSU2KM\nSDB1oudIgYuX6EySZDSNf9iPQJ7iY1uIlVaSk0NoTgkdnn0AfGbRZxAGtx5vNR0UC3wkUvibLVD8\nFzo6vg0GPBFu/tF2dg34+PdbW/nadU3IpCclRRAEvnBVPZ9aW8Mje0b44lOd+CJJxoNxxoNxIsnM\nuflMFDeJRYUqg2jQBAZgWnQ/rTbUstK1EpVMxZZEB0Grksxl87FP7EWaS+EfC+Mdj8z6GNOsLlDK\npLMEp6L4xsJIyFF8bAtCXR0TBHlN5kEikbCxaiN1pjmioO/6kTjVqPU9oruicsW7ev98Po8nnGTA\nE6FzfIapUBKtQopaIUUll6KQScjm8sRTWRLpHHnyyKUSlDIJcqkEhUyC4s1nmQS7XkmpWY1dpzw7\nZf06uxhUPfyU2NRJZRRz8zsfY92ehxmeezXrK9bzVO+T/KB+kH/erqdobBeTVVUEPXF841HMJWfu\ncy1wbvFPRMnl88z40ugzXuTpGBPlBnIKKeMOBT3HeljiWMLiGb/YIiARgs5HxIrqD70I9vozfu9t\nx7x88uEOZFIJv7hrCQ0leoZ9UcKJDOFEhkgyQyyVIZbKYtYoWFpl4YmOMbonQlzRUHTi/pZJBAxq\nOUa1HINahvH4v10mDWrFu2jKVdIq1nLkcmIzvb5XwFyFoed51lQspt/Zzysjr7C1sgx9UEpZQwv2\n6X14pG2k4hmCUzEsjtl7789qYfe7o2TSOYLTcUypCWTZJIFyDUcqZfSHBllcvFgcede3RRxakU2J\nBUcN14qDL94BsVSGZw64GfBEGPRGGfBEGQ/GSWbe2l2hlEnQKmVolVKK9SpaXUYM6rceu6eSS3GZ\n1ZQef7wroVfqTrY+9fWJecq1G5D3Ps8Neju/rl7EguKF7MnvYbLaScmhHUirNxMcDRKsMJDN5pBK\nZ/3G7pIkMBEjNhkgnZVQMdlBQm8hY5UQrrSxbWqnaDFb20RRT0ZEUc8k4QO/AefcM3rPSCLN914+\nxv3bB7Hpldw838WeQT97Bv1vedzSKgv5POwZEl/3prhncnn80RT+6Kl+bYkgUGpWU1esp7ZIh1oh\nJZPN4Y+lCMXTVNl0SE9X/u+cL36JhSdg/wNiCmTtFbSMHWJVyTKO+o+yLXaIxab52OaXY3u9l8mS\nZYQmQ3hHtQVhv1B4RyOEpsJks1Aytp2MyUrAAFtU/agzajbXbabIOwC7fix2ZpxzNczd/I59islM\nljvv20P7UOAUC6PRYcCklmPUyDFrFNh1CjL5PKl0nkQ6SzSVIZLIMJNI44uk2DcSYN9IgMUVFtY1\n2qm26Yins0STWWKpzPGtKSTSWfqnI/RPR4gmM7iDcfyxFCUGFU1OA3OK9JRZ1JSaNajeTqtRqQya\nb4IDvxItd8c8iHoo6XySBSo1iaJm9k128LvWKB89lMMUHyMYKCebyhKcimF1XjrNkS4VEtE0iUiK\nwEgAkFI0uo3AnHIEqcALplGGg8PcaltIXej4cPXOR8TnzQ9C5fJ39F6BaIp+T4QjEyEe3DVM71SE\nGruWK5tKUMhOfukrZBJKDCqcJjU2nYJMLk8mmyeVzZHJ5lhy3Gp/5oCbaDKDVinjTU+MVCKc8shk\nc0RT4ufizR1vNJnhTQfJkkoLP3j/Aor0p+lG6lokWu6TnTC+F0paEIB1MQ3HytbwSM8jPOOcoKgr\nh62hAmkqzkz7CDOlJlKJzKwd8j47V42Yux4JJPAN+pGQxT62nUBrDfvLsrgTU6wtW8tqZZE4Vm7w\ndbH3xfK/fUeiHk9l6XLP8E/PdNE9EWJDYzGNDj2CICCXChQbVLhMalxmNSVGFUrZW4usOxjnV7tH\neLR9hD3P+6myafnAsgo2LSzFqJGTzGSZDiXZ2e9l6zEv+0cCjAfFKlCVXEI6m+fpA+5TzlmkV1Ju\n0VBbpOMjl1dTW/QXRFgqF11Q+x8Sp9HUrIOYl2V7H2FixUeot9Tzh/wR3mezUDS+C19NBaGJIH63\nriDsFyHBqRi5ZJLQTBZNKogiHSZabmBHeZB9wR7m6sr5grJGbPvc+SgkZuDGH0D91W/r/L5Ikp7J\nMP2eCL5IimAsxe86J/BFUyyvsbK4woxWKcNpUuM0qXGZ1BTpladtorVyjp0Wp5FnDo6TyuRIZnIk\n0zmSmeyJnzO5PHKpgEYhQy2XYlDJKTFI0Shk6FQy9EoZL3RNct3/bOMndyxiYflpBm+XLYG1X4En\n7hTntc7/AKbQJOtNRRwtWkj7VDuHLDqWy3OYj43hV7koDYVm9ZB34UKU0C5evDi/d+/ed3WO0SN+\nxro9HHx5FFN0mNa932Xwmnn858JhslKB7y/8EovHDkD7z8WZitd+R5xIdBpyuTzD/hhd7hn6pyO8\n1D1FlzvEmno7Ny9wnRDyIr3q9FvBv0Ayk+WFw5M8sHOYjuEAKrmEG+Y5SaRzbD3mIRhLIxFgUYWZ\n1XV22iotmDRyeqfCHB4P4Y+mCCXSzMTTxFNZ4ukso/44qWyO9y8t57Pr67Bo/0Kf7HhQnDeZjIgf\n+v0PkMxl+PFlH+Dnw7/nE9vNXL49zNbLv4Pdkqd6ZS0LNpQjlRfcMRcTPTsnmGw/Sld3lvKRLVgS\nh9izTsH9Zf2Uqe18Q9/KIplRFPWIBzZ8HZZ/+rTnnQ4l2D3op98TOWFND3qjvNA1iUSA9y8t55oW\nB1U2LVbduekf86YmCYJAMJZiYibBZCjB5EwCTzhJNifGtn5/aIJIMsOn19XwqTW1yE9jWPHyv8C2\n74nFTI755IBHdRp+3P8k+XSaf+itQ+lfRl+2gRpZP85br2bu2rJzco1niiAIHfl8/s+MuzqVWWmx\n5/N5fOMRgv2TZPMSSkZeJ1zsYFdlHH8mxC2l17Bg8ggc2yIWKaz4jGitvgXxVJb9owG6xkNEkuJw\n2219XrrcITYvLuXrN7S8u2DOH6GUSblxvosb57s4PD7DQ7uGefrAODqljCsaillTb2fVHDtGzam+\n+PoSA+sbSzgyGaLbHcITPln+HEtlODgmnus3+8f59Lpa7lxe+ae7CLVJLGQ68JD4c/OtKPY/wHsP\n/JZXXOU8sWCCVduzGBIThGaKyMTF5ki20oLVfrGQSWcJ++IE3WFAS5HnAH0LrTzs6sKiMLJJWcp8\nmVHsAROZFu//04j65EyC3YM+Bjwn6xfy+TztQwF2Dfiosmn58QcWUl9y7hvi/XE8yaRRYNIoaHSI\n75vJ5pgKJ+kcDWJUy3nu0ATff7mPV3o8fHxVNS0uI2VmzZ/fOVzxz6LFPvAaqC1ITOVsiITpdizj\nmaEXeKl4mptyXlTuAL6IFEskTdifQG+ZfcNnZqWwz3jiJCNJApNRJHkZtukDDC+rY4txiBJVER/O\n6ZF6u8RWntVrYc0/iuldf4ZYKkPHcIDOsRlSxwOhWqWU/ukoHcMB7lhWwTdubD5nwydaXEb+7da5\nfOPGFmQS4bRbWbVCysJyMwvLzUyHEnRNhOiZEPNuL6u2UlekY/egn28/18ODO4f50jWNbGwtOXX9\n+mKxM17n46C1Icy5kpKe33Gto5YfarIMVRixTbQzUHUjsbEp/OWmgrBfRMxMx0n7g4TjUuTpCNJ8\nkJ8s9iCTyNiodrJebkF66EkxnrLoQ7D2q3/xXOPBOLsHfAz7TpbSy6UCTpOKx/eOsWvAzy0LXPzr\nza1nzbB5N8ikEnHXbFKzrNrKvFIj9+8YYvegn2/8rptrWx04TWqWVllpdhpO/TwJAtz2MNy/UUz5\nrF6DvXQJ1+bU9JjqeINjLPT2YM5amNA1Ee/uwlOmn5XCPiv3197RCOmpKUJxBabQMbIKOc/ODRDL\nJ9mkraYiGYejz4PeCbf89M9ONY8mM7ze6+G+bYPsHQqQzuaoLdJx0wIXeqWcx/aOcv08J1+/4dyJ\n+h+jkEnecZP/IoOKtfVFfHRVNdfOdVBqVmPVKdnY6uCm+U6SmRyf+tU+bv3xDg6MBk892Fx5vEpP\ngKJmcsZS7jy2gyKJnt8vTGCfFueSB8fDzExFyZ4m+6fA+SM4HSPt8RBJyrF5O9myIEtUlmGjvpqF\nOTllh58VM0Hmvheu/OafzAUFGPXHeLJjjMfbRxn2xRAEKDWr2dBUzLwyE//9Sh97hwJ8/YZm/mvz\nvItC1P8vZq2Cq1sd/OzOxXxqbQ2BaJpH9oxyZCLEy0emeGDnEEcnw6fmyluq4FO7Rb/7wGvQ/Rva\n0nC1thK5VMFvnEPkzTOQzxHoGsI/MTvv/VlnsWfSWQITYYIjfrJ5Hc7RbYxX2tlpGqdFXcJ7FU4x\ntS+fhU33njIPESCSzNA+5KdrfIZ0No9EEGh06GmrtGDVKXn+0ARfefoQq+vs/Nd75s2KiSpSiUBd\nsZ66Yj3eSJLOsSAKmYQyi4Zud4hdAz5u/uF2PnJ5FZ+/qv6ke6a4ScyU6HsZyZyrUO29j1tiMf63\nNsOHJTmUyQDhhIb0tJcZT8msTv+6VMjn8gTHZgh7YuQwYvYf5rdXxbkxXkGdOsHawR1iSuO898K6\nr52YKASia+XYdIS9QwGmQmJQ/s3srqbjro5vP3eEx/aOUm7R8MhHl9FWabkg1/lOMKjkfOGqBq5q\nLuFjD3bw1L5xzBo5dp2Sl7qnmFOk44b5LhZVHA+yqgxw1wvw7KfgwCPIoh5urL+GTnMjr2UPsL/4\nEPXdDrxyJ0UeL363FXu5/q0XcZEx64Td746SmvIQikoRchms/i5+fq0GpSDjw5pajO4D4hSktV8V\nm2AdJ5HOsmvAx6GxGTK5PFKJQLPTwJIqCyaNGGjcdszLZx49wIJyMz/5wKJTUrlmCzadknUNxayo\ntdHtDmHTKZlTrGPbMS8/e2OQl7qn+MHtC2ktPV6RWtYmznQd3QOli7l7rJ2HKirZ3SSlzLOfceUa\nkhPTs75g41IhHEiQmPQQjEkQcmn67T2sCjqYW5Lmur52pIJMrFtY9gkwiCMPM9kc3RMhOoYDBGNp\nAKrtWhZVmHGZxGlZv+uc4Ou/7SYQS/Gx1dV89oq6i9JKfyvmlpp46XOruPeNQbb1eTk2FaZ3OsKO\nfh+/3DmMXiWj2WlkdZ2duy+vQnbDD8XRlzv+B3vnE3yicilHVXZeLOmhobeFpLKSyK4OPDXOgrCf\na3xjYdLuSWaSWiyBLjw2NfudUa5Ul7E6K4WhrWIZ8arPA5DN5TkwGmD3oJ9kOocEcJhUmNQKPJEk\nP/5DPyP+GMO+GH3TEartWu67s23W3dT/F6VMyoJyMwvKzYz4YtQV6/nDUQ8vH5nixh9u445lFXz1\n2kYxk6BmHSRmEDJJJNPdvCcS5TeLsnzjsS7GStcRmknh65+maq4NYRbsYC5lZqbipD1eZpJS7N5D\ndJXb2Zia4bKxPmQKneh+abkF7PUk0lk6x2Y4MBogmhQnapk0clbX2am2izGT8WCcrz19mFd7pml1\nGfnFXW20uGZZ2+o/Qq+S87kNdXxuQ90Jd+sfjk4zMZPAG05ybDrMrgEf7UN+fvyBhShXfQG0dtj2\nPRoHtvGl4mr+Xp3n13O3cVXXPAKJPPphD4l5dlS6ty4svJiYdcIeH5tiJpwml5fimNzDs4viOHIq\nPiqxo+j6DXm1Gc/GexkZDtA+5Gf3oB9POEkokSGRzuKPpsj+UR8IhVRCmUVNuUXD8horH11d/SfZ\nKLOdcquGcquGRRVmWlwGntg7xi93DvNKzzTfvLGFtQ1For897kdWs54PHf0tD5WVElKNIckmCcQl\nWNxThAPVhXmoFxhf3xTeQBwEO5pwB9cIGZbQS1JlQT7vfVC5gmzpUjoG/bQP+U8kBMilAm2VFhZV\nmJFJxVYXv9wxxHdeOgrA165r4s7LKk7p9TLb0SplbGx1sKrOTvuQn8PHd+sHRoO82jPNbf+7i199\nZCmahXeCTAUdv2Dt2B4+ai3mh9Zxrkt349fOp6ivD89oGWWNF79b6k1mnbCn3eP4jm9DdTPdbG3K\n8WmpgbojzxHIa7kj9kUOf7fjlGP0KhmVVi2VZSbKLWoqLFrKLBoqrBpKDKpZ4Uc/G1RYtdx9eTUr\nam3c+8YAzx2a5O4H9rKx1cHnr6yjvOVWSITRuvdxXTTK8wvyrBw+gt9WT9LjITAeLgj7BSQRTRMZ\nmWQsEUad1iK1DLHM2M2U3k5R6/uhqIFh60pe2zlE4LjLBaDSpqHMrGE8GOf7Lx+jdypMlzvEeDDO\nmno737qphVLzpTHE+c+hU8pYW1/E4goz7UN+pBKxwPCVI9Ns/J83uO+uNqrnbgbyoLHy0d7neV1W\nySu1f2C5u43QsVGmj0xSWm+eNTvWWSfsoWiQRKYIq+8wOxtSXJZRcMfgPsYkTt4T+yK1tfWskQoY\nVXJKzWo2znXQ7Jy9W8uzjSAINDuN/MemeVzVXMK/Pd/DswfdHBgN8rHV1Vxfez2G8AR3HLif2xs1\nXHuwC499PoHoNN7uESrmFp3+TQqcEwLuMMEpN7KUC5t3L+sbexhS2JG3bCKhdfBqbhm9+ydIZ3P0\nTISZCMWJJjOMBxMndqlSiUCFVUOry8iXNzZwbavjvGR9XQzoVXLWNRSzqMLC7gEfCqmUF7omuP2n\nu/in65q4sulW5LkMaX8//+Ud4EaXwNr+UQKCDfPQKDOeSkzFs+MLcNYJ+3QkRR45xdP7eG69hHu8\nQxyV1vOeyOdZXF/B3FITSrmEpVVW5peZzrg69FJHLpVwdYuDy+fY+Pfnj/KrPSN863dHaG8u5sOV\nVzKnaB+L00MMm7sBCCVkBIfdxCMp1Lq/UNVa4Jzi7Rpmf2YIi+DAKuxgWlLMkabLaU4aeVBYwnQg\nTufYDIfGZ4ins5RbNDQ6DNw438WcYj11xTqqbNrTtr641DGq5VzZXEJbpYUKq5qfvjHIPz3TRd9l\nldzYch2V84NY//D/+HtvmKO6ndiymwn1djF1pBZT8eyYhTzrhD0Z0yDkUqRzh9mk8XEouYgPRf6O\npbUlzC8TfciX1VjRKGbdpV0QtEo537iphevmOfnMo/t5+oCbAa+Rjxfdyubh/8dP5oW5obufmNbK\njMeNr2+a0vmlF3rZf3Vk0lnGe/tRzRhQJgK0lHTxsnYerpCJB5WXsW0wQu/kJLl8nnWNRXx8dQ2L\nK8x/Ndb4mWDWKvjiNY20lpr47GMHuH/HIMF4iiVFV7C4Zh+3HX2GT5cdwj5wM8Fomsn9x6heXol8\nFiRWnJVIiSAIVwuCcFQQhD5BEL50Ns7558jl8iRTBmy+Lo41xolHF/H+yOdYVFXEDfOc3L60jCsa\niwuifgYsqbLw2udXc9N8J51jM3ztaA1J5dVkitPoZvaQlpkIJ9KM7eu50Ev9qyQw7OP15Btosg3Y\nZ9rZL1vCYXUT/zK+hp/tj9I3HeGWhS5e+/wafn5nG22VloKov002tjp45O6lZLJ5nt4/zs5JgRfV\nm+lXlvMvyW6kyYNE1HOYHu1l+sjEhV7u2+JdC7sgCFLgh8A1QBNwuyAIZz6W5S2YPDRADjV2zz7i\nlib+IfEJLqu28rXrmtjcVnb6Fp4F3hKVXMb337uAe+9cTCYHfzt5A2vCatrL9yPJpcnG1bh7e0nF\n06c/WYGzytFd7SSiaRCkFMu7+L5mHQ9Nr2I6IePDKypp/8p6/vM986i0FWoNzoRFFRYe/egyAB7e\nPcK9x7T8SP1pZBkdDu1WsjItY9EBere2X+CVvj3OhsW+BOjL5/MD+Xw+BTwK3HgWzvsn7H729wi5\nFAHVAPdI7ubKpiLuv6uN5lmcd3sxsr6xmFf/fjXLqu087vskB5qjWHydpCQlRIIeBnbOjpv7UiGf\ny/P70Ueo8S5AG3XznaJr6JJUsHlxKbv+8Qr+6frmE0V2Bc6cFpeRZz61krsvr0YulfDrSRcfyXyW\njZbtKJI+NMk5tI9tIzg+faGXelrOhrC7gNE/+nns+O9OQRCEjwqCsFcQhL0ej+eM3sitGqK+93Ge\ndFzDTa12/veOxajkBbfLucCqU/LQ3yzh7us2IITX4VfsJivVoJMF2fvi74gf74BZ4Nzzym8fo1s9\ngiCrIZ8YYK+u5kOCfwAAIABJREFUgq9ubOA/Ns1Dqyzc/2eTcquGL13TwJb/bzVbv7CWRQvaeCK7\nnqr0VjLKel629PKZnz1NKJ46/ckuIOetGiGfz/80n88vzufzi+12+xmdo/lwHG3gAPLaJr57e1vB\nh3iOEQSBO5dXcc8Hv0lHeRxFKkQq6aBRsYVv/ejH7B1663FoBd4dkWSG3+3tZcfRe1h0bCEAz5oc\n/MN8Ex9ZNTuyM2Yz5VYNX968Cr1qOdXmXQCsHaxnl+EgV/z7CzzVMXZ+B9S/A86GsI8Df9yNvvT4\n7846oU99gYeX38F3PrD6r6ao6GKgqtTC+xo+gia0F58wHwc+/iH4bR6697u8/2e76BguCPzZJJHO\nsr3Pyy+3D5De/z1eM/txRhejjIyyoETLx97zzub1Fnh31CxbSY9kOdZID7bUUpTGbSRyE3z+iYPc\ndX87Q97o6U9ynjkbwt4OzBEEoUoQBAXwXuDZs3DeP+GGJdV88LL52Cps5+L0Bd6C1stXImhnQCLj\nlzO3Es3q+L7sHjaNfJM7f/wKX/51J/FU9kIvc1aTzIiN6u7bPsieQT81oT1MRF6mdLyMpMqJgJdN\nSxsKw8XPM2WLmkhpWrEJXaQUVpYO1VBjfoQ2wzh/6PWw6Sc7+Onr/YQTF09Swbu+Q/L5fAb4W+BF\n4AjweD6f73q35/1LuBY1zpqy3ksJS5WV0rlXoo2MYYg28sv0SnpMddwk3c4WzVfY2b6Hzz9xkB39\nXhLpgsC/E9LZHO1Dfu7fPsTOfh/pTJ51mn5qJ37J4wY5K/qXIuSyOMrsOBfXXejl/tWhtWqwl1Xg\nNZYhS0e5fGQx/RYf863P8LmyY8RTGf7thR4+/mAHbxzzXBT3/1mJvOTz+eeA587GuU6HrbpgrV8I\npFIJJW1N+Pc8SlR3Ge3WJykJl2NqaaHk6Av8p/ZhbjvsQC4VODg6w8JyEwvKzbOy9fH5IpPN0Tk+\nw94h/4nuixatgsrcMAMH/kAw2UMCE1LZfLSJMaz1DRiLCumM5xtBEChuqcI7NEjOP0hYO5fy8MN0\nyob4Unk/K0oVfHWgie39Po5NR1hbX8Q1rSUsrDBjUF2YhoKzLqSuUM+6JV8yFNU7cFeV4g5kWTow\nl5fn7EYvNbCpbBltA69ym/koTx2WoJZLSaSz7B8N0lZpZm6pCXnBfXCCXC5P94Q4ACUUT+OJJHEH\nE4QTaXonZjCkPTyuepj3lpu4eWcLKaWZImmYkvnVhd3qBcJW70S/rYhoYIiMVMMdu1r51w1dDPX9\nnqvrNfxmbRH/7W7mlzuHeWzvKC91TzK31MQN8xysqivCrj83g7//EgWVLPC2MdrVaBfMw/TMHmSq\nJRy2/J7KKRkLK+dT7d7HN+W/YLv2v3j+8CTvXSLG07f2etk3HKStykKry3hK755Rf4xv/b6b3qkI\nD31k6YmhD5cyfdMRdvR7GfHF2HrMw7AvRvJ4a91qs4xbit18NvwdHtLImJFAlX8uPksKU0sltkrT\nBV79Xy8Gmwp1STGaoJeZYApFpJmSaC8/1ynYsP+XaDNxvtRi44PLV/OT1/vZ0j3F670etvV5mVOk\nY0NTMZsWllJxngrICmZUgbeNIBGwN5Vi1qZJK0xcc3geWxRetiTcZKpWI5sZ5smmbSDA84cmKbdo\nEAQxbe+1nml+sWOILvcMsWSG77/cy/rvvs4bx7x4wknuun8PM5dwRet4MM5j7SP89qCbw+MzPNI+\nwoAnyuVzbHx38zx23V3Oq0v283XJfcSz0/zCqGdjdzEBUyumvBdTbRla0/m1+gqcRCKVYKkvxaDU\nocz58JubuG1XJUMKOb/WqsgfeAjaf44z3ss3bmzh2b9dyZeubqDZYWDAE+WeV/u45cc7+PqzXYTO\nQ5C1IOwF3hFWlw7d4nnIMjFa3W2khRy/j02wW2sAQylFh3/K/VcpmQoneGDnENfOdWA7vg2diaX4\nyR/6WfHvr/L9l4+xoamYV/5+Nf97xyIGPFE+/mDHicEQlwreSJJnDozzePso44E4nWNBnuwYQ6uQ\n8dQnlnPvnW3cUh6nZOx5GNuDMN3FV5zlkJewsqeRjFyDscyGvWb2DHm4VLGUmZBbLGj1MpJKM7Uj\nCspDen5oNDKmtcCRZ+H5L4F7P3a9ko+vqeHeOxfzrZuauaKhCKlE4P4dQ+wZOPfpwQVhL/CO0JmV\n6KtLMacnCOnquOFYM4NpD0/lfPgqV0A6xoKuf+OejXYOjc/wrd8d4bbFpSwoN/Fi1yS/7ZxAEARu\nWeDishoriXSOFbU2/v3Wuewc8PHFpzov2qKPd8J0OMHzhyZ4aNcwA54omWyOV49O89pRDytrbWz5\n3GrmlZnAPwBdT4NvgHz/qzxjddAhzbJhpJy4vApZNo65vhSLU3ehL+mvHmORGpndjkUjQD5HRF3G\nzV0NRCU5/tlRRrioEUZ2wLOfgWGxoKnIoGJzWznfurmFL13TwDdvbGFN/ZkVaL4TCj72Au8IQRCw\nlhow15TgcSuZ3zeHbVV9dETH2GJZyOaiJiSju9ng+g3/uuEmvvzSNJv/dxfd7hAKmYS/XVtLuUWc\n5jMdSvL0/nGKDSrmlhr57Po5fP/lY7hMaj5/Vf2FvtQzYtQfo33Iz7AvduJ3iXSWl7qnGPRG+bt1\ntXxmfZ0YawiOwOGnIOYjf+Rpgiod37WYMSfSXLHfRH9RCxZNAmOZBZX20hrXOBtRqGQYKopIDY+g\nlqXw2ObT1PMwLU029hv9/MrRzN1KE5LRnfDK12HNF6F6DQAOo5pbFpaSSGfPy/jBgrAXeMdYXTr0\nzXNQDXURlbpYM1HB4xU97JXnaSxfyDxvL/S/yu3NJqZXrOJ7273cvMDFl69poMggduCcCiXYM+in\n3xNhKpRgS3cChUxgVZ2NH7zWh9Ok5n1Lyy/wlb498vk8fdMR2ocCTIUSJ36vlEuQSwQe2DlEJpvn\nZx9czIamYvGP4Sk49ASk4tD1a3K5DN+oW4w/Nswd43VIwmpyJXIs9RZspQVr/WLBXKIh6CjB4J9i\nKutAMRPhqoFGuufv5JXUFEucc1mQjomW+44fQDoBdVfB8fYnKvn56eVeEPYC7xiNQYHWqsOiTeFW\n1LK0v4dXnIN0THdSU3EVc1yL0IzuBtdiPmPeyp1/dwsm56m9TYoNKq6f58QXSbJ/JMjRqTCpTI65\nLhPDvhhfffoQuXye25eUX7RTsBLpLN3uENv7vEyFEiQyOVKZLGqFDKNKjj+a4uHdw9TYdfzkjkXU\n2I8LdMwPnY9COgm9L0BkiqfrVrI1MUFtwsjCIxq8lmYUJDGWVWJxFHLXLxZMxVpkNhsG7QRTUfDa\n5lJ5dIpllXZ2Ch5eVHuoqFmNJR2Fvi2g0EImDo03gOT8DegoCHuBM8JaqsO/sBH3bj/JkIF1PhdP\nyAcYSgd5qWENN04eRuh/BeZ/AFP/06C7HQzOPz2PTsn6pmJW19s5NhXhsHuGjS0Ontw3xtd/20W/\nJ8KKGhsOkwqnUY1Ze+Ha08ZSGQY9UV7pmWZHv5cjE+G3zOQRBLh+rpNv39KK7s0ujMkwHHwUUjEY\n3wvTXRwtncdjWhWZYJob3LUYh6fobWnEXqLGVKxBNgsm9vy1oDEo0BiUZEqLUPnDTDuXsbDjP1jr\nbqPD5Gdb2k+V3MitDdcjO/QEHPktyNSQSULzLSA7P/dvQdgLnBFWp5YxuxF99hgefT1rJqK8bBuj\nY3Iv5XNuYbThSsoP/Qa8R8HeAJ2Pwfz3g+7PD8OWSyU0OQ00OQ0EYymaXQb+8TeHeKx9FPJgUIs+\nZrVCisOowmFU4zCqKDaozkl1az6fJxhLMxlKcHh8hq29HrrcIUb8MTK5PDKJQLlFw6o5NmqLdFTb\ntZg0CoxqOSa1AqNGjl4pO7VZXTouinrUA4NbYXwvYUslj1Qv5sjoFlaGHbjcasIKDXmJDGuVBaur\n4Ia52LCV6ogF7ehVfjwZB1lBib0/xhpHCS8Ko3Ram3GkY6xquRUOPAxdvwa5CrIpaH0PyM99vUZB\n2AucEUqNHJ1ZiaXazvBwDgbjXOFy8qRsiPHIOC9WL+HDgzuRDrwG1lrR13jwUVjwAdC8deqeSaPg\nurlO5th13PKTHTzSPkJDiYFGh54ivYoBT5QBj9hRTyIIWLRybDoldr3yxPM76VOez+cJxNJMhxNM\nhZJMhxL0eyJ0js3QOxXGGxF7b+tVMpqcBtoqLWxsLaHFZXz7g6GzadGnPrZXdL8kgqQd83hqzmVs\n83WgEZRsmCrC2j9Nb/G1yGV5DEUazMWat30dBc4P1lIdY0cDmJ16PL1ZJstXUTy4jZX1deyw+tg5\n3YGzciOlsRjVrZvhwINw6HGQKsFUfiKgei4pCHuBM8bq0jHTUMroYD8ewcnVXgUvWcbpmNxL6ZxS\ndi96L8tf/z6Md0DZUkhF4eAjorirTj/1qt5h4MmPL+enWwd47tAEB0aDlFs0NJToqbZpUcql5PJ5\nvJEU3kiKnsnwiWM1Cik2nRKrToFEEMjm8mRzeTInnnPk8nlSmRzeSIpUJkcml2PQE6VrIsSIL0Ye\ncBhVrKixsqDcxKo6O40OA/p32v8jlxUtt733wcRBUJth3vt4zepgf8bHVGyKW4K1GEJSZNNTBObU\nU+TQYHHokBRaMVx0KFQyDDY12WQJ8r4Rpp1LKe9/Du14mqvsLp609NEXHec1QzV2iRp9621w4CE4\n9BhUnJ+WywVhL3DGWJxaRrqkWKwSpvMLqe5+mCuKnPxGNow74gazk1bXQvTDO8BUAfoSSITgwHFx\nV57ezdDoMPC92+bzL9c388zBcR7ZM8pL3VMoZBIWV5ipseuQSgQiyQzRZIbI8Uc0IT7HUlk0Cikm\njQKTRo75+LNJLT+RdjYdTtDtDnF0Mkwik0OnlLGi1sbKWhvNLgP1Jfozn6ebz8Or34Q990IqAqVL\noPJyRg12uoU4u3p/T4nUQtu0HstgFK99PnlBgrXCVAiaXsTYSnXMTMcwmqX4fFZSWhvW/ikWlZax\n1Wpk9+Ruqo3VvGy2c6MgRdKySQyYv/otqF3/tu79d0NB2AucMXKFFINNTVGzC++2SaYSJm4O2HjJ\n7GbfVAdOnZPnm69kU2AEyf4HoeYKcC6AeEC03Oe/HxRvz9Vg1Mj54GWV3LGsgsPjIR5tH+GZA252\n9Pv+5LUKmQSLRoFRLaPEqGImnmEsEKN74tRxfmaNHIVMwlQoiUwicPkcO+9ZVMqGpmLkZ8NvH/XB\nEx+EoW2gsUHzzWBwkjFXsFWeoWN4B7FMjDt8c1BlJSgHjjGx8HMoFAI6iwqDrTCc/WLFVKJBKpdg\nqbDg9fmZaNhIRccDqINFXDdZwn3FRznkPYS0aD57nY0sIQ+NN8KRZ8T4SsPGc7q+grAXeFdYXaLl\nolVmcDtXUHH416y3unhGOsRUbAo0xbx63b+yfuf90PcSBIeh/hqIeo8HVN8HsrffA0UQBFpLjbSW\ntvKVaxvZ0j1FMp2j2KiixCA+DGrZnx2bGE6kGfbFGPRGGfRGGfJG8UZTfGptETfMc57dgdAju+GR\n2yAxAxUroHy5mO5mrmSvrYyhsdfp9HbSoqyi2ifFPpoli5wZTRklLh2mIk3BDXMRI5VKsDi0ZJJZ\npBIfXksLZVI5tsEo9SYr1cV2OqY7aLA00BEewlWzGlc+D/VXn3NRh4KwF3iXmEtEASqqsTDYLcPX\nl+W2UCMvmcbomOxgY/VGelN+Km++h9r2X8KuH0LHJDTdJJ7g0BMw9zaQvvPKSo1Cxo3z/2Ru+l9E\nr5LT4jLS4jq9f/+Myeeh/V544Yug0MPCO0F3vCjJXIF/zhXsP/YUr4+9jlwiZ+N4EUpBQHb0EGNV\nawEBi0uHuaQQNL3YsZbq8IyEMRWpCUzliVYuQDfYgb61mOvH7Px3qYd90/tY7lzOy4EuNjdehzrq\nPS9rK5gEBd4VUpkEU7EGS7kZmZBl3HE56s4h1s+UMhwexhsXb+Rt7h0krvga3HqfKH77H4SxdgiM\niIHFZPg07zQLSCfg6U/Cc58HUyUs+tBJUTeVk2/ZxOvu7XT7upmITrBaOw+rP02xDySRGaYcS1Gq\nJGhNSoxFBWG/2NFbVCg1cswuPbm8BG/1WshlKRqO4YqrmZdzcch7iFAyRDQd5bXwgJhEcB4oCHuB\nd43VpUUiFbA61HitLYQG3Lwv0oIyJ6VjqgOAWCbGDvcOaLkFPvQ7MQWy/xUxx9c3CB2/hPDkBb6S\nd0FwFO67Eg7+SnS9tGwC2XEfuakM5m6mZ6af/mA/Oyd24tA6WD6sRi1TIe0eJG5wEpaYMbv06C0q\n5IWipIseQRCwleow2NQIEpiR2Ui6Gsh2H8GpsLFx2IwEgd2TuwEYCg1xJNh3XtZWEPYC7xqjXY1E\nJqGozgaCgLvkMrSdA1wRLmNgZgB/QmxT2uPvYTQ8Co558P6nYM6V4O+HjvtgfJ9oxU/3XOCrOQMG\nXoefrgbPUWi+FSovP9EbBFMZtG4mlkuzw72DHe4dpHNpNujaUHvCOBJqmBrHXX8tIGB1aDAVF7Jh\nZgvWUh1SuRSjXU04pSZStxIhlcQw6MeZN3JZopS+YB/TsWkAgsngeVlXQdgLvGskUglGuxqVVoFB\nL+AuXU2su4c7onNR5CTsm9p34rVbx7aSzqXBXA7X/w8s/ogYPO16Cg4+BvseELNIZgP5POy4Bx68\nCSQyWHAH2Oac/LulClo3g0zBTvdO+oJ9HAseY0HRAqoGomjlGiRdQ+RkCrzGBpQaKWqDouBfn0Wo\ntHL0FiWmYg3prEDYWEnSXkni4CEqdOVsGDOhlijZ6d55XttRF4S9wFnhzZzromozaakGj6UF3cEB\n1kXL6Qv2iRkywExyhvbJdvEggwNW/wMs+xRUrYHAIOz5KWz9Lzj0lFitebGSy8GzfwsvfRWKm2He\n+0BjFf8mCFC5QgwKyxSMhcc47DvM1rGtGJVGlqoa0biDlEuLyAwcI1SzjGhGicWpQ2NQFlr0zjJs\npXpMx2MikbyWaOPlEIsgGxijUuVi3Uwp7qib4fDweVtTQdgLnBVMRRoEiYDJZUAuyzNadQ3xw4f5\ncGQBpqySFwZfIJKKAHDQcxBPzCMeqLPDko9A6yZo+4hYcj3wKrz4JXjt2xdnUDWfFwOk+x+CmnVQ\nt/FkyqZcJfYDqVoFgkA2l2Xr2FY6pjoIpUKsLl2Npc+DU+uAngHI5ZgsXw0IWBxaTIUWArMOi0OL\nUiNa7uG0ilRRNWmTg2jHfhwaB1d4bJglOna5d5HNZc/LmgrCXuCsIJVLxCCSIGB3KgmpnUQVNtSd\n/XzRv4xMNsXzQ8+TzqbJ5/O8NvoaufzxMXhKvVisVLtBDDo23Sz2Kd/2XXjwFjEnPHeRjMzL5+HZ\nT8Pen0PZMnC1nfSn64th0V1gPdmieN/0PvqD/RycPki9uZ5yqZ1id4wShY1EVxdJZwMzghWVVoZa\nLy8I+yxEKpdgdmgwFWtIxHJk5BoiDSvJh4JkBoeoMdRwjcdFIBlgu3v7eVlTQdgLnDXe9A3b64oQ\nyDNSfyPxzk4W5cr4UGIxvriPV0ZfIZ/P4417Oeg5ePJgiQTmrIfmm6CkRbTeXYvFlMgHrhf92Edf\ngEzqwlxcPg+eXnjkvWKQ17kQqlafFHXHPFjwQVCbThwSSATomOzg9bHXUUgVXOa8DFPfFFX6SpKH\nuyARJ1i3imhKjsWhRaESG6sVmH3YSnWYjt//EZmFZGkjGZ2FaMc+dHId6+OVuCQWnu1/llg6dpqz\nvXsKwl7grGEu0YIgoFDKMJkkTBmbyeSlJA52cnOsgTWmNgZnBtkzuQeA9sl2ZpIzp56kuEnM/zY4\nxZ4aiz4k5oQPboVH3yemFO574Py5aPJ5MVNn733w/BfFzozFreLuQhDEoGnDRvEhPVnvl81l2TK8\nhUPeQ0zFpljuXI42J6d+Wo4qJyO+bx/Jklr8umrx/86pxVSs/rMVswUufgw2NQarGr1FideTRVCq\nidavIOf1kB4bo0xfxq2TZYRTYXa6d57z9RSEvcBZQ66UoreIFmdRrZkcUiYbryXR2Yk8necTsSU0\nWhrZN72P3kDv/9/emQbHdWX3/Xdf7zsa3dh3gATBnRQxFCUxFClSIqURNdKMxnHicWZsxzO2q/Il\ncdlx5ksq+RKXs1S5bJejpFJOvEkjcTQjeSRRoiiJEkWCBEWBFDdwwb5vve/dNx8e2CQEbiKBxsL7\nq+pCL6/vOxfd/e/T5557Dplcho/7Pp49kMMPW34IpS36Bp+1L8HWH0PFBhg+q4dCXtkFR/4rhEfn\nZzKZpF6V8uT/hnNvQuf7euy/pEUviSCEXqXxkd/UvfWvcXzoOD2hHo4PHafKWUWzt5nqgSQVJj+J\nL79EJpOE1z1FOGPH6jRhc6owzFJGCIGvykl5o4dUIkvE4idet5GszUXs1CkMwsAusZr/UvK77K7b\nPe/2KGFXzCnecj07xlXqwmrO0VvyOLl0mnhHB/7xNL9d8T0qHZV83Pcxw9FhBiIDnBk7M3sgo0UX\n9BW79RorNi+s3AuP/oG+ASjYr1dNfOVJ+NUf6iKcTswe55sSGoKL7+hpjJ3v6zVtRr6Cy+9BcRO0\n7Aeh6Zkwrb+lV6z8Gn2hPjpGOzg6cJSszLKjegcGKdgwaoVkiviXX5KqbiHhqSKaMFBcYcdgNOAu\nmf8GDIr5w1/jxFNqw+owMjYOWO1EVz5GZmCA9MgIHouHzbaVdx1nLlDCrphTrsfZhRCUVNtJSBvh\nVTtInDlDLpHgW6MOvrvyuzhMDt7rfo9wKszRwaP0h/tvPWDNVj0cc11AzXZ9A9C2P4AVz0A6Bif/\nF/z99+HAv4azb8DE1W+22JpJweBpPdxy6m/0munXUy3HL8HFX+nZOmte1LNeVj8Pa164ZfGyWDrG\nh70fcmnqEleDV9lStoUiSxHfCvuxpQTx06eR6TShNU8RSuk7U4srHHhKbBhU0a8ljc1pxum1Utbo\nIRZKkXSWEG/cQs5kJf6FvpfDbXEXxJYHKgImhPgzYD+QAq4CvyWlLMzWKsWixGI3YfdYiAWT+FeU\nMNDVS3f102y4dIR4RwcOm43nNuxiomGCA5cP8G7Xu7y04iXe73mfl5tfxm2+xRvfWaoX0+pr0zcv\n5TJ60bCqR6ByE4xdhN7jcPFt6Ppkuub543qJ4NI1ehw8k9DDK5kkZJM3rifDunjfvCgrcxAahMlr\n0Hdcj/evexmKqnVxv0MHqI/6PmIoOsSnA59S4ahgc+lm/FYf9WeTZKJR4mfOkGtcQ8ZTSjjqxOY0\nYXOZVRhmmeCvcRGeiDNwaYrxKY1qu5PYiq1oF46QmZwsmB0PWt3xA+BPpJQZIcSfAn8C/PGDm6VY\nyhRX2IkFkxhNBrzFGhMTXnJNa0mcOYNt40aKLg2xc/VOwukwv7r2Kw71HmJf/T7evfYu3135XUy3\nqvSoaXr3mZJVugcdnPbwhaaLd8nqaSE+BlcPQe9RPaumcovuZd+NZFjfIDV5Tf+bSQICvPW6mNc/\nAY277thp/szYGa4Fr3Go9xBCCHbX7saoGdmRaSQXaCN26hRkswRbdpHOGYjGoHKlvuCshH154Kt0\n0HfeQGmdm8HLASpWlxJd+SiOzs+Jnz6N++k9BbHjgYRdSvn+TTePAy8/mDmK5YC33EH/xSkASpqK\nmZiYYGTlXiquniPe0YHmsNPa+i/pL+1nKqHn9p4ePc0jZY/wYe+H7K3fe/vsEHux3n1p4Au49tGN\nkIkQev64r0kX/d5j0P2p7snbikAzgcGsd4k3TF83mPWQTaBbbzANYHaCvxm8jbqo24uh5Xnwr7jj\nnMfj4xwbPMbJ4ZOMxkZ5pu4ZXGYXrWWtWI5cIxkOkzh3Dq15LUlHCWGhe/2+KgdOrwWTRRX9Wg4Y\nzQaKyhwkYxmGrgYZD5soc3iINzyC6GwvmNc+l/XYfxt47XYPCiF+DPwYoLa2dg5Pq1hs2FxmrE4z\niUgKp9+J0TDOMJXUNTbmvfZUxxn2bN3DVGKKkdgIJ4ZPUObQS9y2j7TzrfJv3f4EQkD1Fl3EOw/q\nXvbNeKr13Z+RURj6Um9Jl03pXwLxqH49k9L/IsFdrZc0KG4ARymYbXorP2+9/gvBfOeiXJlchkM9\nh+gN93J69DQtxS00FTVR4ahgXbqU8MhxYu3tAMTW/jMkgkDUiKPIgNWhsmGWGyW1LiYHI/irHYz3\nRyhbU0qk+XFsV08SPvg+nuefn3cb7irsQohDwOylf/iplPKX08f8FMgAf3+7caSUrwCvALS2thau\nGo5iQfCW2xm6kkIIgdtvJTgqYeM25LV/IH7mDAaXk+LWVh6vfJx4Js54fJwPej7g+83fp324HZ/N\nR6On8c4nsRXBxn+uZ8NER3WvOzJ247qzVK8geSek1D14T7Uu5N56faH2G+STfz74OYORQT7s/RCP\nxcP2yu14LB72Newj+c4HZAMBkhcuYFm3nlFjKRmHn8RYhrp17vz/SrF8cPv1Ou1lDR7GeiNMxm0U\nu30ka9cT+eQTMlNTGL3eebXhrsIupbxjUEgI8SPgeWC3LGT5MsWixlvuYOiKvo5eVOFiciTJoKmJ\nysZGEh0d2DZuJP7ll6x//HH6I/3srd/LgcsH+KDnA15oeoHDvYfxrPDgs/nufjKTVc9aKfraL8F4\nAGIT+mIrAGJasKdFWwhd1F0V99XBCaAr2MXZsbN83P8x8Uyc7674Lm6Lm+cbn8c4GSbS00vs5Ekw\nGEivfZxcTiOYcSC0KMUVjukc9jlsyadYcK7XaU/G0hSV2RjrjeBvKSWyajvWwYvEOzpw7dw5rzY8\nUH6VEGIf8EfAC1LK+d8nq1gyOL0WzDbdb7ienz0cdWJt/RYylSLe0UH87Ffkkkn21O2hpbiFJ6uf\nZCg6xImhE6SyKd7rfo9E5gFy021FerimZNX0pVkvq+tfoV98TfqXwX2K+nB0mI/6PuL85Hm6gl08\nWv4oFc6LFyB4AAAeGklEQVQKnm14Fo/FQ+zYMTITEyQ7O7Ft2EBQK8bg8zM5Eqeo1D4dj1Xe+nLE\nX+sCIShv8JBJ5whmnWSLKzD88Z/Nu6jDg+ex/wXgAj4QQnwphPjrObBJsUy4vlnJZDbgKDITyTmI\nuaowT3vt2XBY35WqmXiu4Tm2lG1hjW8Np8dO0xXsIpgM8n7P+wWriHevSCk5NXKKN6+8yWBkkM8H\nPqfGWcOmkk3sqd1DuaOcVF8fqd4+YidOIMxmjBu2EMuaiVu8ZFI5fNVOACXsyxSLzYjHb8VZbMHh\nMTPSE8FQ4kdYC7MJ7YGEXUq5QkpZI6XcNH35vbkyTLH0uTl27CmxEYsLxuN27K2tN7z2jg5kKoXd\nZOf5xud5quYpSmwlHO47TCgZoj/cz4HLB/K9UxeaaDrKW1ffom2ojXQ2zaGeQxgNRp6qfYonqp+g\nsagRKSXRz4+RGR0lde0ato0bCVGEwVfC5EgSo0lvTGI0G3B57yEVU7Ek8de4EEJQ1ughGc0QNRSB\noTDZT2qrm2LecBVbMU737vRMh2PGtQpyxWV5rz0TCBI7/SUAXquX55ueZ1/9PgAO9hwkk8swHh/n\njc43ODl88kap3wWgK9jFa5deYyAyQCAZ4IOeD5hITPBUzVNsq9zGxhK9ZkzqyhUyo6NE29oQFgvW\nTZsIpKyIkjKmRmIUVzrQNIG3XK9hr1ieeMv1cFtxuR2zzcBITxRzXV1Bzq2EXTFvCO3GxhtHkQWD\nSSOatRNMO2Z67V+cIhvQF1qrnFW8uPJF9tTsYTw+nq9fnZM5Tg6f5I3ON5iITxR0HplchiP9R3i3\n612Go8N82Pshr158lf5wP9sqtrGrZhdPVD4BgMzliB5vIz00RLq3F9sjj5AQdrJF5QQnM8gc+TBM\nSa2roPNQFBbNoOGrciI0QVmDm8hUkmCwMI6JEnbFvHK9ZZ4QAk+JjeBkgnBRHQZ/yY1YezRG5MiR\n/HOavc38WsuvsblkM+cnznNy+CRDkSFi6RhjsTFe73yd9uH2gnjvk4lJDnQe4OjAUQ73HubVi69y\nLXCNDSUb+I3Vv8G++n3srtud31CVOHeObCBArK0NYbNhW7+eQMqGqbKCiYEIVocJh8eM3a3XFVEs\nb/w101/iNS4MRsHVL8YKct653KCkUMzC7bdiMGlk0zk8JTYmB6PEzKXEErrXHrh2jURHB5rFQvLq\nVSxNevehLWVb+OHaHzLWPkb7SDvtI/oGH7NmxmPx8H73+1Q6K9lRvYO99XvxWDxzancml+H06GkO\n9x7m5PBJOqc6MQgDG0o2sKlkE3aTHY/Fw7MNz2LS9KwamUoRO3GSVH8/6YEBHNu3I40mYtYaMlmN\n8GSSqlVFejqc8tYfChweS752Ukmti8ErAULjcdz++V1EVcKumFc0g4anxM7kYASPX/dQg5Mp4tWr\ncBDF3NhIvKMD67p1RD79FHNNDcKs53Xvqt1FJB3h/MR5AskAwWSQYDJIIBlgODbM5cBlPun/hL84\n/Rf8+VN/zqbSTXNi87XgNT4f+JxP+j+hbagNTWgzBB3AYXKwv2l//jZAvKODbDRK7MQJNIcD69q1\nhDNWRGUFE71RAHxVTjSDwF/lnBNbFYufkhoXPcEkZfV6OCYylVTCrlj6XN9ibbIasbvNBMfiRFaU\n47PasW/bRuDVV4keO4Zr926iJ0/ifEKPV2tC49mGZ8nkMozERmaNm8llGI2N8mHvh/zovR/xkw0/\n4ccbfozhDoW67kQgEeCzwc/oCfbkfyU0eZrYXrV9hoBbjVb2N+2fUYkyF48T++I06b4+MkNDOJ58\nEmE0EnU1IsxmxvvHcPmsWGxGvBWO/KKyYvnjq3bQd2ECs83Irt9soXJl0d2f9ICoGLti3nH7rVin\nd1d6SmxEppKk05Jkw0aMXi+2TZtIXrxIemiIeEfHjEJJZoOZ/U37qXBUzBrXqBmpdFbyvZXfo9Re\nyl91/BU/+eAnXJi8wDfZBJ3OpTk+dJzXLr1GT7CHtuE22kfaafG2sKduzwxRN2kmvt3wbYqtM0v3\nxtpPkUsmibW1oblcWFevJiMMJNyVRANJkrEM/ip9vUEtmj5cGE2G/J6OQrU+VMKumHeEEJTW6WLm\nKbWBhNB4nLClDIPbhX3LFjSnk8iRI8h0hsjHn8x4vtlg5vmm56lx1dxyfLvJzv7G/azxraFtuI0/\n/PgP+bsLf8dAZOCWx6dzaYLJIMPRYS5MXOAfL/wjX4x8QSaX4djQMU6PnmaNbw07a3aiiRsfEU1o\n7GvYly9Wdp1sKETiq7OkurvJjI5ib21FGAzEa9aDycx4f1RPb6xwYHWacftUp6SHDX9NYb/MVShG\nURD8NU76L03paY9GoYdjKhxo61sRRz/C8cQThA8eJHHuHELTSFy6hHXVqvzzTZqJZxue5WD3QXpC\nPbPGN2gGnqx+Er/Vz2cDn/HKmVfoDfWyzr8Ok2YilokRz8SJZ+Jk8rVjbiCl5LOBz/hq4ivW+9fz\nROUTM7wrIQRP1z19yy+XaFsbuXRGj617PFhWrUIr8hKy15CLZpgcilJUbsdg1JS3/pByvTBYoVAe\nu6IgGE0GfeFQE7j9NoJjcaSUhK3lGHzFmJuaMFVXEzt+nFwsRvSzo+SSyZljaEb21e+jsej2VR/X\n+teyv2k/iWyCn1/+OZ8Pfk53qJvR2CjhVPi2on6k/whfTXzFxpKNs0Qd4MnqJ2kqapr13Mz4OMlL\nnaSuXiU7Po79W99CGI3kNj1BKpElMBojm87hr9bzmf3VatH0YUQIkU99LARK2BUFIx+OKbGRTmSJ\nR9JMDEZx7tyJ0DQcO3YgMxmix46Ri8WItbXNGsOgGXim7hmavc23PU+ls5KXV76M2+Lmna53OHD5\nAJ8NfEbnVCeBZGBG/D0nc/lCXptLN/NYxWOzRP2xysdY41tzy3NFjx1HZrPETpzA4PViWbkS24b1\nTEb1fqgTA1FMFgNunxVvuUM11HiI8de48oVF5xsVilEUDIfHgrPYSique83B0Th2l5mo5sO2YT3x\njjPYNm0i/sUXWNesAU1gaWnBVFo6YxxNaOyu3Y1BGLgweeGW53KZXby44kVOj55mKDLEhckLnB0/\nC+gx+1JbKaX2UoLJIFeDV2kta6W1rHVm+AXBI2WPsLl08y3PET1+nFR3N8krV8hOTeF65hmM3iK0\ndVsIfj5KOpUlOBqjrMGN0AQltcpbf5jRC4MVZn1FCbuioJTVu4lMJrC5TATH4lQ0eRi6GmT1tm2k\nuruxb9lCsrOTyJEjFH3/+0Q++YSil1+e5UULIdhZsxOTwcTZsbNIZmfBmDQTW8u3ArpnPpWYYjQ2\nmr+cHj2NRLK1fCtbyrbkn+c0OVntW01LcQsu861j4pGjR4l/cRqZy+neus+HecUKnLt2MTgQBymZ\nHIwipZ67brGb5j13WbH4cfkKs9tYCbuioHgrHBgtBjwlNka6QmQzOSKTCcKhLM5duwj+4pezFlLD\nBw/i2rMHYZz5dhVCsL1qO1vKtjAQHqA/0s9AZIBgMjjrvJrQ8Nl8+Gw+VvtWA3p2TDKTxGl2IoSg\nwd3Aat9qal21d0xLixw5QrzjDADJS5fIBYO4nn0W29o1GMqrmDjXC8BEfwSb24Tdbaak1lWwVDfF\n4qVQ7wEl7IqComlC37A0EGH4WojQRAJvmZ3BKwFattVgXbMaKWV+IdXS1ETy8hVysTjubz+HZrHM\nGtNmtLHCu4IVXr3hdCgVygv9YGSQdE5veC0QCCEQiHwao8VuodnbTEtxy4x89VshpSTy8cckvjqn\n385miZ08ibG0FOu6dTi2b2e0P0w2nSMylSQaTFG7plhfNC3gwplCoYRdUXBK69wMXg6gGQTB0Tje\nMjuhsTiRqSSO7dtJ9fTi2LFjxo7U9MAAwZ//HPf+FzA479xc2m124/a58575XCClJHL4MInzN2L6\niQsXyIXDOJ98EteunQizmdFuvcjTSHcIg1EX9KJSO2ar+qgpCofKilEUHIvNSHG5Q29yPZ32CDB4\nZQrNYsG588lZO1IBMuMTBA+8QWZqqqD2ylyO8PsfzBD1bCBA7NgxjBUVOHfvxtLYSGg8TiKSIhnX\nc9f9NS6Vu65YEJSwKxaE0noXnhIbqXiGRFTPkgmMxImFUlgaG7GsXJHfkRo+dIhsOAxANhQmeOAA\n6eHhgtgps1nCBw+S7Oy8cV86Tei990DT8Ox/HteTOwDdSwcY7QmB1BeKzTZjvsmIQlEolLArFgS3\n30ZpnV5EKzg23QddSoau6A03nDt2YPC4ce3di0wkCL75JtmgviiaiycI/uIXJLu65tVGmUoRevc9\nkleu3rhvOs6enZjA9fTTuL/9bTS7nUQ0TWAkTjaTY6w3grfCjsVu1NujqS5JigKjhF2xIAghqF3r\nw+owEhyL5++fHIqSiKbR7HYc27djKi/H853vIFMpgm++mQ/DyHSG0DvvED93bl7sywYCTL3xBqmv\nfXkkzp0j2dmJfetWXLt25sse6F66ZGIgQjado6zeDUKoMIxiQVDCrlgw/DVOisochCcSJKJ65orM\n3fDarS0tmOvrMJaW4nnxRWQup4v7xHRrvJwkcvgjwoc/QqbTc2ZXqqeHqZ+9TnZicsb96ZERop9+\niqmuDseOHTh37QIgm80x3hdBSslIVwhHkRmn14K33I7FphZNFYVHCbtiwTCaDKzZXoGmCbrPTuQX\nUcf7IySnd6c6d+5EWCwY/X48L72E0DRd3MdutBhLnDvH1Ouvzyj3e7/E2tsJvv1PyK/VqcnF44Tf\new/N4cC1Zw+up55Cs+mx88mBKJlUluBonEQ0Q1m9G6FpVK/yPrA9CsX9oIRdsaDUrvVR3VJMeCLB\nRH8E0L324at6PN3gcuHasxuEwOj16uJuNhP8xS9mLKBmJyYJ/Oxn9x2a0ePp7xI9dhy+Vstd5nKE\nP/iAXDyO+9lnsW95BEtjQ/7xkS7d1pHuECarAW+FA1+VA5vLfF+2KBQPihJ2xYLi8Fho2OTH6bXQ\ne2GKdDILwFhvOH/d0tiI/RG9XovB49HF3WYj+Mtfkhq4UXNdpjNEDn9E6OD75FKpe7YhMzXF1Ouv\nz1gkvZnYyZOk+/pw7tiBZUUTju3b84+FJvRMnlgoRWg8QVmdnuJYtVJ564qFQwm7YsGpXlVM/Xof\nuWyO3vN6OCWXzTF87UZpAPu2bZiqqwHdiy966SUMLheht98m1ds7Y7xkZyeBV18jPTJ623PKbJZs\nMEjiUieB198gO3nr3PhUdzfx9nYsq1djXbsW1549aOYbnvhot56GOdIdQjPoi6W+KidWZ+FqbysU\nX0et7CgWHE+JjdJ6D5NDMQYvB/BVOSgqtTPaE6JihQejyYDQNNx7n2HqtZ+Ri0TQHA48L71E8Je/\nJPTOO7iffRZzXV1+zGwwSODAG9i3tKJZzGTDEXKRMNlwmFw4Qi4enxVyuRmZy5EeHCR86BAGvx/n\njh3YNm/CVFmZPyY0EWdqOEo6mWViIIK/2oXJaqSqef57WioUd0IJu2JRUN3iJTgaY3IoSs9XE7h2\n6FXwRrpCVDXrYQ3Nbse9by+BN9+EbA7NZsPz4osE33rrhrjX198YNKtXXrxXZCpFqq+PVHc3qe5u\nZCKBsFpx79uHqbwMx7Zt+WOT8QxXTo0ic5Kx3jAyB2UNbkpqXQXtlKNQ3Aol7IpFgavYirfCQf16\nHxePDTPQGaB2TTEjXSHK6t0YzXqDClNFBc7HHyfy6WcAaFYrnhdeIPT224TefRfXvn1YGhrudKoZ\nZCMRXci7ukj390Muh7BYMNfVYW5owFRbi2az4nr6aYRBtyGbzXH55AiZZJZcVjLSE8JTYsPhMRek\nA71CcTfmRNiFEP8O+K9AiZRyfC7GVDx8VDXrXntJrYuRrhDFlQ6cRRY6T47Qsq0czaAvCdk2bSI9\nPELy8mVAF3f3Cy8Qeustwu+9B3v3Ymm8ffs80EM1sba2G2O43VjXr9fFvLw8L+IAjm3bMPr9+dtd\nX44TC+rpkJNDUTLJHGUNbkrr3KrYl2JR8MDvQiFEDfAM0Hu3YxWKO+H0Wigqt1OdzhEYidF9dpw1\nT1QSmUxw7ctxmh4pydezdj21i8zEeH7RU7NYdHF/+23CBw/CM89gaZrdozQXixFrbydx7hxoGrbN\nm7G0tGDwem9ZK9tUWYlt840OSoOXA0wOTqdlTm9IsjlNFJXbqVihvHXF4mAusmL+B/BHcIsWNgrF\nN6Sq2YvRbKB2bTHxUJqRLr2w1uRghL7zNzYgCbMZ93PPIUw34tnXxd1YWqoX7rpyJf9YLpkk2tbG\n5N/+LYmvvsK6ejXeH/wAx+OPYywuni3qQmBpbsa1d2/+scBIjP5LN7JnwpMJYqEUZQ1uyhs9qp+p\nYtHwQB67EOI7wICUsuNunUGEED8GfgxQW1v7IKdVLGMcHgvFFQ697kpZlIHOAN5yO1aHieFrQcx2\nI+UNHgCMXi+up/cQPnwYmdBDI5rZjHv/fkL/9E+E338fmckgEwlip04hEwnMK1bgePRRDEW3967N\n9XV6+KWkJH9fPJzi6unRfCZNLicZuBTAaNYorXdR0eiZx/+KQvHNEPIOKV8AQohDQPktHvop8B+A\nZ6SUQSFEN9B6LzH21tZW2d7efh/mKh4G4uEUZz8ZIBVPc/aTAZxFFpq3lumesxCs2FKqi/80Mpsl\n1dNLsrOTVHcXMp3Ri4b96ldkBgcBMNXU6GL9tcbYN2OqrMDx2GMzUhoBMuks5z8bJBGZrmcjJd1n\nJxjvi9C42c+GnTVUqfIBigIghDglpWy923F39dillHtuc4L1QANw3VuvBr4QQmyVUhamWLZiWWJz\nmfFVOZjoj1Dd7KX3/CRTw7G8J3/t9CgmSwWuYj0lUhgMWBobsDQ2IFMpkl1dJDs78Rj2EzvZjqmq\nCnNNzW3PZyzx49i2bWaq5DQyJ7n6xVhe1EHfjDTeF6FyhYeyeg/lyltXLDLuOxQjpTwL5N2fb+Kx\nKxR3o6rZy+RglNI6F2N9YfrOT+IpsWEwauSykssnR1jzROWsHZ7CbMa6ahXWVavIxeMkn34amUzp\nNdHF9Ys2/VfPjTfX19+2yXDfxUmCo7H87cBojL7zU3jL7VQ2F1He5MFgUhu4FYsLlZulWJRYHSb8\n1U7GesPUrdNz24euBKlu0UMemVSWSyeGWfNE5W0XLTWbDdvatfdtw0DnVL4YGeghomunx7C7zTRs\n9GO2mShrcN/3+ArFfDFnroaUsl5564q5pHJlEUITuIqt+KocDHcF83XbAZLRNJ0nhsmks3N+7sHL\nUwzclAGTSWW53D6KMAhWtJbqhb6aizAYlLeuWHyod6Vi0WKxm/IdiKpbvAhN0HtukpsX/KOBJBeP\nDecrQc4Fg1cC9F+8Ieq5nOTKqTFSiQwrt5RisRmxucyU1KjuSIrFiRJ2xaKmcmURmkHDbDVStbKI\n4FicwEh8xjGxYJILnw/mm3M8CENXAvRfuJEvL6Wk99wE4ckE9ev9OL36gu31LxqFYjGihF2xqDFb\njfn6K6X1bmxOE73nJ8llczOOS0TSXDg6SDxy73XYv87Q1SB9F2Z2YRrtCTPWG6G8yYO/2gmAy2fF\nW+641RAKxaJACbti0VPe5MHqNKNpgtp1xaTiGYZuWtS8Tiqe4cLRIaKB5C1GuTPD14L0nZ+YcV9w\nNEbv+UmKymxUr7qxoalmdfE3n4RCUUCUsCsWPZomqF/vA8Dts1Fc6WDo6syF1OtkUlkuHh8iNB6f\n9djtGL4WpPfcTFEPTya4cmoMu8tM46YbNWq8FY58OEahWKwoYVcsCdx+G77pUEjNar1g1821Y24m\nm87ReWKYqeHobcdLJ7OEJxP0X5qaJerRYJLLJ0cw2ww0by3DYNQ/JkITyltXLAlUHrtiyVCzupjA\nSAwzety9/+IUgZEYRWX2WcfmspIrp0apXePDaNZIRNP6JaL/zaZztziDnqveeWIEg0mj+dHyGTny\nJbUurA7VREOx+FHCrlgymK1GqluK6Tk7TlmDm/G+CL3nJ3H7rfla7Tcjc5Ker+59a0UyluZS2wgI\nWPVoORbbjY+HwaTlOzkpFIsdFYpRLClK61w4iixomqBuXTHJWIbL7aNMDkXJZe+/cnQqkeFS2wi5\nnGTV1vJZnnlFkyrLq1g6KGFXLCmEENSv94MQuP02qlu8xMIprn4xxpeH+ug+M054MsHdqpbeTDqV\n5VLbCOlkluatZdjd5hmPm6xGylShL8USQoViFEsOR5GF0joXo90hKpo8lDe4CU0kmBiIMDEYZawv\ngtlmwFfpxFflwOo03bbIl77QOkIylqF5aynOIsusY1TpAMVSQwm7YklS3eJlaihGOplBaAJPiQ1P\niY1sRm+rNz4QYehqUM93F2A0aZgsBoxmAyazhtFswGgxEBqLEw+lWLGlFLfPNus8qnSAYimihF2x\nJDGaDNSsKeba6dEZ9xuMGr4qJ74qJ+lEhqmROKlEhkwySzqVI5PKEgulSCdzZDM5hICGTSW3zKzR\nDBq1a32qdIBiyaGEXbFk8Vc7Ge8L33YzkslqpLTu9t52LieRUt4yzOLyWWnYWKLSGxVLEhU4VCxp\n6jf4cftnh1DuBU0Ts0RdM2jUrvPR8liFEnXFkkV57IoljdVhouWxCqLBJCPXQkwMRpC5+0t7VF66\nYrmghF2xLHB4LDRuLqF6tZeR7hBjPWEyqXur0a4ZNKpbvJQ1uG+bPaNQLCWUsCuWFWarkZqWYipX\nFjHRH2G0O0Q6mZtuc6qL9s3XzTYjdWt9s3qnKhRLGSXsimWJwaBRWuemtE71JFU8fKjFU4VCoVhm\nKGFXKBSKZYYSdoVCoVhmKGFXKBSKZYYSdoVCoVhmKGFXKBSKZYYSdoVCoVhmKGFXKBSKZYYSdoVC\noVhmiG/SQmzOTirEGNBzn0/3A/feoXh5oOb8cKDm/HDwIHOuk1KW3O2gBRH2B0EI0S6lbF1oOwqJ\nmvPDgZrzw0Eh5qxCMQqFQrHMUMKuUCgUy4ylKOyvLLQBC4Ca88OBmvPDwbzPecnF2BUKhUJxZ5ai\nx65QKBSKO7BohV0IsU8IcUkIcUUI8e9v8bhFCPHa9ONtQoj6wls5t9zDnP+tEOK8EOKMEOJDIUTd\nQtg5l9xtzjcd9z0hhBRCLOkMinuZrxDi16Zf53NCiH8otI1zzT28r2uFEB8JIU5Pv7efWwg75xIh\nxP8RQowKIb66zeNCCPHn0/+TM0KIR+bUACnlorsABuAq0AiYgQ5gzdeO+QPgr6ev/zrw2kLbXYA5\n7wLs09d//2GY8/RxLuAIcBxoXWi75/k1XgmcBrzTt0sX2u4CzPkV4Penr68Buhfa7jmY9w7gEeCr\n2zz+HPAuIIBtQNtcnn+xeuxbgStSymtSyhTwKvCdrx3zHeD/Tl9/A9gtlnYn4rvOWUr5kZQyNn3z\nOFBdYBvnmnt5nQH+M/CnQKKQxs0D9zLf3wX+Uko5BSClHC2wjXPNvcxZAtd7GHqAwQLaNy9IKY8A\nk3c45DvA/5M6x4EiIUTFXJ1/sQp7FdB30+3+6ftueYyUMgMEAV9BrJsf7mXON/M76N/4S5m7znn6\nJ2qNlPJXhTRsnriX17gZaBZCHBVCHBdC7CuYdfPDvcz5PwI/EEL0A+8A/6Ywpi0o3/Tz/o1QzayX\nIEKIHwCtwJMLbct8IoTQgP8O/GiBTSkkRvRwzE70X2RHhBDrpZSBBbVqfvkXwN9IKf+bEOIx4G+F\nEOuklLmFNmypslg99gGg5qbb1dP33fIYIYQR/SfcREGsmx/uZc4IIfYAPwVekFImC2TbfHG3ObuA\ndcDHQohu9FjkW0t4AfVeXuN+4C0pZVpK2QV0ogv9UuVe5vw7wM8ApJTHACt6PZXlzD193u+XxSrs\nJ4GVQogGIYQZfXH0ra8d8xbww+nrLwOH5fSqxBLlrnMWQmwG/ie6qC/12CvcZc5SyqCU0i+lrJdS\n1qOvK7wgpWxfGHMfmHt5X/8C3VtHCOFHD81cK6SRc8y9zLkX2A0ghFiNLuxjBbWy8LwF/Kvp7Jht\nQFBKOTRnoy/06vEdVpWfQ/dWrgI/nb7vP6F/sEF/8V8HrgAngMaFtrkAcz4EjABfTl/eWmib53vO\nXzv2Y5ZwVsw9vsYCPfx0HjgL/PpC21yAOa8BjqJnzHwJPLPQNs/BnP8RGALS6L/Cfgf4PeD3bnqd\n/3L6f3J2rt/XauepQqFQLDMWayhGoVAoFPeJEnaFQqFYZihhVygUimWGEnaFQqFYZihhVygUimWG\nEnaFQqFYZihhVygUimWGEnaFQqFYZvx/gb4AWr8KgesAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7faee186d358>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import pylab as plt\n",
+    "[plt.plot(X[:,0],Y[:,p]) for p in range(P)]\n",
+    "[plt.fill_between(X[:,0],ystar[:,p]-2*np.sqrt(varstar[:,p]),ystar[:,p]+2*np.sqrt(varstar[:,p]),alpha=0.5) for p in range(P)]\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAJsAAAD8CAYAAABgkNZuAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAACtlJREFUeJzt3U+IXdUdB/Dv12nMWJsgJaGEjK0u\nRBApWmxcuGpKaKqii24U7ErISrBQEO3GdaEUN26CDQoWRWILQSJBSUIQtE2iQTRRGqTSCS1DjNIE\n2pi89+3ivZQxzJt3bubc37n3ne8HLmQyZ+49iy/n3vPn3kNJMItwXekKWD0cNgvjsFkYh83COGwW\nxmGzMA6bhXHYLIzDZmG+1cZJr+d6zePGNk6d34Zvl65BI+fPnzkrafO1/v3PfnKjvjg3SCp7/MOL\nByTtvNZrXa2VsM3jRtzLn7Zx6uwGP/5R6So0cujgbz5fy99/cW6Avx74flLZuS1/27SWa12tlbBZ\ndwnAEMMi13bYKiMIl5R2G83NYauQWzYLIQiDQsvKHLYKDeGwWQABGDhsFsUtm4UQgEt+ZrMIgnwb\ntSACBoXecXLYKjOaQSjDYasOMQCLXNlhq8yog+CwWYDROJvDZkGGbtksQsmWLWlZOMmdJD8leZrk\n021XytojEANcl3TkNrVlIzkH4HkAOwAsAjhKcp+kk9lrYyG6fBvdBuC0pM8AgOSrAB4G4LD1kEB8\nrbki104J21YA/1j28yKAe9upjrVtNKhb5qW6bB0EkrsA7AKAefTrjaXadHno4wyAm5f9vDD+v2+Q\ntBvAbgDYyO/6C4MdJREDlWnZUq56FMBtJG8leT2ARwDsa7da1qYhmHTkNrVlk3SZ5BMADgCYA7BH\n0sfZa2IhRh2EMsOrSVeVtB/A/pbrYgFmooNg/THo8DibzZArMwg5jQf+jwE4I+nBSeUctgoN8/dG\nnwRwCsDG1Qr5k1mVGU3E55sbJbkA4AEAL0wr65atMgJxKe901XMAngKwYVpBt2yVkYCBrks6AGwi\neWzZsWv5uUg+CGBJ0vGUa7tlq06jAduzku5Z5ff3AXiI5P0A5gFsJPmypMdWKuyWrTJCo5Zt9XNJ\nz0hakHQLRjNLBycFDXDLVqU2FkamcNgqI7CVxZOSDgM4vFoZh60yo1f5Ojw3arPELylbEKGVGYQk\nDluF3LJZCIlu2SzGqIPQ3berbKaUeweh+rD9a9t86So0c3Btfz7qIPiZzYJ4BsFCtDWDkMJhq5Bf\neLEQEnBp6LBZgNFt1GGzIJ5BsBAe+rBAvo1aoDY+GpPCYavMqDfquVEL4EFdC+XbqIVwb9RCuTdq\nISTissNmUXwbtRAln9mmtqck95BcIvlRRIWsfUMx6cgt5eb9IoCd2a9sRVwZZysRtpRP0x8heUv2\nK1sxHmezEBJwue+LJ713VX/0vjfqvav6wXOjFkodHvp4BcC7AG4nuUjy8farZW3q8kZpj2a/qhUj\nzcAzm/UFMeh7b9T6o9Qzm8NWGa9nszgaPbeV4LBVKFdPk+Q8gCMA1mOUpb2Snp1U3mGrjPJ2EC4C\n2C7pAsl1AN4h+aak91Yq7LBVKNdtVJIAXBj/uG58TDy7966qkMSkA1N25QNGuyiTPAFgCcBbkv4y\n6bpu2SojNRr6mLYrHyQNANxF8iYAfyZ5p6QVF9q6ZatQG4snJX0F4BBWWWjrsFVISjumIbl53KKB\n5A0AdgD4ZFJ530YrIxDDfL3RLQBeIjmHUcP1mqQ3JhV22CqUa0xX0ocA7k4t77DVplkHISuHrUae\nrrIobtkK+e8P/1O6CqEEYDh02CyCALhlsyheYmRxHDaLQXcQLJBbNgshQO6NWhyHzaL4NmphHDYL\n4UFdi+RBXYvj3qhFoVs2CyG4g2BR6A6CBXLLZmGGZS6b8k3dm0keInmS5Mckn4yomLXkyjhbypFZ\nSst2GcCvJb1PcgOA4yTfknQye20sRKne6NSWTdI/Jb0//vd5AKcAbG27YtYiJR6ZNXo1eryH1d0A\nJn6pxmyS5A4Cye8AeB3AryT9e4Xfezuhnuj0oO74q4KvA/ijpD+tVMbbCfWE0N3pKpIE8AcApyT9\nvv0qWeu62kEAcB+AXwLYTvLE+Li/5XpZi6i0I7eU7YTeQal1xNaOLj+z2Yxx2CxCW7fIFA5bjbra\nG7XZ45bN4jhsFsLPbBaqw4O6NmM4TDumnqfhWke3bLYWjdY6umWrUab1bE3XOrplq01LHYSUtY4O\nW43Sw7aJ5LFlP+8eLyX7hmlrHa9w2GqUHrapW0CmrHW8wmGrDJHW00w6V8O1ju4g1CZxLVvic12j\ntY5u2WqUb4/4RmsdHbYaebqqjF/c8UHpKjTyuwzn8NyoxXHYLITy9Uabcthq5JbNoviZzeI4bBbC\n39S1KIRvoxbIYbM4DpuFcdgshF/ls1AOm0XxdJWF8W3UYnhQ10I5bBah0zMIJOcBHAGwflx+r6Rn\n266YtYfDMmlLadkuAtgu6cL4HcF3SL4p6b2W62Zt6PIzmyQBuDD+cd348KYaPdbZjdIAgOQcyRMA\nlgC8Jcl7V/VZlzdKkzSQdBeABQDbSN55dRmSu0geI3nsEi7mrqdlVGrTjUZvxEv6CsAhADtX+N1u\nSfdIumcd1ueqn7Whqy0byc0kbxr/+wYAOwB8kr8qFkL5vjzZVEpvdAuAl0jOYRTO1yS9kb8qFqHT\n42ySPsToI282K9TdcTabMZ1t2WzGdHlQ12aP17NZGIfNYgjuIFgcdxAsjsNmETo9qGszRur04kmb\nNV1ez2azJdcSI5J7SC6R/Cjlug5bbQRgqLRjuhexwnKzSRy2GuXbAvIIgHOpl/UzW4Ua9EaTduVL\n5bBVqEFvdOqufE04bLXxqo9yfvu9E6Wr0MhatxMaDeqWSZs7CDUaJh5TkHwFwLsAbie5SPLx1cpX\n37LVKFfLJunRJuUdttr4mc3ieG7UInnxpIXwFpAWyi2bhXEHwaJwWOY+6rDVRkgasG2Dw1YZQsWm\nqxy2GjlsFsZhsxB+ZrNI7o1aEPk2akEKflgmefHkeC+ED0j6e7p9l2nxZFNNWrYnAZwCsDF/NSxS\np5eFk1wA8ACAF9qtjoWQ0o7MUlu25wA8BWBD9hpYLAkYlOmNpmy68SCAJUnHp5TzdkJ9UahlS7mN\n3gfgIZJ/B/AqgO0kX766kLcT6pGuhk3SM5IWJN0C4BEAByU9lr0mFiPvh2Ua8ThbdQSoBzMIkg4D\nONxKTSyGUKyD4JatRp6usjAOm8XwRLxFEQAvMbIwbtksRrnpKoetNgLUh3E2mxH+ipGF8TObhZDc\nG7VAbtkshqDBoMiVHbbaXFliVIA/TV8jDdOOBCR3kvyU5GmST69W1i1bZQRAmVo2knMAngewA8Ai\ngKMk90k6uVJ5t2y1kXK2bNsAnJb0maSvMXpt4OFJhd2yVShjB2ErgH8s+3kRwL2TCrcStvP48uzb\n2vt55tNuAnA28zkxtyX3Gf+vlfoC+MFa/vg8vjzwtvZuSiw+3/ktICVtzn1OksdybkfYtq7WV1Ly\nzscJzgC4ednPC+P/W5Gf2WwtjgK4jeStJK/H6O27fZMK+5nNrpmkyySfAHAAwByAPZI+nlS+T2G7\n5meFQvpW32siaT+A/SllqULzZFYfP7NZmF6ErcmUSGkk95BcIvlR6bp0TefDtmxK5OcA7gDwKMk7\nytZqVS8CyDm8MDM6HzY0nBIpTdIRAOdK16OL+hC2laZEthaqi61BH8JmM6IPYWs0JWLd1YewNZoS\nse7qfNgkXQZwZUrkFIDXVpsSKY3kKwDeBXA7yUWSj5euU1d4BsHCdL5ls9nhsFkYh83COGwWxmGz\nMA6bhXHYLIzDZmH+B1b1jjN/+YYVAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7faf2d62e208>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(model.kern.W.value)\n",
+    "plt.colorbar()\n",
+    "plt.show()"
+   ]
   }
  ],
  "metadata": {
@@ -1521,7 +1709,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,

--- a/gpflow/multioutput/conditionals.py
+++ b/gpflow/multioutput/conditionals.py
@@ -14,7 +14,7 @@
 
 import tensorflow as tf
 
-from .features import SeparateIndependentMof, SharedIndependentMof, MixedKernelSharedMof
+from .features import SeparateIndependentMof, SharedIndependentMof, MixedKernelSharedMof, MixedKernelSeparateMof
 from .features import Kuu, Kuf
 from .kernels import Mok, SharedIndependentMok, SeparateIndependentMok, SeparateMixedMok
 from .. import settings
@@ -206,7 +206,7 @@ def _conditional(Xnew, feat, kern, f, *, full_cov=False, full_output_cov=False, 
     return fmean, fvar
 
 
-@conditional.register(object, MixedKernelSharedMof, SeparateMixedMok, object)
+@conditional.register(object, (MixedKernelSharedMof,MixedKernelSeparateMof), SeparateMixedMok, object)
 @name_scope("conditional")
 def _conditional(Xnew, feat, kern, f, *, full_cov=False, full_output_cov=False, q_sqrt=None, white=False):
     """
@@ -225,7 +225,7 @@ def _conditional(Xnew, feat, kern, f, *, full_cov=False, full_output_cov=False, 
     - See the multiouput notebook for more information about the multiouput framework.
 
     """
-    logger.debug("conditional: MixedKernelSharedMof, SeparateMixedMok")
+    logger.debug("conditional: (MixedKernelSharedMof, MixedKernelSeparateMof), SeparateMixedMok")
     independent_cond = conditional.dispatch(object, SeparateIndependentMof, SeparateIndependentMok, object)
     gmu, gvar = independent_cond(Xnew, feat, kern, f, full_cov=full_cov, q_sqrt=q_sqrt,
                                  full_output_cov=False, white=white)  # N x L, L x N x N or N x L
@@ -256,7 +256,7 @@ def _conditional(Xnew, feat, kern, f, *, full_cov=False, full_output_cov=False, 
 # Sample conditional
 # ------------------
 
-@sample_conditional.register(object, MixedKernelSharedMof, SeparateMixedMok, object)
+@sample_conditional.register(object, (MixedKernelSharedMof, MixedKernelSeparateMof), SeparateMixedMok, object)
 @name_scope("sample_conditional")
 def _sample_conditional(Xnew, feat, kern, f, *, full_output_cov=False, q_sqrt=None, white=False):
     """
@@ -268,7 +268,7 @@ def _sample_conditional(Xnew, feat, kern, f, *, full_output_cov=False, q_sqrt=No
 
     :return: N x P (full_output_cov = False) or N x P x P (full_output_cov = True)
     """
-    logger.debug("sample conditional: MixedKernelSharedMof, SeparateMixedMok")
+    logger.debug("sample conditional: (MixedKernelSharedMof, MixedKernelSeparateMof), SeparateMixedMok")
     independent_cond = conditional.dispatch(object, SeparateIndependentMof, SeparateIndependentMok, object)
     g_mu, g_var = independent_cond(Xnew, feat, kern, f, white=white, q_sqrt=q_sqrt,
                                    full_output_cov=False, full_cov=False)  # N x L, N x L

--- a/gpflow/multioutput/features.py
+++ b/gpflow/multioutput/features.py
@@ -65,6 +65,13 @@ class MixedKernelSharedMof(SharedIndependentMof):
     """
     pass
 
+class MixedKernelSeparateMof(SeparateIndependentMof):
+    """
+    This Mof is used in combination with the `SeparateMixedMok`.
+    Using this feature with the `SeparateMixedMok` leads to the most efficient code.
+    """
+    pass
+
 
 # ---
 # Kuf
@@ -120,6 +127,10 @@ def Kuf(feat, kern, Xnew):
     debug_kuf(feat, kern)
     return tf.stack([Kuf(feat.feat, k, Xnew) for k in kern.kernels], axis=0)  # L x M x N
 
+@dispatch(MixedKernelSeparateMof, SeparateMixedMok, object)
+def Kuf(feat, kern, Xnew):
+    debug_kuf(feat, kern)
+    return tf.stack([Kuf(f, k, Xnew) for f, k in zip(feat.feat_list, kern.kernels)], axis=0)  # L x M x N
 
 # ---
 # Kuu
@@ -167,7 +178,7 @@ def Kuu(feat, kern, *, jitter):
     return Kmm + jittermat
 
 
-@dispatch(SeparateIndependentMof, (SeparateIndependentMok, SeparateMixedMok))
+@dispatch((SeparateIndependentMof,MixedKernelSeparateMof), (SeparateIndependentMok, SeparateMixedMok))
 def Kuu(feat, kern, *, jitter=0.0):
     debug_kuu(feat, kern, jitter)
     Kmm = tf.stack([Kuu(f, k) for f, k in zip(feat.feat_list, kern.kernels)], axis=0)  # L x M x M

--- a/tests/test_multioutput.py
+++ b/tests/test_multioutput.py
@@ -289,6 +289,11 @@ def test_MixedMok_Kgg(session_tf):
     np.testing.assert_array_almost_equal(Kff, Kff_infered, decimal=5)
 
 
+
+
+
+
+
 # ------------------------------------------
 # Integration tests
 # ------------------------------------------
@@ -482,3 +487,21 @@ def test_multioutput_with_diag_q_sqrt(session_tf):
     m2 = SVGP(data.X, data.Y, k2, Gaussian(), feat=f2, q_mu=data.mu_data, q_sqrt=q_sqrt, q_diag=False)
 
     check_equality_predictions(session_tf, [m1, m2])
+
+def test_MixedKernelSeparateMof(session_tf):
+    data = DataMixedKernel
+
+    kern_list = [RBF(data.D) for _ in range(data.L)]
+    feat_list = [InducingPoints(data.X[:data.M, ...].copy()) for _ in range(data.L)]
+    k1 = mk.SeparateMixedMok(kern_list, W=data.W)
+    f1 = mf.SeparateIndependentMof(feat_list)
+    m1 = SVGP(data.X, data.Y, k1, Gaussian(), feat=f1, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
+
+    kern_list = [RBF(data.D) for _ in range(data.L)]
+    feat_list = [InducingPoints(data.X[:data.M, ...].copy()) for _ in range(data.L)]
+    k2 = mk.SeparateMixedMok(kern_list, W=data.W)
+    f2 = mf.MixedKernelSeparateMof(feat_list)
+    m2 = SVGP(data.X, data.Y, k2, Gaussian(), feat=f2, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
+
+    check_equality_predictions(session_tf, [m1, m2])
+


### PR DESCRIPTION
## PR content:

* [Title](#title)
* [Description](#description)
* [Minimal working example](#minimal-working-example)

### Title

This provides the missing MixedKernelSeparateMof that does efficient  mixing of ind. latents for separate inducing points.

### Description

Working on the solution to #819 I found that one way to address the problem was to define the missing feature MixedKernelSeparateMof and to create the corresponding dispatch route. Bug #819 is still not resolved because the path `conditional(feat: SeparateIndependentMof, kern: SeparateMixedMok)` has a shape conflict, however this PR will add a more efficient route anyways.


### Minimal working example

See the commited `notebooks/multioutput.ipynb`

## Code quality requirements

Not a significant code change
