### PR TITLE
URGENT: FIX TensorFlow api compatibility problem

### DIFF
--- a/gpflow/misc.py
+++ b/gpflow/misc.py
@@ -199,7 +199,11 @@ def vec_to_tri(vectors, N):
 def initialize_variables(variables=None, session=None, force=False, **run_kwargs):
     session = tf.get_default_session() if session is None else session
     if variables is None:
-        initializer = tf.global_variables_initializer()
+        if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0
+            initializer = tf.initialize_all_variables()
+        else: # For tf version >= 0.12.0
+            initializer = tf.global_variables_initializer()
+
     else:
         if force:
             vars_for_init = list(_initializable_tensors(variables))
@@ -207,7 +211,11 @@ def initialize_variables(variables=None, session=None, force=False, **run_kwargs
             vars_for_init = list(_find_initializable_tensors(variables, session))
         if not vars_for_init:
             return
-        initializer = tf.variables_initializer(vars_for_init)
+        if(tf.__version__.startswith("0.") and int(tf.__version__.split(".")[1])<12): # For tf version <0.12.0                
+            initializer = tf.initialize_variables(vars_for_init)
+        else: # For tf version >= 0.12.0 
+            initializer = tf.variables_initializer(vars_for_init)
+
     session.run(initializer, **run_kwargs)
 
 


### PR DESCRIPTION
Dear developers,

I found some compatibility problems in your use of TensorFlow APIs, which might lead to crashes in a low version of TensorFlow. And I fix it for you as below:

`tf.variables_initializer` is the updated version of tf.initialize_variables, however, it appears until tf 0.12.0-rc0. So for version before that, it's better to use `tf.initialize_variables` to be safe.

`tf.global_variables_initializer` is the updated version of `tf.initialize_all_variables`, however, it also appears until tf 0.12.0-rc0. So for version before that, it's better to use `tf.initialize_all_variables` to be safe.

@davidsheldon @jameshensman @icouckuy @vals @javdrher 
Hope you could take my advice and look forward to your reply! 😄