### PR TITLE
Quickfix: enable notebook test of regression.ipynb

### DIFF
--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -29,7 +29,6 @@ from nbconvert.preprocessors.execute import CellExecutionError
 BLACKLISTED_NOTEBOOKS = [
     "kernel_design.ipynb",  # PR #1087
     "coregionalisation.ipynb",  # PR #1072
-    "regression.ipynb",  # PR #1076
     "Sanity_check.ipynb",  # PR #1078
 
     "external-mean-function.ipynb",  # TODO: @vdutor


### PR DESCRIPTION
Forgot to remove it from the blacklist in #1076.