### PR TITLE
Minor performance improvement: pass Cholesky of K to gauss_kl

### DIFF
--- a/gpflow/kullback_leiblers.py
+++ b/gpflow/kullback_leiblers.py
@@ -42,13 +42,17 @@ def gauss_kl(q_mu, q_sqrt, K=None, *, K_cholesky=None):
 
     K is the covariance of p, [M, M] or [L, M, M]
     K_cholesky is the cholesky of the covariance of p, [M, M] or [L, M, M]
-    Either `K` or `K_cholesky` have to be None.
-    If `K` and `K_cholesky` are None, compute the KL divergence to p(x) = N(0, I) instead.
+    
+    Note: if no K matrix is given (both `K` and `K_cholesky` are None),
+    `gauss_kl` computes the KL divergence from p(x) = N(0, I) instead.
+    The K matrix can be passed either directly as `K`, or as its Cholesky factor, `K_cholesky`. 
+    In either case, it can be a single matrix [M, M], in which case the sum of the L KL divergences 
+    is computed by broadcasting, or L different covariances [L, M, M].
     """
 
     if (K is not None) and (K_cholesky is not None):
-        raise ValueError("Ambigious args are passed to `gauss_kl`, "
-                         "Either `K` or `K_cholesky` need to be `None`")
+        raise ValueError("Ambiguous arguments: gauss_kl() must only "
+                         "be passed one of `K` or `K_cholesky`.")
 
     white = (K is None) and (K_cholesky is None)
     diag = q_sqrt.get_shape().ndims == 2

--- a/gpflow/kullback_leiblers.py
+++ b/gpflow/kullback_leiblers.py
@@ -22,7 +22,7 @@ from .decors import name_scope
 
 
 @name_scope()
-def gauss_kl(q_mu, q_sqrt, K=None):
+def gauss_kl(q_mu, q_sqrt, K=None, *, K_cholesky=None):
     """
     Compute the KL divergence KL[q || p] between
 
@@ -33,38 +33,46 @@ def gauss_kl(q_mu, q_sqrt, K=None):
     We assume N multiple independent distributions, given by the columns of
     q_mu and the last dimension of q_sqrt. Returns the sum of the divergences.
 
-    q_mu is a matrix (M x L), each column contains a mean.
+    q_mu is a matrix [M, L], each column contains a mean.
 
-    q_sqrt can be a 3D tensor (L x M x M), each matrix within is a lower
+    q_sqrt can be a 3D tensor [L, M, M], each matrix within is a lower
         triangular square-root matrix of the covariance of q.
-    q_sqrt can be a matrix (M x L), each column represents the diagonal of a
+    q_sqrt can be a matrix [M, L], each column represents the diagonal of a
         square-root matrix of the covariance of q.
 
-    K is the covariance of p.
-    It is a positive definite matrix (M x M) or a tensor of stacked such matrices (L x M x M)
-    If K is None, compute the KL divergence to p(x) = N(0, I) instead.
+    K is the covariance of p, [M, M] or [L, M, M]
+    K_cholesky is the cholesky of the covariance of p, [M, M] or [L, M, M]
+    Either `K` or `K_cholesky` have to be None.
+    If `K` and `K_cholesky` are None, compute the KL divergence to p(x) = N(0, I) instead.
     """
 
-    white = K is None
+    if (K is not None) and (K_cholesky is not None):
+        raise ValueError("Ambigious args are passed to `gauss_kl`, "
+                         "Either `K` or `K_cholesky` need to be `None`")
+
+    white = (K is None) and (K_cholesky is None)
     diag = q_sqrt.get_shape().ndims == 2
 
     M, B = tf.shape(q_mu)[0], tf.shape(q_mu)[1]
 
     if white:
-        alpha = q_mu  # M x B
+        alpha = q_mu  # [M, B]
     else:
-        batch = K.get_shape().ndims == 3
+        if K is not None:
+            Lp = tf.cholesky(K)  # [B, M, M] or [M, M]
+        elif K_cholesky is not None:
+            Lp = K_cholesky  # [B, M, M] or [M, M]
 
-        Lp = tf.cholesky(K)  # B x M x M or M x M
-        q_mu = tf.transpose(q_mu)[:, :, None] if batch else q_mu  # B x M x 1 or M x B
-        alpha = tf.matrix_triangular_solve(Lp, q_mu, lower=True)  # B x M x 1 or M x B
+        batched = Lp.get_shape().ndims == 3
+        q_mu = tf.transpose(q_mu)[:, :, None] if batched else q_mu  # [B, M, 1] or [M, B]
+        alpha = tf.matrix_triangular_solve(Lp, q_mu, lower=True)  # [B, M, 1] or [M, B]
 
     if diag:
         Lq = Lq_diag = q_sqrt
-        Lq_full = tf.matrix_diag(tf.transpose(q_sqrt))  # B x M x M
+        Lq_full = tf.matrix_diag(tf.transpose(q_sqrt))  # [B, M, M]
     else:
-        Lq = Lq_full = tf.matrix_band_part(q_sqrt, -1, 0)  # force lower triangle # B x M x M
-        Lq_diag = tf.matrix_diag_part(Lq)  # M x B
+        Lq = Lq_full = tf.matrix_band_part(q_sqrt, -1, 0)  # force lower triangle # [B, M, M]
+        Lq_diag = tf.matrix_diag_part(Lq)  # [M, B]
 
     # Mahalanobis term: μqᵀ Σp⁻¹ μq
     mahalanobis = tf.reduce_sum(tf.square(alpha))
@@ -79,15 +87,15 @@ def gauss_kl(q_mu, q_sqrt, K=None):
     if white:
         trace = tf.reduce_sum(tf.square(Lq))
     else:
-        if diag and not batch:
-            # K is M x M and q_sqrt is M x B: fast specialisation
-            LpT = tf.transpose(Lp)  # M x M
-            Lp_inv = tf.matrix_triangular_solve(Lp, tf.eye(M, dtype=settings.float_type),lower=True)  # M x M
-            K_inv = tf.matrix_diag_part(tf.matrix_triangular_solve(LpT, Lp_inv, lower=False))[:, None]  # M x M -> M x 1
+        if diag and not batched:
+            # K is [M, M] and q_sqrt is [M, B]: fast specialisation
+            LpT = tf.transpose(Lp)  # [M, M]
+            Lp_inv = tf.matrix_triangular_solve(Lp, tf.eye(M, dtype=settings.float_type),lower=True)  # [M, M]
+            K_inv = tf.matrix_diag_part(tf.matrix_triangular_solve(LpT, Lp_inv, lower=False))[:, None]  # [M, M] -> [M, 1]
             trace = tf.reduce_sum(K_inv * tf.square(q_sqrt))
         else:
-            # TODO: broadcast instead of tile when tf allows (not implemented in tf <= 1.6.0)
-            Lp_full = Lp if batch else tf.tile(tf.expand_dims(Lp, 0), [B, 1, 1])
+            # TODO: broadcast instead of tile when tf allows (not implemented in tf <= 1.12)
+            Lp_full = Lp if batched else tf.tile(tf.expand_dims(Lp, 0), [B, 1, 1])
             LpiLq = tf.matrix_triangular_solve(Lp_full, Lq_full, lower=True)
             trace = tf.reduce_sum(tf.square(LpiLq))
 
@@ -98,7 +106,7 @@ def gauss_kl(q_mu, q_sqrt, K=None):
         log_sqdiag_Lp = tf.log(tf.square(tf.matrix_diag_part(Lp)))
         sum_log_sqdiag_Lp = tf.reduce_sum(log_sqdiag_Lp)
         # If K is B x M x M, num_latent is no longer implicit, no need to multiply the single kernel logdet
-        scale = 1.0 if batch else tf.cast(B, settings.float_type)
+        scale = 1.0 if batched else tf.cast(B, settings.float_type)
         twoKL += scale * sum_log_sqdiag_Lp
 
     return 0.5 * twoKL


### PR DESCRIPTION
This PR adds the ability to pass the Cholesky of K to `gauss_kl(.)` for the unwhitened case, instead of `K`. It prevents the double cost of inverting `K` twice, in both conditionals and gauss_kl.

## changes:
- added `K_cholesky` kwarg to `kullback_leiblers.gauss_kl`
- updated file to the new way of documenting array shapes. From `A x B` to `[A, B]`
- added unit test