### PR TITLE
Fix convolutional notebook (currently in invalid state for jupyter)

### DIFF
--- a/doc/source/notebooks/advanced/convolutional.ipynb
+++ b/doc/source/notebooks/advanced/convolutional.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +433,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -467,7 +467,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [


### PR DESCRIPTION
A previous PR left the `convolutional.ipynb` in an invalid state (Jupyter throws an error). (PR #1108). This directly undoes that and has been manually tested.