### PR TITLE
Typo "NOSET" -> "NOTSET" in gpflowrc

### DIFF
--- a/gpflow/gpflowrc
+++ b/gpflow/gpflowrc
@@ -1,5 +1,5 @@
 [logging]
-# possible levels: CRITICAL, ERROR, WARNING, INFO, DEBUG, NOSET
+# possible levels: CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET
 level = WARNING
 
 [verbosity]


### PR DESCRIPTION
(inhouse version of PR #903)

The available Python logging levels are as written now in the file:
https://docs.python.org/3/library/logging.html#levels

I don't think it's worth making a test for this. You can check the bug by doing:
```python
import gpflow
gpflow.settings.logging.level = 'NOSET'
gpflow.settings.logger()
```
and
```python
import gpflow
gpflow.settings.logging.level = 'NOTSET'
gpflow.settings.logger()
```


