### PR TITLE
fix models maths documentation (#905)

### DIFF
--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -108,12 +108,12 @@ class GPModel(Model):
     .. math::
        :nowrap:
 
-       \\begin{align}
-       \\theta & \sim p(\\theta) \\\\
-       f       & \sim \\mathcal{GP}(m(x), k(x, x'; \\theta)) \\\\
-       f_i       & = f(x_i) \\\\
+       \begin{align}
+       \theta & \sim p(\theta) \\
+       f       & \sim \mathcal{GP}(m(x), k(x, x'; \theta)) \\
+       f_i       & = f(x_i) \\
        y_i\,|\,f_i     & \sim p(y_i|f_i)
-       \\end{align}
+       \end{align}
 
     This class mostly adds functionality to compile predictions. To use it,
     inheriting classes must define a build_predict function, which computes

--- a/gpflow/models/sgpmc.py
+++ b/gpflow/models/sgpmc.py
@@ -25,7 +25,7 @@ from ..decors import params_as_tensors
 
 
 class SGPMC(GPModel):
-    """
+    r"""
     This is the Sparse Variational GP using MCMC (SGPMC). The key reference is
 
     ::
@@ -44,15 +44,15 @@ class SGPMC(GPModel):
     .. math::
        :nowrap:
 
-       \\begin{align}
-       \\mathbf v & \\sim N(0, \\mathbf I) \\\\
-       \\mathbf u &= \\mathbf L\\mathbf v
-       \\end{align}
+       \begin{align}
+       \mathbf v & \sim N(0, \mathbf I) \\
+       \mathbf u &= \mathbf L\mathbf v
+       \end{align}
 
     with
 
     .. math::
-        \\mathbf L \\mathbf L^\\top = \\mathbf K
+        \mathbf L \mathbf L^\top = \mathbf K
 
 
     """

--- a/gpflow/models/vgp.py
+++ b/gpflow/models/vgp.py
@@ -43,7 +43,7 @@ class VGP(GPModel):
 
     .. math::
 
-       q(\\mathbf f) = N(\\mathbf f \\,|\\, \\boldsymbol \\mu, \\boldsymbol \\Sigma)
+       q(\mathbf f) = N(\mathbf f \,|\, \boldsymbol \mu, \boldsymbol \Sigma)
 
     """
 
@@ -95,7 +95,7 @@ class VGP(GPModel):
 
         with
 
-            q(\\mathbf f) = N(\\mathbf f \\,|\\, \\boldsymbol \\mu, \\boldsymbol \\Sigma)
+            q(\mathbf f) = N(\mathbf f \,|\, \boldsymbol \mu, \boldsymbol \Sigma)
 
         """
 
@@ -149,8 +149,8 @@ class VGP_opper_archambeau(GPModel):
     only the diagonal elements of the precision need be adjusted.
     The posterior approximation is
     .. math::
-       q(\\mathbf f) = N(\\mathbf f \\,|\\, \\mathbf K \\boldsymbol \\alpha,
-                         [\\mathbf K^{-1} + \\textrm{diag}(\\boldsymbol \\lambda))^2]^{-1})
+       q(\mathbf f) = N(\mathbf f \,|\, \mathbf K \boldsymbol \alpha,
+                         [\mathbf K^{-1} + \textrm{diag}(\boldsymbol \lambda))^2]^{-1})
 
     This approach has only 2ND parameters, rather than the N + N^2 of vgp,
     but the optimization is non-convex and in practice may cause difficulty.


### PR DESCRIPTION
Some docstrings had \\ for LaTeX maths commands but had a r at the start, so they were escaped too much. One docstring was missing the r but had some single-\. Fixes those.