### PR TITLE
Rename inducing_variables -> inducing_variable as model attribute

### DIFF
--- a/gpflow/kullback_leiblers.py
+++ b/gpflow/kullback_leiblers.py
@@ -26,11 +26,11 @@ prior_kl = Dispatcher('prior_kl')
 
 
 @prior_kl.register(InducingVariables, Kernel, object, object)
-def _(inducing_variables, kernel, q_mu, q_sqrt, whiten=False):
+def _(inducing_variable, kernel, q_mu, q_sqrt, whiten=False):
     if whiten:
         return gauss_kl(q_mu, q_sqrt, None)
     else:
-        K = Kuu(inducing_variables, kernel, jitter=default_jitter())  # [P, M, M] or [M, M]
+        K = Kuu(inducing_variable, kernel, jitter=default_jitter())  # [P, M, M] or [M, M]
         return gauss_kl(q_mu, q_sqrt, K)
 
 

--- a/gpflow/models/gplvm.py
+++ b/gpflow/models/gplvm.py
@@ -76,7 +76,7 @@ class BayesianGPLVM(GPModel):
                  x_data_mean: tf.Tensor,
                  x_data_var: tf.Tensor,
                  kernel: Kernel,
-                 num_inducing_variables: int,
+                 num_inducing_variables: Optional[int]=None,
                  inducing_variable=None,
                  x_prior_mean=None,
                  x_prior_var=None):
@@ -106,14 +106,15 @@ class BayesianGPLVM(GPModel):
         assert x_data_mean.shape[0] == data.shape[0], 'X mean and Y must be same size.'
         assert x_data_var.shape[0] == data.shape[0], 'X var and Y must be same size.'
 
-        # inducing points
+        if (inducing_variable is None) == (num_inducing_variables is None):
+            raise ValueError("BayesianGPLVM needs exactly one of `inducing_variable` and `num_inducing_variables`")
+
         if inducing_variable is None:
             # By default we initialize by subset of initial latent points
             inducing_variable = np.random.permutation(x_data_mean.copy())[:num_inducing_variables]
 
-        self.inducing_variable = inducing_variables.InducingPoints(inducing_variable)
+        self.inducing_variable = inducingpoint_wrapper(inducing_variable)
 
-        assert len(self.inducing_variable) == num_inducing_variables
         assert x_data_mean.shape[1] == self.num_latent
 
         # deal with parameters for the prior mean variance of X

--- a/gpflow/models/gplvm.py
+++ b/gpflow/models/gplvm.py
@@ -25,6 +25,7 @@ from ..kernels import Kernel
 from ..mean_functions import MeanFunction, Zero
 from ..probability_distributions import DiagonalGaussian
 from ..utilities.ops import pca_reduce
+from .util import inducingpoint_wrapper
 from .gpr import GPR
 from .model import GPModel
 

--- a/gpflow/models/sgpmc.py
+++ b/gpflow/models/sgpmc.py
@@ -24,6 +24,7 @@ from ..conditionals import conditional
 from ..inducing_variables import InducingPoints
 from ..kernels import Kernel
 from ..models.model import GPModel, MeanAndVariance, Data
+from .util import inducingpoint_wrapper
 
 
 class SGPMC(GPModel):
@@ -65,7 +66,7 @@ class SGPMC(GPModel):
                  likelihood: Likelihood,
                  mean_function: Optional[MeanFunction] = None,
                  num_latent: int = 1,
-                 inducing_variables: Optional[InducingPoints] = None):
+                 inducing_variable: Optional[InducingPoints] = None):
         """
         data is a tuple of X, Y with X, a data matrix, size [N, D] and Y, a data matrix, size [N, R]
         Z is a data matrix, of inducing inputs, size [M, D]
@@ -77,10 +78,8 @@ class SGPMC(GPModel):
                          num_latent=num_latent)
         self.data = data
         self.num_data = data[0].shape[0]
-        if not isinstance(inducing_variables, InducingPoints):
-            inducing_variables = InducingPoints(inducing_variables)
-        self.inducing_variables = inducing_variables
-        self.V = Parameter(np.zeros((len(self.inducing_variables), self.num_latent)))
+        self.inducing_variable = inducingpoint_wrapper(inducing_variable)
+        self.V = Parameter(np.zeros((len(self.inducing_variable), self.num_latent)))
         self.V.prior = tfp.distributions.Normal(loc=0., scale=1.)
 
     def log_likelihood(self, *args, **kwargs) -> tf.Tensor:
@@ -106,7 +105,7 @@ class SGPMC(GPModel):
 
         """
         mu, var = conditional(X,
-                              self.inducing_variables,
+                              self.inducing_variable,
                               self.kernel,
                               self.V,
                               full_cov=full_cov,

--- a/gpflow/models/sgpr.py
+++ b/gpflow/models/sgpr.py
@@ -21,7 +21,7 @@ from .model import MeanAndVariance, GPModel, Data
 from .. import likelihoods
 from ..config import default_float, default_jitter
 from ..covariances.dispatch import Kuf, Kuu
-from ..inducing_variable import InducingPoints
+from ..inducing_variables import InducingPoints
 from ..mean_functions import Zero, MeanFunction
 from .util import inducingpoint_wrapper
 

--- a/gpflow/models/sgpr.py
+++ b/gpflow/models/sgpr.py
@@ -21,8 +21,9 @@ from .model import MeanAndVariance, GPModel, Data
 from .. import likelihoods
 from ..config import default_float, default_jitter
 from ..covariances.dispatch import Kuf, Kuu
-from ..inducing_variables import InducingPoints
+from ..inducing_variable import InducingPoints
 from ..mean_functions import Zero, MeanFunction
+from .util import inducingpoint_wrapper
 
 
 class SGPRUpperMixin(GPModel):
@@ -55,8 +56,8 @@ class SGPRUpperMixin(GPModel):
         num_data = tf.cast(tf.shape(y_data)[0], default_float())
 
         Kdiag = self.kernel(x_data)
-        kuu = Kuu(self.inducing_variables, self.kernel, jitter=default_jitter())
-        kuf = Kuf(self.inducing_variables, self.kernel, x_data)
+        kuu = Kuu(self.inducing_variable, self.kernel, jitter=default_jitter())
+        kuf = Kuf(self.inducing_variable, self.kernel, x_data)
 
         L = tf.linalg.cholesky(kuu)
         LB = tf.linalg.cholesky(kuu + self.likelihood.variance ** -1.0 *
@@ -114,7 +115,7 @@ class SGPR(SGPRUpperMixin):
                  data: Data,
                  kernel: Kernel,
                  mean_function: Optional[MeanFunction] = None,
-                 inducing_variables: Optional[InducingPoints] = None,
+                 inducing_variable: Optional[InducingPoints] = None,
                  num_latent: Optional[int] = None
                  ):
         """
@@ -132,9 +133,7 @@ class SGPR(SGPRUpperMixin):
         self.data = data
         self.num_data = x_data.shape[0]
 
-        if not isinstance(inducing_variables, InducingPoints):
-            inducing_variables = InducingPoints(inducing_variables)
-        self.inducing_variables = inducing_variables
+        self.inducing_variable = inducingpoint_wrapper(inducing_variable)
 
     def log_likelihood(self):
         """
@@ -143,14 +142,14 @@ class SGPR(SGPRUpperMixin):
         SGPR notebook.
         """
         x_data, y_data = self.data
-        num_inducing = len(self.inducing_variables)
+        num_inducing = len(self.inducing_variable)
         num_data = tf.cast(tf.shape(y_data)[0], default_float())
         output_dim = tf.cast(tf.shape(y_data)[1], default_float())
 
         err = y_data - self.mean_function(x_data)
         Kdiag = self.kernel(x_data)
-        kuf = Kuf(self.inducing_variables, self.kernel, x_data)
-        kuu = Kuu(self.inducing_variables, self.kernel, jitter=default_jitter())
+        kuf = Kuf(self.inducing_variable, self.kernel, x_data)
+        kuu = Kuu(self.inducing_variable, self.kernel, jitter=default_jitter())
         L = tf.linalg.cholesky(kuu)
         sigma = tf.sqrt(self.likelihood.variance)
 
@@ -185,11 +184,11 @@ class SGPR(SGPRUpperMixin):
         notebook.
         """
         x_data, y_data = self.data
-        num_inducing = len(self.inducing_variables)
+        num_inducing = len(self.inducing_variable)
         err = y_data - self.mean_function(x_data)
-        kuf = Kuf(self.inducing_variables, self.kernel, x_data)
-        kuu = Kuu(self.inducing_variables, self.kernel, jitter=default_jitter())
-        Kus = Kuf(self.inducing_variables, self.kernel, X)
+        kuf = Kuf(self.inducing_variable, self.kernel, x_data)
+        kuu = Kuu(self.inducing_variable, self.kernel, jitter=default_jitter())
+        Kus = Kuf(self.inducing_variable, self.kernel, X)
         sigma = tf.sqrt(self.likelihood.variance)
         L = tf.linalg.cholesky(kuu)
         A = tf.linalg.triangular_solve(L, kuf, lower=True) / sigma
@@ -217,7 +216,7 @@ class GPRFITC(SGPRUpperMixin):
                  data: Data,
                  kernel: Kernel,
                  mean_function: Optional[MeanFunction] = None,
-                 inducing_variables: Optional[InducingPoints] = None
+                 inducing_variable: Optional[InducingPoints] = None
                  ):
         """
         This implements GP regression with the FITC approximation.
@@ -254,17 +253,15 @@ class GPRFITC(SGPRUpperMixin):
         self.data = data
         self.num_data = x_data.shape[0]
 
-        if not isinstance(inducing_variables, InducingPoints):
-            inducing_variables = InducingPoints(inducing_variables)
-        self.inducing_variables = inducing_variables
+        self.inducing_variable = inducingpoint_wrapper(inducing_variable)
 
     def common_terms(self):
         x_data, y_data = self.data
-        num_inducing = len(self.inducing_variables)
+        num_inducing = len(self.inducing_variable)
         err = y_data - self.mean_function(x_data)  # size [N, R]
         Kdiag = self.kernel(x_data, full=False)
-        kuf = Kuf(self.inducing_variables, self.kernel, x_data)
-        kuu = Kuu(self.inducing_variables, self.kernel, jitter=default_jitter())
+        kuf = Kuf(self.inducing_variable, self.kernel, x_data)
+        kuu = Kuu(self.inducing_variable, self.kernel, jitter=default_jitter())
 
         Luu = tf.linalg.cholesky(kuu)  # => Luu Luu^T = kuu
         V = tf.linalg.triangular_solve(
@@ -337,7 +334,7 @@ class GPRFITC(SGPRUpperMixin):
         Xnew.
         """
         _, _, Luu, L, _, _, gamma = self.common_terms()
-        Kus = Kuf(self.inducing_variables, self.kernel, X)  # size  [M, X]new
+        Kus = Kuf(self.inducing_variable, self.kernel, X)  # size  [M, X]new
 
         w = tf.linalg.triangular_solve(Luu, Kus, lower=True)  # size [M, X]new
 
@@ -356,13 +353,3 @@ class GPRFITC(SGPRUpperMixin):
             var = tf.tile(var[:, None], [1, self.num_latent])
 
         return mean, var
-
-    @property
-    def Z(self):
-        raise NotImplementedError(
-            "Inducing points are now in `model.inducing_variables.Z()`.")
-
-    @Z.setter
-    def Z(self, _):
-        raise NotImplementedError(
-            "Inducing points are now in `model.inducing_variables.Z()`.")

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -43,7 +43,7 @@ class SVGP(GPModel):
     def __init__(self,
                  kernel,
                  likelihood,
-                 inducing_variables=None,
+                 inducing_variable=None,
                  mean_function=None,
                  num_latent=1,
                  q_diag=False,
@@ -71,10 +71,10 @@ class SVGP(GPModel):
         self.num_data = num_data
         self.q_diag = q_diag
         self.whiten = whiten
-        self.inducing_variables = inducingpoint_wrapper(inducing_variables)
+        self.inducing_variable = inducingpoint_wrapper(inducing_variable)
 
         # init variational parameters
-        num_inducing = len(self.inducing_variables)
+        num_inducing = len(self.inducing_variable)
         self._init_variational_parameters(num_inducing, q_mu, q_sqrt, q_diag)
 
     def _init_variational_parameters(self, num_inducing, q_mu, q_sqrt, q_diag):
@@ -136,7 +136,7 @@ class SVGP(GPModel):
                                         transform=triangular())  # [L|P, M, M]
 
     def prior_kl(self):
-        return kullback_leiblers.prior_kl(self.inducing_variables, self.kernel, self.q_mu, self.q_sqrt, whiten=self.whiten)
+        return kullback_leiblers.prior_kl(self.inducing_variable, self.kernel, self.q_mu, self.q_sqrt, whiten=self.whiten)
 
     def log_likelihood(self, X: tf.Tensor, Y: tf.Tensor) -> tf.Tensor:
         """
@@ -166,7 +166,7 @@ class SVGP(GPModel):
         q_mu = self.q_mu
         q_sqrt = self.q_sqrt
         mu, var = conditional(Xnew,
-                              self.inducing_variables,
+                              self.inducing_variable,
                               self.kernel,
                               q_mu,
                               q_sqrt=q_sqrt,

--- a/gpflow/models/util.py
+++ b/gpflow/models/util.py
@@ -1,14 +1,13 @@
 import numpy as np
 
-from ..inducing_variables import InducingPoints
+from ..inducing_variables import InducingVariables, InducingPoints
 
 
 def inducingpoint_wrapper(inducing_variable):
     """
-    Models which used to take only Z can now pass `inducing_variable` and `Z` to this method. This method will
-    check for consistency and return the correct inducing_variable. This allows backwards compatibility in
-    for the methods.
+    This wrapper allows transparently passing either an InducingVariables
+    object or an array specifying InducingPoints positions.
     """
-    if isinstance(inducing_variable, np.ndarray):
+    if not isinstance(inducing_variable, InducingVariables):
         inducing_variable = InducingPoints(inducing_variable)
     return inducing_variable

--- a/notebooks2/advanced/convolutional.ipynb
+++ b/notebooks2/advanced/convolutional.ipynb
@@ -203,7 +203,7 @@
     }
    ],
    "source": [
-    "gpflow.utilities.set_trainable(rbf_m.inducing_variables, False)\n",
+    "gpflow.utilities.set_trainable(rbf_m.inducing_variable, False)\n",
     "start_time = time.time()\n",
     "res = gpflow.optimizers.Scipy().minimize(lambda: -rbf_m_log_likelihood(X, Y), variables=rbf_m.trainable_variables,\n",
     "                                         method=\"l-bfgs-b\", options={\"disp\": True, \"maxiter\": MAXITER})\n",
@@ -273,7 +273,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gpflow.utilities.set_trainable(conv_m.inducing_variables, False)\n",
+    "gpflow.utilities.set_trainable(conv_m.inducing_variable, False)\n",
     "conv_m.kernel.basekern.variance.trainable = False\n",
     "conv_m.kernel.weights.trainable = False"
    ]
@@ -422,7 +422,7 @@
        "<tbody>\n",
        "<tr><td>SVGP.kernel.variance     </td><td>Parameter</td><td>Softplus      </td><td>True       </td><td>()           </td><td>float64</td><td>3.2215907092264167                                  </td></tr>\n",
        "<tr><td>SVGP.kernel.lengthscale  </td><td>Parameter</td><td>Softplus      </td><td>True       </td><td>()           </td><td>float64</td><td>4.7557641241995325                                  </td></tr>\n",
-       "<tr><td>SVGP.inducing_variables.Z</td><td>Parameter</td><td>              </td><td>False      </td><td>(100, 784)   </td><td>float64</td><td>[[0., 0., 0....                                     </td></tr>\n",
+       "<tr><td>SVGP.inducing_variable.Z</td><td>Parameter</td><td>              </td><td>False      </td><td>(100, 784)   </td><td>float64</td><td>[[0., 0., 0....                                     </td></tr>\n",
        "<tr><td>SVGP.q_mu                </td><td>Parameter</td><td>              </td><td>True       </td><td>(100, 1)     </td><td>float64</td><td>[[0.64493545...                                     </td></tr>\n",
        "<tr><td>SVGP.q_sqrt              </td><td>Parameter</td><td>FillTriangular</td><td>True       </td><td>(1, 100, 100)</td><td>float64</td><td>[[[5.08200149e-01, 0.00000000e+00, 0.00000000e+00...</td></tr>\n",
        "</tbody>\n",
@@ -456,7 +456,7 @@
        "<tr><td>SVGP.kernel.basekern.variance   </td><td>Parameter</td><td>Chain         </td><td>True       </td><td>()         </td><td>float64</td><td>99.99507057380984                                    </td></tr>\n",
        "<tr><td>SVGP.kernel.basekern.lengthscale</td><td>Parameter</td><td>Chain         </td><td>True       </td><td>()         </td><td>float64</td><td>0.0012267091878449328                                </td></tr>\n",
        "<tr><td>SVGP.kernel.weights             </td><td>Parameter</td><td>Chain         </td><td>True       </td><td>(676,)     </td><td>float64</td><td>[0.42713141, 0.42713141, 0.42713141...               </td></tr>\n",
-       "<tr><td>SVGP.inducing_variables.Z       </td><td>Parameter</td><td>              </td><td>False      </td><td>(45, 9)    </td><td>float64</td><td>[[0., 0., 0....                                      </td></tr>\n",
+       "<tr><td>SVGP.inducing_variable.Z       </td><td>Parameter</td><td>              </td><td>False      </td><td>(45, 9)    </td><td>float64</td><td>[[0., 0., 0....                                      </td></tr>\n",
        "<tr><td>SVGP.q_mu                       </td><td>Parameter</td><td>              </td><td>True       </td><td>(45, 1)    </td><td>float64</td><td>[[0.01086709...                                      </td></tr>\n",
        "<tr><td>SVGP.q_sqrt                     </td><td>Parameter</td><td>FillTriangular</td><td>True       </td><td>(1, 45, 45)</td><td>float64</td><td>[[[-2.65773193e-02, 0.00000000e+00, 0.00000000e+00...</td></tr>\n",
        "</tbody>\n",

--- a/notebooks2/advanced/multioutput.ipynb
+++ b/notebooks2/advanced/multioutput.ipynb
@@ -236,7 +236,7 @@
    "outputs": [],
    "source": [
     "# create SVGP model as usual and optimize\n",
-    "m = gpf.models.SVGP(kernel, gpf.likelihoods.Gaussian(), inducing_variables=iv, num_latent=P)"
+    "m = gpf.models.SVGP(kernel, gpf.likelihoods.Gaussian(), inducing_variable=iv, num_latent=P)"
    ]
   },
   {
@@ -270,7 +270,7 @@
        "<tr><td>SVGP.kernel.kernel.Sum_kernels[0].lengthscale     </td><td>Parameter</td><td>Softplus      </td><td>True       </td><td>()         </td><td>float64</td><td>0.7982771183272557                                  </td></tr>\n",
        "<tr><td>SVGP.kernel.kernel.Sum_kernels[1].variance        </td><td>Parameter</td><td>Softplus      </td><td>True       </td><td>()         </td><td>float64</td><td>1.2137690489319697                                  </td></tr>\n",
        "<tr><td>SVGP.likelihood.variance                          </td><td>Parameter</td><td>Softplus      </td><td>True       </td><td>()         </td><td>float64</td><td>0.03966098208182285                                 </td></tr>\n",
-       "<tr><td>SVGP.inducing_variables.inducing_variable_shared.Z</td><td>Parameter</td><td>              </td><td>True       </td><td>(15, 1)    </td><td>float64</td><td>[[-4.83941461...                                    </td></tr>\n",
+       "<tr><td>SVGP.inducing_variable.inducing_variable_shared.Z</td><td>Parameter</td><td>              </td><td>True       </td><td>(15, 1)    </td><td>float64</td><td>[[-4.83941461...                                    </td></tr>\n",
        "<tr><td>SVGP.q_mu                                         </td><td>Parameter</td><td>              </td><td>True       </td><td>(15, 3)    </td><td>float64</td><td>[[-0.90096213, 0.69852585, -1.47398702...           </td></tr>\n",
        "<tr><td>SVGP.q_sqrt                                       </td><td>Parameter</td><td>FillTriangular</td><td>True       </td><td>(3, 15, 15)</td><td>float64</td><td>[[[1.71095614e-02, 0.00000000e+00, 0.00000000e+00...</td></tr>\n",
        "</tbody>\n",
@@ -394,7 +394,7 @@
    "outputs": [],
    "source": [
     "# create SVGP model as usual and optimize\n",
-    "m = gpf.models.SVGP(kernel, gpf.likelihoods.Gaussian(), inducing_variables=iv, num_latent=P)"
+    "m = gpf.models.SVGP(kernel, gpf.likelihoods.Gaussian(), inducing_variable=iv, num_latent=P)"
    ]
   },
   {
@@ -547,7 +547,7 @@
    "outputs": [],
    "source": [
     "# create SVGP model as usual and optimize\n",
-    "m = gpf.models.SVGP(kernel, gpf.likelihoods.Gaussian(), inducing_variables=iv, num_latent=P)"
+    "m = gpf.models.SVGP(kernel, gpf.likelihoods.Gaussian(), inducing_variable=iv, num_latent=P)"
    ]
   },
   {
@@ -622,9 +622,9 @@
     }
    ],
    "source": [
-    "for i in range(len(m.inducing_variables.inducing_variable_list)):\n",
-    "    q_mu_unwhitened, q_var_unwhitened = m.predict_f(m.inducing_variables.inducing_variable_list[i].Z)\n",
-    "    plt.plot(m.inducing_variables.inducing_variable_list[i].Z.numpy(), q_mu_unwhitened[:, i, None].numpy(), \"o\")\n",
+    "for i in range(len(m.inducing_variable.inducing_variable_list)):\n",
+    "    q_mu_unwhitened, q_var_unwhitened = m.predict_f(m.inducing_variable.inducing_variable_list[i].Z)\n",
+    "    plt.plot(m.inducing_variable.inducing_variable_list[i].Z.numpy(), q_mu_unwhitened[:, i, None].numpy(), \"o\")\n",
     "plt.gca().set_xticks(np.linspace(-6, 6, 20), minor=True)\n",
     "plt.gca().set_yticks(np.linspace(-9, 9, 20), minor=True)\n",
     "plt.grid(which='minor')"
@@ -647,7 +647,7 @@
     }
    ],
    "source": [
-    "m.inducing_variables.inducing_variable_list"
+    "m.inducing_variable.inducing_variable_list"
    ]
   },
   {
@@ -703,7 +703,7 @@
     "q_sqrt = np.repeat(np.eye(M)[None, ...], L, axis=0) * 1.0 \n",
     "\n",
     "# create SVGP model as usual and optimize\n",
-    "m = gpf.models.SVGP(kernel, gpf.likelihoods.Gaussian(), inducing_variables=iv, q_mu=q_mu, q_sqrt=q_sqrt)"
+    "m = gpf.models.SVGP(kernel, gpf.likelihoods.Gaussian(), inducing_variable=iv, q_mu=q_mu, q_sqrt=q_sqrt)"
    ]
   },
   {

--- a/notebooks2/basics/gplvm.ipynb
+++ b/notebooks2/basics/gplvm.ipynb
@@ -209,8 +209,8 @@
     "            x_data_mean=x_mean_init,\n",
     "            x_data_var=x_var_init,\n",
     "            kernel=kernel,\n",
-    "            num_inducing_variables=num_inducing,\n",
-    "            inducing_variable=inducing_variable)"
+    "            inducing_variable=inducing_variable)\n",
+    "# Instead of passing an inducing_variable directly, we can also set the num_inducing_variables argument to an integer, which will randomly pick from the data."
    ]
   },
   {

--- a/notebooks2/intro_to_gpflow2.ipynb
+++ b/notebooks2/intro_to_gpflow2.ipynb
@@ -198,9 +198,9 @@
    "source": [
     "kernel = gpflow.kernels.RBF(variance=2.)\n",
     "likelihood = gpflow.likelihoods.Gaussian()\n",
-    "features = np.linspace(0, 10, num_features).reshape(-1, 1)\n",
+    "inducing_variable = np.linspace(0, 10, num_features).reshape(-1, 1)\n",
     "\n",
-    "model = gpflow.models.SVGP(kernel=kernel, likelihood=likelihood, inducing_variables=features)"
+    "model = gpflow.models.SVGP(kernel=kernel, likelihood=likelihood, inducing_variable=inducing_variable)"
    ]
   },
   {
@@ -262,7 +262,7 @@
       "SVGP.kernel.variance       Parameter  Softplus        False        ()           float64  2.0\n",
       "SVGP.kernel.lengthscale    Parameter  Softplus        True         ()           float64  0.5\n",
       "SVGP.likelihood.variance   Parameter  Softplus        False        ()           float64  1.0\n",
-      "SVGP.inducing_variables.Z  Parameter                  True         (10, 1)      float64  [[0....\n",
+      "SVGP.inducing_variable.Z   Parameter                  True         (10, 1)      float64  [[0....\n",
       "SVGP.q_mu                  Parameter                  True         (10, 1)      float64  [[0....\n",
       "SVGP.q_sqrt                Parameter  FillTriangular  True         (1, 10, 10)  float64  [[[1., 0., 0....\n"
      ]
@@ -297,7 +297,7 @@
        "<tr><td>SVGP.kernel.variance     </td><td>Parameter</td><td>Softplus      </td><td>False      </td><td>()         </td><td>float64</td><td>2.0             </td></tr>\n",
        "<tr><td>SVGP.kernel.lengthscale  </td><td>Parameter</td><td>Softplus      </td><td>True       </td><td>()         </td><td>float64</td><td>0.5             </td></tr>\n",
        "<tr><td>SVGP.likelihood.variance </td><td>Parameter</td><td>Softplus      </td><td>False      </td><td>()         </td><td>float64</td><td>1.0             </td></tr>\n",
-       "<tr><td>SVGP.inducing_variables.Z</td><td>Parameter</td><td>              </td><td>True       </td><td>(10, 1)    </td><td>float64</td><td>[[0....         </td></tr>\n",
+       "<tr><td>SVGP.inducing_variable.Z</td><td>Parameter</td><td>              </td><td>True       </td><td>(10, 1)    </td><td>float64</td><td>[[0....         </td></tr>\n",
        "<tr><td>SVGP.q_mu                </td><td>Parameter</td><td>              </td><td>True       </td><td>(10, 1)    </td><td>float64</td><td>[[0....         </td></tr>\n",
        "<tr><td>SVGP.q_sqrt              </td><td>Parameter</td><td>FillTriangular</td><td>True       </td><td>(1, 10, 10)</td><td>float64</td><td>[[[1., 0., 0....</td></tr>\n",
        "</tbody>\n",
@@ -493,7 +493,7 @@
     }
    ],
    "source": [
-    "model = gpflow.models.SVGP(kernel=kernel, likelihood=likelihood, inducing_variables=features)\n",
+    "model = gpflow.models.SVGP(kernel=kernel, likelihood=likelihood, inducing_variable=inducing_variable)\n",
     "\n",
     "output_logdir = enumerated_logdir()\n",
     "monitored_training_loop(model, output_logdir, epochs=1000, logging_epoch_freq=100)"
@@ -610,7 +610,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = gpflow.models.SVGP(kernel=kernel, likelihood=likelihood, inducing_variables=features)\n",
+    "model = gpflow.models.SVGP(kernel=kernel, likelihood=likelihood, inducing_variable=inducing_variable)\n",
     "\n",
     "def checkpointing_training_loop(model: gpflow.models.SVGP,\n",
     "                                batch_size: int,\n",

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -24,8 +24,8 @@ from gpflow.config import default_jitter
 @pytest.mark.parametrize('N, D', [[17, 3], [10, 7]])
 def test_inducing_points_inducing_variable_len(N, D):
     Z = np.random.randn(N, D)
-    inducing_variables = InducingPoints(Z)
-    assert_equal(len(inducing_variables), N)
+    inducing_variable = InducingPoints(Z)
+    assert_equal(len(inducing_variable), N)
 
 
 _kernel_setups = [
@@ -41,8 +41,8 @@ _kernel_setups = [
 def test_inducing_equivalence(N, kernel):
     # Inducing inducing must be the same as the kernel evaluations
     Z = np.random.randn(N, 5)
-    inducing_variables = InducingPoints(Z)
-    assert_allclose(Kuu(inducing_variables, kernel), kernel(Z))
+    inducing_variable = InducingPoints(Z)
+    assert_allclose(Kuu(inducing_variable, kernel), kernel(Z))
 
 
 @pytest.mark.parametrize('N, M, D', [[23, 13, 3], [10, 5, 7]])

--- a/tests/test_gplvm.py
+++ b/tests/test_gplvm.py
@@ -61,8 +61,8 @@ def test_bayesian_gplvm_1d():
                                     np.zeros((Data.N, Q)),
                                     np.ones((Data.N, Q)),
                                     kernel,
-                                    num_inducing_variables=Data.M,
                                     inducing_variable=inducing_variable)
+    assert len(m.inducing_variable) == Data.M
     log_likelihood_initial = m.log_likelihood()
     opt = gpflow.optimizers.Scipy()
 

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -386,7 +386,7 @@ def test_switched_likelihood_regression_valid_num_latent(X, Y, num_latent):
     likelihoods = [StudentT()] * 3
     switched_likelihood = SwitchedLikelihood(likelihoods)
     m = gpflow.models.SVGP(kernel=gpflow.kernels.Matern12(),
-                           inducing_variables=Z,
+                           inducing_variable=Z,
                            likelihood=switched_likelihood,
                            num_latent=num_latent)
     if num_latent == 1:

--- a/tests/test_mean_functions.py
+++ b/tests/test_mean_functions.py
@@ -213,7 +213,7 @@ def test_models_with_mean_functions_changes(model_class):
     """
     data = rng.randn(Datum.N, Datum.input_dim), rng.randn(Datum.N, 1)
     predict_at = rng.randn(Datum.Ntest, Datum.input_dim)
-    inducing_variables = InducingPoints(Z=rng.randn(Datum.M, Datum.input_dim))
+    inducing_variable = InducingPoints(Z=rng.randn(Datum.M, Datum.input_dim))
     kernel = gpflow.kernels.Matern32()
     likelihood = gpflow.likelihoods.Gaussian()
     zero_mean = Zero()
@@ -228,31 +228,31 @@ def test_models_with_mean_functions_changes(model_class):
     elif model_class in [gpflow.models.SVGP]:
         model_zero_mean = model_class(kernel=kernel,
                                       likelihood=likelihood,
-                                      inducing_variables=inducing_variables,
+                                      inducing_variable=inducing_variable,
                                       mean_function=zero_mean)
         model_non_zero_mean = model_class(kernel=kernel,
                                           likelihood=likelihood,
-                                          inducing_variables=inducing_variables,
+                                          inducing_variable=inducing_variable,
                                           mean_function=non_zero_mean)
     elif model_class in [gpflow.models.SGPR, gpflow.models.GPRFITC]:
         model_zero_mean = model_class(data,
                                       kernel=kernel,
-                                      inducing_variables=inducing_variables,
+                                      inducing_variable=inducing_variable,
                                       mean_function=zero_mean)
         model_non_zero_mean = model_class(data,
                                           kernel=kernel,
-                                          inducing_variables=inducing_variables,
+                                          inducing_variable=inducing_variable,
                                           mean_function=non_zero_mean)
     elif model_class in [gpflow.models.SGPMC]:
         model_zero_mean = model_class(data,
                                       kernel=kernel,
                                       likelihood=likelihood,
-                                      inducing_variables=inducing_variables,
+                                      inducing_variable=inducing_variable,
                                       mean_function=zero_mean)
         model_non_zero_mean = model_class(data,
                                           kernel=kernel,
                                           likelihood=likelihood,
-                                          inducing_variables=inducing_variables,
+                                          inducing_variable=inducing_variable,
                                           mean_function=non_zero_mean)
     elif model_class in [gpflow.models.GPMC]:
         model_zero_mean = model_class(data,

--- a/tests/test_method_equivalence.py
+++ b/tests/test_method_equivalence.py
@@ -82,26 +82,26 @@ def _create_approximate_models():
                                 mean_function=gpflow.mean_functions.Constant())
     model_2 = gpflow.models.SVGP(gpflow.kernels.SquaredExponential(),
                                  gpflow.likelihoods.Gaussian(),
-                                 inducing_variables=Datum.X.copy(),
+                                 inducing_variable=Datum.X.copy(),
                                  q_diag=False,
                                  mean_function=gpflow.mean_functions.Constant(),
                                  num_latent=Datum.Y.shape[1])
-    gpflow.utilities.set_trainable(model_2.inducing_variables, False)
+    gpflow.utilities.set_trainable(model_2.inducing_variable, False)
     model_3 = gpflow.models.SVGP(kernel=gpflow.kernels.SquaredExponential(),
                                  likelihood=gpflow.likelihoods.Gaussian(),
-                                 inducing_variables=Datum.X.copy(), q_diag=False, whiten=True,
+                                 inducing_variable=Datum.X.copy(), q_diag=False, whiten=True,
                                  mean_function=gpflow.mean_functions.Constant(),
                                  num_latent=Datum.Y.shape[1])
-    gpflow.utilities.set_trainable(model_3.inducing_variables, False)
+    gpflow.utilities.set_trainable(model_3.inducing_variable, False)
     model_4 = gpflow.models.GPRFITC((Datum.X, Datum.Y),
                                     kernel=gpflow.kernels.SquaredExponential(),
-                                    inducing_variables=Datum.X.copy(),
+                                    inducing_variable=Datum.X.copy(),
                                     mean_function=Constant())
-    gpflow.utilities.set_trainable(model_4.inducing_variables, False)
+    gpflow.utilities.set_trainable(model_4.inducing_variable, False)
     model_5 = gpflow.models.SGPR((Datum.X, Datum.Y), gpflow.kernels.SquaredExponential(),
-                                 inducing_variables=Datum.X.copy(),
+                                 inducing_variable=Datum.X.copy(),
                                  mean_function=Constant())
-    gpflow.utilities.set_trainable(model_5.inducing_variables, False)
+    gpflow.utilities.set_trainable(model_5.inducing_variable, False)
 
     # Train models
 
@@ -250,7 +250,7 @@ def test_upper_bound_few_inducing_points():
     Test for upper bound for regression marginal likelihood
     """
     model_vfe = gpflow.models.SGPR((DatumUpper.X, DatumUpper.Y), gpflow.kernels.SquaredExponential(),
-                                   inducing_variables=DatumUpper.X[:10, :].copy(),
+                                   inducing_variable=DatumUpper.X[:10, :].copy(),
                                    mean_function=Constant())
     opt = gpflow.optimizers.Scipy()
 

--- a/tests/test_multioutput.py
+++ b/tests/test_multioutput.py
@@ -224,12 +224,12 @@ def test_sample_conditional(whiten, full_cov, full_output_cov):
     Z = Data.X[:Data.M, ...]  # [M, D]
     Xs = np.ones((Data.N, Data.D), dtype=float_type)
 
-    inducing_variables = InducingPoints(Z)
+    inducing_variable = InducingPoints(Z)
     kernel = SquaredExponential()
 
     # Path 1
     value_f, mean_f, var_f = sample_conditional(Xs,
-                                                inducing_variables,
+                                                inducing_variable,
                                                 kernel,
                                                 q_mu,
                                                 q_sqrt=q_sqrt,
@@ -541,12 +541,12 @@ def test_compare_mixed_kernel():
     kern_list = [SquaredExponential() for _ in range(data.L)]
     k1 = mk.LinearCoregionalization(kern_list, W=data.W)
     f1 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[:data.M, ...]))
-    model_1 = SVGP(k1, Gaussian(), inducing_variables=f1, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
+    model_1 = SVGP(k1, Gaussian(), inducing_variable=f1, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
 
     kern_list = [SquaredExponential() for _ in range(data.L)]
     k2 = mk.LinearCoregionalization(kern_list, W=data.W)
     f2 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[:data.M, ...]))
-    model_2 = SVGP(k2, Gaussian(), inducing_variables=f2, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
+    model_2 = SVGP(k2, Gaussian(), inducing_variable=f2, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
 
     check_equality_predictions(Data.X, Data.Y, [model_1, model_2])
 
@@ -560,12 +560,12 @@ def test_multioutput_with_diag_q_sqrt():
     kern_list = [SquaredExponential() for _ in range(data.L)]
     k1 = mk.LinearCoregionalization(kern_list, W=data.W)
     f1 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[:data.M, ...]))
-    model_1 = SVGP(k1, Gaussian(), inducing_variables=f1, q_mu=data.mu_data, q_sqrt=q_sqrt_diag, q_diag=True)
+    model_1 = SVGP(k1, Gaussian(), inducing_variable=f1, q_mu=data.mu_data, q_sqrt=q_sqrt_diag, q_diag=True)
 
     kern_list = [SquaredExponential() for _ in range(data.L)]
     k2 = mk.LinearCoregionalization(kern_list, W=data.W)
     f2 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[:data.M, ...]))
-    model_2 = SVGP(k2, Gaussian(), inducing_variables=f2, q_mu=data.mu_data, q_sqrt=q_sqrt, q_diag=False)
+    model_2 = SVGP(k2, Gaussian(), inducing_variable=f2, q_mu=data.mu_data, q_sqrt=q_sqrt, q_diag=False)
 
     check_equality_predictions(Data.X, Data.Y, [model_1, model_2])
 
@@ -577,12 +577,12 @@ def test_MixedKernelSeparateMof():
     inducing_variable_list = [InducingPoints(data.X[:data.M, ...]) for _ in range(data.L)]
     k1 = mk.LinearCoregionalization(kern_list, W=data.W)
     f1 = mf.SeparateIndependentInducingVariables(inducing_variable_list)
-    model_1 = SVGP(k1, Gaussian(), inducing_variables=f1, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
+    model_1 = SVGP(k1, Gaussian(), inducing_variable=f1, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
 
     kern_list = [SquaredExponential() for _ in range(data.L)]
     inducing_variable_list = [InducingPoints(data.X[:data.M, ...]) for _ in range(data.L)]
     k2 = mk.LinearCoregionalization(kern_list, W=data.W)
     f2 = mf.SeparateIndependentInducingVariables(inducing_variable_list)
-    model_2 = SVGP(k2, Gaussian(), inducing_variables=f2, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
+    model_2 = SVGP(k2, Gaussian(), inducing_variable=f2, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
 
     check_equality_predictions(Data.X, Data.Y, [model_1, model_2])

--- a/tests/test_multioutput_features.py
+++ b/tests/test_multioutput_features.py
@@ -74,10 +74,10 @@ def test_kuf(inducing_variable, kernel):
 
 @pytest.mark.parametrize('fun', [mo_kuus.Kuu, mo_kufs.Kuf])
 def test_mixed_shared(fun):
-    inducing_variables = mf.SharedIndependentInducingVariables(make_ip())
+    inducing_variable = mf.SharedIndependentInducingVariables(make_ip())
     kernel = mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W)
     if fun is mo_kuus.Kuu:
-        t = tf.linalg.cholesky(fun(inducing_variables, kernel, jitter=1e-9))
+        t = tf.linalg.cholesky(fun(inducing_variable, kernel, jitter=1e-9))
     else:
-        t = fun(inducing_variables, kernel, Datum.Xnew)
+        t = fun(inducing_variable, kernel, Datum.Xnew)
         print(t.shape)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -45,10 +45,10 @@ class ModelSetup:
         params = dict(kernel=self.kernel, num_latent=num_latent)
 
         if self.whiten is not None and self.q_diag is not None:
-            params.update(inducing_variables=Z, whiten=self.whiten, q_diag=self.q_diag)
+            params.update(inducing_variable=Z, whiten=self.whiten, q_diag=self.q_diag)
 
         if self.requires_inducing_variables:
-            params.update(dict(inducing_variables=Z))
+            params.update(dict(inducing_variable=Z))
 
         if self.requires_data:
             params.update(dict(data=data))

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -69,7 +69,7 @@ def create_compose_kernel():
 def create_model():
     kernel = create_kernel()
     model = gpflow.models.SVGP(kernel=kernel, likelihood=gpflow.likelihoods.Gaussian(),
-                               inducing_variables=Data.Z, q_diag=True)
+                               inducing_variable=Data.Z, q_diag=True)
     model.q_mu.trainable = False
     return model
 
@@ -137,7 +137,7 @@ model_gp_param_dict = {
         'trainable': True,
         'shape': ()
     },
-    'inducing_variables.Z': {
+    'inducing_variable.Z': {
         'value': Data.Z,
         'trainable': True,
         'shape': (Data.M, Data.D)
@@ -161,7 +161,7 @@ example_dag_module_param_dict = {
         'trainable': True,
         'shape': ()
     },
-    'SVGP.inducing_variables.Z': {
+    'SVGP.inducing_variable.Z': {
         'value': Data.Z,
         'trainable': True,
         'shape': (Data.M, Data.D)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -44,7 +44,7 @@ def model():
     return gpflow.models.SVGP(
         kernel=gpflow.kernels.SquaredExponential(lengthscale=Data.ls, variance=Data.var),
         likelihood=gpflow.likelihoods.Gaussian(),
-        inducing_variables=Data.Z,
+        inducing_variable=Data.Z,
         q_diag=True
     )
 
@@ -56,19 +56,19 @@ def model():
 model_param_updates = {
     'SVGP.kernel.lengthscale': Data.ls_new,
     'SVGP.likelihood.variance': Data.var_new,
-    'SVGP.inducing_variables.Z': np.zeros_like(Data.Z),
+    'SVGP.inducing_variable.Z': np.zeros_like(Data.Z),
     'SVGP.q_sqrt': 0.5 * np.ones((Data.M, 1))
 }
 model_wrong_path = [
     {'kernel.lengthscale': Data.ls_new},
     {'SVGP.Gaussian.variance': Data.var_new},
-    {'inducing_variables.Z': np.zeros_like(Data.Z)},
+    {'inducing_variable.Z': np.zeros_like(Data.Z)},
     {'SVGP.q_std': 0.5 * np.ones((Data.M, 1))}
 ]
 
 model_wrong_value = [
     {'SVGP.likelihood.variance': np.ones((2, 1), dtype=np.int32)},
-    {'SVGP.inducing_variables.Z': [1, 2, 3]}
+    {'SVGP.inducing_variable.Z': [1, 2, 3]}
 ]
 
 

--- a/tests/test_uncertain_conditional.py
+++ b/tests/test_uncertain_conditional.py
@@ -39,7 +39,7 @@ class MomentMatchingSVGP(gpflow.models.SVGP):
     def uncertain_predict_f_moment_matching(self, Xmu, Xcov):
         return uncertain_conditional(Xmu,
                                      Xcov,
-                                     self.inducing_variables,
+                                     self.inducing_variable,
                                      self.kernel,
                                      self.q_mu,
                                      self.q_sqrt,
@@ -141,7 +141,7 @@ def test_no_uncertainty(white, mean):
                                gpflow.likelihoods.Gaussian(),
                                num_latent=Data.D_out,
                                mean_function=mean_function,
-                               inducing_variables=Data.X.copy(),
+                               inducing_variable=Data.X.copy(),
                                whiten=white)
     model.full_output_cov = False
 
@@ -172,7 +172,7 @@ def test_monte_carlo_1_din(white, mean):
                                gpflow.likelihoods.Gaussian(),
                                num_latent=DataMC1.D_out,
                                mean_function=mean_function,
-                               inducing_variables=DataMC1.X.copy(),
+                               inducing_variable=DataMC1.X.copy(),
                                whiten=white)
     model.full_output_cov = True
 
@@ -204,7 +204,7 @@ def test_monte_carlo_2_din(white, mean):
                                gpflow.likelihoods.Gaussian(),
                                num_latent=DataMC2.D_out,
                                mean_function=mean_function,
-                               inducing_variables=DataMC2.X.copy(),
+                               inducing_variable=DataMC2.X.copy(),
                                whiten=white)
     model.full_output_cov = True
 
@@ -231,14 +231,14 @@ def test_monte_carlo_2_din(white, mean):
 @pytest.mark.parametrize('white', [True, False])
 def test_quadrature(white, mean):
     kernel = gpflow.kernels.SquaredExponential()
-    inducing_variables = gpflow.inducing_variables.InducingPoints(DataQuad.Z)
+    inducing_variable = gpflow.inducing_variables.InducingPoints(DataQuad.Z)
     mean_function = mean_function_factory(mean, DataQuad.D_in, DataQuad.D_out)
 
     effective_mean = mean_function or (lambda X: 0.0)
 
     def conditional_fn(X):
         return conditional(X,
-                           inducing_variables,
+                           inducing_variable,
                            kernel,
                            DataQuad.q_mu,
                            q_sqrt=DataQuad.q_sqrt,
@@ -264,7 +264,7 @@ def test_quadrature(white, mean):
     mean_analytic, var_analytic = uncertain_conditional(
         DataQuad.Xmu,
         DataQuad.Xvar,
-        inducing_variables,
+        inducing_variable,
         kernel,
         DataQuad.q_mu,
         DataQuad.q_sqrt,

--- a/tests/test_variational.py
+++ b/tests/test_variational.py
@@ -120,7 +120,7 @@ def test_variational_univariate_prior_KL(diag, whiten):
     q_sqrt = ones * Datum.posterior_std
     model = gpflow.models.SVGP(kernel=SquaredExponential(variance=Datum.K),
                                likelihood=Gaussian(),
-                               inducing_variables=Datum.Z,
+                               inducing_variable=Datum.Z,
                                num_latent=Datum.num_latent,
                                q_diag=diag,
                                whiten=whiten,
@@ -142,7 +142,7 @@ def test_variational_univariate_log_likelihood(diag, whiten):
     q_sqrt = ones * Datum.posterior_std
     model = gpflow.models.SVGP(kernel=SquaredExponential(variance=Datum.K),
                                likelihood=Gaussian(),
-                               inducing_variables=Datum.Z,
+                               inducing_variable=Datum.Z,
                                num_latent=Datum.num_latent,
                                q_diag=diag,
                                whiten=whiten,
@@ -163,7 +163,7 @@ def test_variational_univariate_conditionals(diag, whiten):
     q_sqrt = ones * Datum.posterior_std
     model = gpflow.models.SVGP(kernel=SquaredExponential(variance=Datum.K),
                                likelihood=Gaussian(),
-                               inducing_variables=Datum.Z,
+                               inducing_variable=Datum.Z,
                                num_latent=Datum.num_latent,
                                q_diag=diag,
                                whiten=whiten,
@@ -196,7 +196,7 @@ def test_variational_multivariate_prior_KL_full_q(whiten):
     model = gpflow.models.SVGP(kernel=SquaredExponential(variance=MultiDatum.signal_var,
                                                          lengthscale=MultiDatum.ls),
                                likelihood=Gaussian(MultiDatum.noise_var),
-                               inducing_variables=MultiDatum.Z,
+                               inducing_variable=MultiDatum.Z,
                                num_latent=MultiDatum.num_latent,
                                q_diag=False,
                                whiten=whiten,


### PR DESCRIPTION
This change makes it easier to distinguish the module `inducing_variables` from the model attribute `inducing_variable`, and is in line with the nomenclature for the other object - we generally think of a single \vec{u} just as we think of a single k(.,.)