### PR TITLE
Modified Saver to work with file-like objects as well as path names.

### DIFF
--- a/gpflow/saver/saver.py
+++ b/gpflow/saver/saver.py
@@ -13,12 +13,6 @@
 # limitations under the License.
 
 
-from datetime import datetime
-
-import h5py
-import numpy as np
-import tensorflow as tf
-
 from .coders import CoderDispatcher
 from .context import BaseContext
 from .serializers import HDF5Serializer
@@ -31,14 +25,14 @@ class SaverContext(BaseContext):
 
 
 class Saver:
-    def save(self, pathname, target, context=None):
+    def save(self, pathname_or_file_like, target, context=None):
         context = Saver.__get_context(context)
         encoded_target = CoderDispatcher(context).encode(target)
-        context.serializer(context).dump(pathname, encoded_target)
+        context.serializer(context).dump(pathname_or_file_like, encoded_target)
 
-    def load(self, pathname, context=None):
+    def load(self, pathname_or_file_like, context=None):
         context = Saver.__get_context(context)
-        encoded_target = context.serializer(context).load(pathname)
+        encoded_target = context.serializer(context).load(pathname_or_file_like)
         return CoderDispatcher(context).decode(encoded_target)
 
     @staticmethod

--- a/gpflow/saver/serializers.py
+++ b/gpflow/saver/serializers.py
@@ -17,7 +17,6 @@ import abc
 from datetime import datetime
 
 import h5py
-import numpy as np
 
 from .. import misc
 from .context import Contexture
@@ -34,8 +33,8 @@ class BaseSerializer(Contexture, metaclass=abc.ABCMeta):
 
 
 class HDF5Serializer(BaseSerializer):
-    def dump(self, pathname, data):
-        with h5py.File(pathname) as h5file:
+    def dump(self, pathname_or_file_like, data):
+        with h5py.File(pathname_or_file_like) as h5file:
             meta = h5file.create_group('meta')
             date = datetime.now().isoformat() #TODO(@awav): py3.6 timespec='seconds'.
             version = misc.version()
@@ -43,6 +42,6 @@ class HDF5Serializer(BaseSerializer):
             meta.create_dataset(name='version', data=version)
             h5file.create_dataset(name='data', data=data)
 
-    def load(self, pathname):
-        with h5py.File(pathname) as h5file:
+    def load(self, pathname_or_file_like):
+        with h5py.File(pathname_or_file_like) as h5file:
             return h5file['data'].value

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     'pandas>=0.18.1',
     'multipledispatch>=0.4.9',
     'pytest>=3.5.0',
-    'h5py>=2.7.0',
+    'h5py>=2.9.0',
     'matplotlib>=2.2.2'
 ]
 

--- a/tests/test_saver.py
+++ b/tests/test_saver.py
@@ -64,10 +64,13 @@ class Data:
         return np.random.rand(10, 2)
 
 
-@pytest.fixture
-def filename(request):
+@pytest.fixture(params=['file', 'filename'])
+def filename(file_or_filename):
     with tempfile.NamedTemporaryFile() as file:
-        yield file.name
+        if file_or_filename.param == 'file':
+            yield file
+        else:
+            yield file.name
 
 
 @pytest.fixture


### PR DESCRIPTION
This required updating h5py>=2.9.0 (http://docs.h5py.org/en/stable/high/file.html).
I have a use case where I'd like to save the GPFlow model to a cloud datastore

Updated tests to test this.

Also removed some unused imports.
