### PR TITLE
fix error in python example in contributing readme

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -55,7 +55,7 @@ class Foo:
         :return: Result depends on which value was passed to
             the method. It can be either a scalar or NumPy array.
         """
-        default_name = self.__class__.__name__
+        default_name = cls.__name__
         name = op_name if op_name is not None else default_name
         session = gpflow.get_default_session()
         with tf.name_scope(name):


### PR DESCRIPTION
### Title

Correct error in python example in contributing documentation.

### Description

**bug fix** Example in contributing.md refers to `self`, which is not defined for a class method.