### PR TITLE
fix bug in log_prior when a Parameter has a transform but no prior

### DIFF
--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -46,7 +46,7 @@ class Parameter(tf.Module):
                  name: Optional[str] = None):
         """
         Unconstrained parameter representation.
-        According to standart terminology `y` is always transformed representation or,
+        According to standard terminology `y` is always transformed representation or,
         in other words, it is constrained version of the parameter. Normally, it is hard
         to operate with unconstrained parameters. For e.g. `variance` cannot be negative,
         therefore we need positive constraint and it is natural to use constrained values.

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -73,9 +73,9 @@ class Parameter(tf.Module):
         bijector = self.transform
         if self.prior is not None:
             out += tf.reduce_sum(self.prior.log_prob(x))
-        if self.transform is not None:
-            log_det_jacobian = bijector.forward_log_det_jacobian(y, y.shape.ndims)
-            out += tf.reduce_sum(log_det_jacobian)
+            if self.transform is not None:
+                log_det_jacobian = bijector.forward_log_det_jacobian(y, y.shape.ndims)
+                out += tf.reduce_sum(log_det_jacobian)
         return out
 
     @property

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -66,17 +66,15 @@ class Parameter(tf.Module):
     def log_prior(self):
         x = self.read_value()
         y = self._unconstrained
-        dtype = x.dtype
 
-        out = tf.convert_to_tensor(0., dtype=dtype)
-
-        bijector = self.transform
         if self.prior is not None:
-            out += tf.reduce_sum(self.prior.log_prob(x))
+            out = tf.reduce_sum(self.prior.log_prob(x))
             if self.transform is not None:
-                log_det_jacobian = bijector.forward_log_det_jacobian(y, y.shape.ndims)
+                log_det_jacobian = self.transform.forward_log_det_jacobian(y, y.shape.ndims)
                 out += tf.reduce_sum(log_det_jacobian)
-        return out
+            return out
+        else:
+            return tf.convert_to_tensor(0., dtype=self.dtype)
 
     @property
     def handle(self):

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -1,4 +1,6 @@
 import gpflow
+import numpy as np
+import tensorflow as tf
 import pytest
 
 
@@ -9,3 +11,20 @@ def test_log_prior_with_no_prior():
     """
     param = gpflow.Parameter(5.3, transform=gpflow.positive())
     assert param.log_prior().numpy() == 0.0
+
+
+np.random.seed(1)
+
+class Datum:
+    X = 10 * np.random.randn(5,1)
+    Y = 10 * np.random.randn(5,1)
+
+def test_gpr_objective_equivalence():
+    data = (Datum.X, Datum.Y)
+    l_value = 1.3
+    l_variable = tf.Variable(l_value, dtype=gpflow.default_float(), trainable=True)
+    m1 = gpflow.models.GPR(data, kernel=gpflow.kernels.SquaredExponential(lengthscale=l_value))
+    m2 = gpflow.models.GPR(data, kernel=gpflow.kernels.SquaredExponential(lengthscale=l_variable))
+    m2.kernel.lengthscale._transform = None
+    assert np.allclose(m1.neg_log_marginal_likelihood().numpy(),
+                       m2.neg_log_marginal_likelihood().numpy())

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -4,6 +4,36 @@ import tensorflow as tf
 import pytest
 
 
+np.random.seed(1)
+
+class Datum:
+    X = 10 * np.random.randn(5,1)
+    Y = 10 * np.random.randn(5,1)
+    lengthscale = 3.3
+
+
+def test_gpr_objective_equivalence():
+    """
+    In Maximum Likelihood Estimation (MLE), i.e. when there are no priors on
+    the parameters, the objective should not depend on any transforms on the
+    parameters.
+    We use GPR as a simple model that has an objective.
+    """
+    data = (Datum.X, Datum.Y)
+    l_value = Datum.lengthscale
+
+    l_variable = tf.Variable(l_value, dtype=gpflow.default_float(), trainable=True)
+    m1 = gpflow.models.GPR(data, kernel=gpflow.kernels.SquaredExponential(lengthscale=l_value))
+    m2 = gpflow.models.GPR(data, kernel=gpflow.kernels.SquaredExponential())
+    m2.kernel.lengthscale = gpflow.Parameter(l_variable, transform=None)
+    assert np.allclose(m1.kernel.lengthscale.numpy(),
+                       m2.kernel.lengthscale.numpy())  # consistency check
+
+    assert np.allclose(m1.neg_log_marginal_likelihood().numpy(),
+                       m2.neg_log_marginal_likelihood().numpy()), \
+            "MLE objective should not depend on Parameter transform"
+
+
 def test_log_prior_with_no_prior():
     """
     A parameter without any prior should have zero log-prior,
@@ -11,20 +41,3 @@ def test_log_prior_with_no_prior():
     """
     param = gpflow.Parameter(5.3, transform=gpflow.positive())
     assert param.log_prior().numpy() == 0.0
-
-
-np.random.seed(1)
-
-class Datum:
-    X = 10 * np.random.randn(5,1)
-    Y = 10 * np.random.randn(5,1)
-
-def test_gpr_objective_equivalence():
-    data = (Datum.X, Datum.Y)
-    l_value = 1.3
-    l_variable = tf.Variable(l_value, dtype=gpflow.default_float(), trainable=True)
-    m1 = gpflow.models.GPR(data, kernel=gpflow.kernels.SquaredExponential(lengthscale=l_value))
-    m2 = gpflow.models.GPR(data, kernel=gpflow.kernels.SquaredExponential(lengthscale=l_variable))
-    m2.kernel.lengthscale._transform = None
-    assert np.allclose(m1.neg_log_marginal_likelihood().numpy(),
-                       m2.neg_log_marginal_likelihood().numpy())

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -1,0 +1,11 @@
+import gpflow
+import pytest
+
+
+def test_log_prior_with_no_prior():
+    """
+    A parameter without any prior should have zero log-prior,
+    even if it has a transform to constrain it.
+    """
+    param = gpflow.Parameter(5.3, transform=gpflow.positive())
+    assert param.log_prior().numpy() == 0.0

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -1,6 +1,7 @@
 import gpflow
 import numpy as np
 import tensorflow as tf
+import tensorflow_probability as tfp
 import pytest
 
 
@@ -41,3 +42,36 @@ def test_log_prior_with_no_prior():
     """
     param = gpflow.Parameter(5.3, transform=gpflow.positive())
     assert param.log_prior().numpy() == 0.0
+
+
+
+def fix_dtype(x):
+    # TODO replace with generic function for handling tensorflow_probability ...
+    return tf.cast(x, gpflow.default_float())
+
+class DummyModel(gpflow.models.BayesianModel):
+    value = 3.3
+    log_scale = 0.4
+
+    def __init__(self, with_transform):
+        super().__init__()
+
+        prior = tfp.distributions.Normal(fix_dtype(1.0), fix_dtype(1.0))
+
+        scale = np.exp(self.log_scale)
+        if with_transform:
+            transform = tfp.bijectors.AffineScalar(scale=fix_dtype(scale))
+        else:
+            transform = None
+
+        self.theta = gpflow.Parameter(self.value, prior=prior, transform=transform)
+
+    def log_likelihood(self):
+        return (self.theta + 5) ** 2
+
+def test_map_contains_log_det_jacobian():
+    m1 = DummyModel(with_transform=True)
+    m2 = DummyModel(with_transform=False)
+    assert np.allclose(- m1.neg_log_marginal_likelihood().numpy(),
+                       - m2.neg_log_marginal_likelihood().numpy() + m1.log_scale), \
+            "MAP objective should differ by log|Jacobian| of the transform"


### PR DESCRIPTION
When doing MLE instead of MAP (i.e., no prior on the hyperparameters), the objective should be independent of the parametrisation of the parameters. This means that the `log_prior` of a parameter with a `transform` (e.g. `positive()`) but without a `prior` should be zero. This was not the case, leading to difficult / wrong optimisation e.g. in #1087. Fixed in this PR.