### PR TITLE
Change step_callback behaviour of Scipy optimizer in gpflow2 to behave as in gpflow1

### DIFF
--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -21,7 +21,7 @@ class Scipy:
                  **scipy_kwargs) -> OptimizeResult:
         """
         Minimize is a wrapper around the `scipy.optimize.minimize` function
-        handling the packing and unpacking of lists of shaped variables on the
+        handling the packing and unpacking of a list of shaped variables on the
         TensorFlow side vs. the flat numpy array required on the Scipy side.
 
         Args:

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -10,7 +10,7 @@ __all__ = ['Scipy']
 Loss = tf.Tensor
 Variables = List[tf.Variable]
 Gradients = List[tf.Tensor]
-StepCallback = Callable[[int, Loss, Variables, Gradients], None]
+StepCallback = Callable[[int, Variables, tf.Tensor], None]
 LossClosure = Callable[..., Tuple[tf.Tensor, Variables]]
 
 
@@ -59,14 +59,13 @@ class Scipy:
         return _eval
 
     @classmethod
-    def callback_func(cls, closure: LossClosure, variables: Variables, step_callback: Optional[StepCallback] = None):
+    def callback_func(cls, variables: Variables, step_callback: StepCallback):
         step = 0  # type: int
 
         def _callback(x):
             nonlocal step
-            cls.unpack_tensors(variables, x)
-            loss, grads = _compute_loss_and_gradients(closure, variables)
-            step_callback(step=step, loss=loss, variables=variables, gradients=grads)
+            values = cls.unpack_tensors(variables, x)
+            step_callback(step=step, variables=variables, values=values)
             step += 1
 
         return _callback

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -10,7 +10,7 @@ __all__ = ['Scipy']
 Loss = tf.Tensor
 Variables = List[tf.Variable]
 Gradients = List[tf.Tensor]
-StepCallback = Callable[[int, Variables, tf.Tensor], None]
+StepCallback = Callable[[int, Variables, List[tf.Tensor]], None]
 LossClosure = Callable[..., Tuple[tf.Tensor, Variables]]
 
 

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -15,6 +15,8 @@ LossClosure = Callable[..., Tuple[tf.Tensor, Variables]]
 
 
 class Scipy:
+    _DEFAULT_METHOD = 'L-BFGS-B'
+
     def minimize(self,
                  closure: LossClosure,
                  variables: Variables,
@@ -35,13 +37,17 @@ class Scipy:
             raise TypeError('Callable object expected.')  # pragma: no cover
         initial_params = self.initial_parameters(variables)
         func = self.eval_func(closure, variables)
+
         if step_callback is not None:
             if 'callback' in scipy_kwargs:
                 raise ValueError("Callback passed both via `step_callback` and `callback`")
 
             callback = self.callback_func(closure, variables, step_callback)
             scipy_kwargs.update(dict(callback=callback))
-        return scipy.optimize.minimize(func, initial_params, jac=True, **scipy_kwargs)
+
+        method = scipy_kwargs.pop('method', self._DEFAULT_METHOD)
+        return scipy.optimize.minimize(func, initial_params, jac=True, method=method,
+                                       **scipy_kwargs)
 
     @classmethod
     def initial_parameters(cls, variables):

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -15,8 +15,6 @@ LossClosure = Callable[..., Tuple[tf.Tensor, Variables]]
 
 
 class Scipy:
-    _DEFAULT_METHOD = 'L-BFGS-B'
-
     def minimize(self,
                  closure: LossClosure,
                  variables: Variables,
@@ -37,17 +35,13 @@ class Scipy:
             raise TypeError('Callable object expected.')  # pragma: no cover
         initial_params = self.initial_parameters(variables)
         func = self.eval_func(closure, variables)
-
         if step_callback is not None:
             if 'callback' in scipy_kwargs:
                 raise ValueError("Callback passed both via `step_callback` and `callback`")
 
             callback = self.callback_func(closure, variables, step_callback)
             scipy_kwargs.update(dict(callback=callback))
-
-        method = scipy_kwargs.pop('method', self._DEFAULT_METHOD)
-        return scipy.optimize.minimize(func, initial_params, jac=True, method=method,
-                                       **scipy_kwargs)
+        return scipy.optimize.minimize(func, initial_params, jac=True, **scipy_kwargs)
 
     @classmethod
     def initial_parameters(cls, variables):


### PR DESCRIPTION
Changes behaviour of `step_callback` so that the callback only gets called once per optimisation step, not once per objective function evaluation. Makes gpflow2's Scipy() behave more like gpflow1's ScipyOptimizer()/monitoring.
