### PR TITLE
gpflow.Module.parameter (base for Model) returns an tuple, not generator 

### DIFF
--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -28,11 +28,11 @@ def _IS_TRAINABLE_PARAMETER(o):
 class Module(tf.Module):
     @property
     def parameters(self):
-        return self._flatten(predicate=_IS_PARAMETER)
+        return tuple(self._flatten(predicate=_IS_PARAMETER))
 
     @property
     def trainable_parameters(self):
-        return self._flatten(predicate=_IS_TRAINABLE_PARAMETER)
+        return tuple(self._flatten(predicate=_IS_TRAINABLE_PARAMETER))
 
 
 class Parameter(tf.Module):

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -324,3 +324,19 @@ def test_leaf_components_combination_kernel():
     """
     k = gpflow.kernels.SquaredExponential() + gpflow.kernels.SquaredExponential()
     assert leaf_components(k), "Combination kernel should have non-empty leaf components"
+
+
+def test_module_parameters_return_iterators_not_generators():
+    """
+    Regression test: Ensure that gpflow.Module parameters return iterators like in TF2, not
+    generators.
+
+    Reason:
+    param = m.params  # <generator object>
+    x = [p for p in param] # List[Parameters]
+    y = [p for p in param] # [] empty!
+    """
+    m = create_model()
+    assert isinstance(m, gpflow.base.Module)
+    assert isinstance(m.parameters, tuple)
+    assert isinstance(m.trainable_parameters, tuple)


### PR DESCRIPTION
This supercedes PR #1100 

The variables and trainable_variables parameters on tf.Module return tuples: see [here](https://github.com/tensorflow/tensorflow/blob/1cf0898dd4331baf93fe77205550f2c2e6c90ee5/tensorflow/python/module/module.py#L143) However, the key problem here is that at the moment the `Module` wrapper we have neither returns lists nor tuples, but rather a generator for `self._flatten`. If you don't wrap the generator in an iterable, when you pass the generator to the frozenset SampleHelper, the generator exhausts after its first use. eg:
```
params = m.trainable_parameters
y = [p for p in params]  # List[Params]
z = [p for p in params]  # [] Empty! 
```

I was unsure where to put the tests, so I put them in printing.