### PR TITLE
Ensure all tf_probability distributions take the correct dtype parameters

### DIFF
--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -1,4 +1,5 @@
 import os
+import contextlib
 
 import numpy as np
 import tabulate
@@ -13,6 +14,9 @@ __all__ = [
     "set_default_float",
     "set_default_jitter",
     "set_default_int",
+    "to_default_float",
+    "to_default_int",
+    "config_session"
 ]
 
 _ENV_JITTER = "GPFLOW_JITTER"
@@ -51,6 +55,14 @@ def default_jitter():
     return __config._jitter
 
 
+def to_default_int(x):
+    return tf.cast(x, dtype=default_int())
+
+
+def to_default_float(x):
+    return tf.cast(x, dtype=default_float())
+
+
 def set_default_int(value_type):
     try:
         tf_dtype = tf.as_dtype(value_type)  # Test that it's a tensorflow-valid dtype
@@ -87,3 +99,16 @@ def set_summary_fmt(fmt: str):
         raise ValueError(f"Summary does not support '{fmt}' format")
 
     __config._summary_fmt = fmt
+
+
+@contextlib.contextmanager
+def config_session():
+    '''Ensure that global configs defaults, with a context manager. Useful
+    for testing.'''
+    float_dtype = default_float()
+    int_dtype = default_int()
+    jitter = default_jitter()
+    yield
+    set_default_float(float_dtype)
+    set_default_int(int_dtype)
+    set_default_jitter(jitter)

--- a/gpflow/likelihoods/robustmax.py
+++ b/gpflow/likelihoods/robustmax.py
@@ -3,7 +3,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 from ..base import Parameter
-from ..config import default_int
+from ..config import default_int, to_default_float
 
 
 class RobustMax(tf.Module):
@@ -22,7 +22,7 @@ class RobustMax(tf.Module):
     def __init__(self, num_classes, epsilon=1e-3, **kwargs):
         super().__init__(**kwargs)
         transform = tfp.bijectors.Sigmoid()
-        prior = tfp.distributions.Beta(0.2, 5.)
+        prior = tfp.distributions.Beta(to_default_float(0.2), to_default_float(5.))
         self.epsilon = Parameter(epsilon, transform=transform, prior=prior, trainable=False)
         self.num_classes = num_classes
         self._squash = 1e-4

--- a/gpflow/models/gpmc.py
+++ b/gpflow/models/gpmc.py
@@ -23,7 +23,7 @@ from ..mean_functions import MeanFunction
 from .model import GPModel, MeanAndVariance, Data
 from ..base import Parameter
 from ..conditionals import conditional
-from ..config import default_float, default_jitter
+from ..config import default_float, default_jitter, to_default_float
 
 
 class GPMC(GPModel):
@@ -53,7 +53,7 @@ class GPMC(GPModel):
         self.data = data
         self.num_data = data[0].shape[0]
         self.V = Parameter(np.zeros((self.num_data, self.num_latent)))
-        self.V.prior = tfp.distributions.Normal(loc=0., scale=1.)
+        self.V.prior = tfp.distributions.Normal(loc=to_default_float(0.), scale=to_default_float(1.))
 
     def log_likelihood(self, *args, **kwargs) -> tf.Tensor:
         """

--- a/gpflow/models/sgpmc.py
+++ b/gpflow/models/sgpmc.py
@@ -24,6 +24,7 @@ from ..conditionals import conditional
 from ..inducing_variables import InducingPoints
 from ..kernels import Kernel
 from ..models.model import GPModel, MeanAndVariance, Data
+from ..config import to_default_float
 from .util import inducingpoint_wrapper
 
 
@@ -80,7 +81,7 @@ class SGPMC(GPModel):
         self.num_data = data[0].shape[0]
         self.inducing_variable = inducingpoint_wrapper(inducing_variable)
         self.V = Parameter(np.zeros((len(self.inducing_variable), self.num_latent)))
-        self.V.prior = tfp.distributions.Normal(loc=0., scale=1.)
+        self.V.prior = tfp.distributions.Normal(loc=to_default_float(0.), scale=to_default_float(1.))
 
     def log_likelihood(self, *args, **kwargs) -> tf.Tensor:
         """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,3 +67,20 @@ def test_summary_fmt_setting():
 def test_summary_fmt_errorcheck():
     with pytest.raises(ValueError):
         config.set_summary_fmt("this_format_definitely_does_not_exist")
+
+
+@pytest.mark.parametrize('setter, getter, converter, dtype, value', [
+    (config.set_default_int, config.default_int, config.to_default_int, np.int32, 3),
+    (config.set_default_int, config.default_int, config.to_default_int, tf.int32, 3),
+    (config.set_default_int, config.default_int, config.to_default_int, tf.int64, [3, 1, 4, 1, 5, 9]),
+    (config.set_default_int, config.default_int, config.to_default_int, np.int64, [3, 1, 4, 1, 5, 9]),
+    (config.set_default_float, config.default_float, config.to_default_float, np.float32, 3.14159),
+    (config.set_default_float, config.default_float, config.to_default_float, tf.float32, [3.14159, 3.14159, 3.14159]),
+    (config.set_default_float, config.default_float, config.to_default_float, np.float64, [3.14159, 3.14159, 3.14159]),
+    (config.set_default_float, config.default_float, config.to_default_float, tf.float64, [3.14159, 3.14159, 3.14159]),
+])
+def test_native_to_default_dtype(setter, getter, converter, dtype, value):
+    with config.config_session():
+        setter(dtype)
+        assert converter(value).dtype == dtype
+        assert converter(value).dtype == getter()

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -73,7 +73,7 @@ def test_map_contains_log_det_jacobian():
             "MAP objective should differ by log|Jacobian| of the transform"
 
 
-def get_GPMC_model_params():
+def get_gpmc_model_params():
     kernel = gpflow.kernels.Matern32()
     likelihood = gpflow.likelihoods.Gaussian()
     data = [np.arange(5), np.arange(5)]
@@ -84,7 +84,7 @@ def get_GPMC_model_params():
     (gpflow.models.GPMC, get_GPMC_model_params()),
     #(gpflow.models.SGPMC, get_SGPMC_model_params()) # Fails due to inducing_variable=None bug
     ])
-def test_V_prior_dtypes(model_class, args):
+def test_v_prior_dtypes(model_class, args):
     with config_session():
         set_default_float(np.float32)
         m = model_class(*args)

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -1,4 +1,5 @@
 import gpflow
+from gpflow.config import to_default_float, set_default_float, config_session
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
@@ -44,11 +45,6 @@ def test_log_prior_with_no_prior():
     assert param.log_prior().numpy() == 0.0
 
 
-
-def fix_dtype(x):
-    # TODO replace with generic function for handling tensorflow_probability ...
-    return tf.cast(x, gpflow.default_float())
-
 class DummyModel(gpflow.models.BayesianModel):
     value = 3.3
     log_scale = 0.4
@@ -56,11 +52,11 @@ class DummyModel(gpflow.models.BayesianModel):
     def __init__(self, with_transform):
         super().__init__()
 
-        prior = tfp.distributions.Normal(fix_dtype(1.0), fix_dtype(1.0))
+        prior = tfp.distributions.Normal(to_default_float(1.0), to_default_float(1.0))
 
         scale = np.exp(self.log_scale)
         if with_transform:
-            transform = tfp.bijectors.AffineScalar(scale=fix_dtype(scale))
+            transform = tfp.bijectors.AffineScalar(scale=to_default_float(scale))
         else:
             transform = None
 
@@ -75,3 +71,24 @@ def test_map_contains_log_det_jacobian():
     assert np.allclose(- m1.neg_log_marginal_likelihood().numpy(),
                        - m2.neg_log_marginal_likelihood().numpy() + m1.log_scale), \
             "MAP objective should differ by log|Jacobian| of the transform"
+
+
+def get_GPMC_model_params():
+    kernel = gpflow.kernels.Matern32()
+    likelihood = gpflow.likelihoods.Gaussian()
+    data = [np.arange(5), np.arange(5)]
+    return data, kernel, likelihood
+
+
+@pytest.mark.parametrize('model_class, args', [
+    (gpflow.models.GPMC, get_GPMC_model_params()),
+    #(gpflow.models.SGPMC, get_SGPMC_model_params()) # Fails due to inducing_variable=None bug
+    ])
+def test_V_prior_dtypes(model_class, args):
+    with config_session():
+        set_default_float(np.float32)
+        m = model_class(*args)
+        assert m.V.prior.dtype == np.float32
+        set_default_float(np.float64)
+        m = model_class(*args)
+        assert m.V.prior.dtype == np.float64

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -81,7 +81,7 @@ def get_gpmc_model_params():
 
 
 @pytest.mark.parametrize('model_class, args', [
-    (gpflow.models.GPMC, get_GPMC_model_params()),
+    (gpflow.models.GPMC, get_gpmc_model_params()),
     #(gpflow.models.SGPMC, get_SGPMC_model_params()) # Fails due to inducing_variable=None bug
     ])
 def test_v_prior_dtypes(model_class, args):


### PR DESCRIPTION
This PR supercedes PR # 1100

TF Probabilities does not allow you to either choose a dtype for your distributions (see PR #1100 ) at the moment. Instead it is currently inferred by the dtype of the params. Tensorflow also has no way of setting default dtypes in the backend, and this is also an open issue.

There are two solutions to this: 
* One is simply to covert native values to the default dtype before sending them into the tfp distribution. This relies on the user knowing this is how tfp distributions work.
* The other is to create an intermediate wrapper around all the distributions in tfp, and allow users of gpflow not to have to worry about this.

Although the first is uglier (users will get bitten by this, possibly), if we create a wrapper around tfp.distributions.Gamma etc, we will have to maintain it, probably for a very long time (in particular, we may have to add distributions etc). 

Ultimately this is a tf problem and I think it best if we don't turn it into our problem as well - is there a way we could communicate this problem clearly to users? If so where would we put it?
