### PR TITLE
We should not be using NotImplementedError for `.fixed`.

### DIFF
--- a/gpflow/params/parameterized.py
+++ b/gpflow/params/parameterized.py
@@ -367,8 +367,8 @@ class Parameterized(Node):
 
     @property
     def fixed(self):
-        raise NotImplementedError("`fixed` property is no longer supported. Please use `trainable` instead.")
+        raise GPflowError("`fixed` property is no longer supported. Please use `trainable` instead.")
 
     @fixed.setter
     def fixed(self, _):
-        raise NotImplementedError("`fixed` property is no longer supported. Please use `trainable` instead.")
+        raise GPflowError("`fixed` property is no longer supported. Please use `trainable` instead.")

--- a/gpflow/params/parameterized.py
+++ b/gpflow/params/parameterized.py
@@ -364,11 +364,3 @@ class Parameterized(Node):
 
     def _repr_html_(self):
         return self.as_pandas_table()._repr_html_()
-
-    @property
-    def fixed(self):
-        raise GPflowError("`fixed` property is no longer supported. Please use `trainable` instead.")
-
-    @fixed.setter
-    def fixed(self, _):
-        raise GPflowError("`fixed` property is no longer supported. Please use `trainable` instead.")


### PR DESCRIPTION
This should be for abstract methods only. It also causes the inspections in my IDE to constantly say that I need to implement more abstract methods...