### PR TITLE
GPflow TF 1.14 compatible. Fixes optimizers importing issue.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 #Assumes you are running from within cloned repo.
 
 #Uses official Tensorflow docker for cpu only.
-FROM tensorflow/tensorflow:1.12.0
+FROM tensorflow/tensorflow:1.14.0
 COPY ./ /usr/local/GPflow/
 
 RUN cd /usr/local/GPflow && \

--- a/gpflow/training/tensorflow_optimizer.py
+++ b/gpflow/training/tensorflow_optimizer.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import sys
-
 import tensorflow as tf
+from pkg_resources import parse_version
 
 from . import optimizer
 from .. import misc
@@ -164,7 +164,13 @@ def _register_optimizer(name, optimizer_type):
 
 
 # Create GPflow optimizer classes with same names as TensorFlow optimizers
-for key, train_type in tf.train.__dict__.items():
+
+if parse_version(tf.VERSION) >= parse_version("1.14"):
+    train_items = tf.train._dw_wrapped_module.__dict__.items()
+else:
+    train_items = tf.train.__dict__.items()
+
+for key, train_type in train_items:
     suffix = 'Optimizer'
     if key != suffix and key.endswith(suffix):
         _register_optimizer(key, train_type)

--- a/gpflow/training/tensorflow_optimizer.py
+++ b/gpflow/training/tensorflow_optimizer.py
@@ -165,10 +165,10 @@ def _register_optimizer(name, optimizer_type):
 # Create GPflow optimizer classes with same names as TensorFlow optimizers
 for name in dir(tf.train):
     suffix = 'Optimizer'
-    if key != suffix and key.endswith(suffix):
+    if name != suffix and name.endswith(suffix):
         train_type = getattr(tf.train, name, None)
         if train_type is not None:
-            _register_optimizer(key, train_type)
+            _register_optimizer(name, train_type)
 
 
 __all__ = list(_REGISTERED_TENSORFLOW_OPTIMIZERS.keys())

--- a/gpflow/training/tensorflow_optimizer.py
+++ b/gpflow/training/tensorflow_optimizer.py
@@ -166,6 +166,8 @@ def _register_optimizer(name, optimizer_type):
 # Create GPflow optimizer classes with same names as TensorFlow optimizers
 
 if parse_version(tf.VERSION) >= parse_version("1.14"):
+    # tensorflow 1.14 deprecated the `train` module and wraps it in a DeprecationWrapper
+    # which requires this hack to get access to the list of objects in the namespace
     train_items = tf.train._dw_wrapped_module.__dict__.items()
 else:
     train_items = tf.train.__dict__.items()

--- a/gpflow/training/tensorflow_optimizer.py
+++ b/gpflow/training/tensorflow_optimizer.py
@@ -14,7 +14,6 @@
 
 import sys
 import tensorflow as tf
-from pkg_resources import parse_version
 
 from . import optimizer
 from .. import misc
@@ -164,18 +163,12 @@ def _register_optimizer(name, optimizer_type):
 
 
 # Create GPflow optimizer classes with same names as TensorFlow optimizers
-
-if parse_version(tf.VERSION) >= parse_version("1.14"):
-    # tensorflow 1.14 deprecated the `train` module and wraps it in a DeprecationWrapper
-    # which requires this hack to get access to the list of objects in the namespace
-    train_items = tf.train._dw_wrapped_module.__dict__.items()
-else:
-    train_items = tf.train.__dict__.items()
-
-for key, train_type in train_items:
+for name in dir(tf.train):
     suffix = 'Optimizer'
     if key != suffix and key.endswith(suffix):
-        _register_optimizer(key, train_type)
+        train_type = getattr(tf.train, name, None)
+        if train_type is not None:
+            _register_optimizer(key, train_type)
 
 
 __all__ = list(_REGISTERED_TENSORFLOW_OPTIMIZERS.keys())


### PR DESCRIPTION
This fixes issue https://github.com/GPflow/GPflow/issues/995 and makes GPflow compatible with the latest TF version 1.14.

Details:
TensorFlow wrapped `tf.train` in a module deprecation-wrapper, so we simply go and get the items from inside the wrapper.