### PR TITLE
Add config option for positive bijector + re-introduce positive lower bound

### DIFF
--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -31,7 +31,7 @@ class _Values(enum.Enum):
     INT = np.int32
     FLOAT = np.float64
     POSITIVE_BIJECTOR = "softplus"
-    POSITIVE_MINIMUM = None
+    POSITIVE_MINIMUM = 1e-10
     SUMMARY_FMT = None
     JITTER = 1e-6
 

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -31,7 +31,7 @@ class _Values(enum.Enum):
     INT = np.int32
     FLOAT = np.float64
     POSITIVE_BIJECTOR = "softplus"
-    POSITIVE_MINIMUM = 1e-10
+    POSITIVE_MINIMUM = None
     SUMMARY_FMT = None
     JITTER = 1e-6
 

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -144,11 +144,11 @@ _VALID_POSITIVE_BIJECTORS = {"exp", "softplus"}
 
 def set_default_positive_bijector(value: str):
     if not isinstance(value, str):
-        TypeError(f"Expected a string, but got a {type(value)}")
+        raise TypeError(f"Expected a string, but got a {type(value)}")
 
     value = value.lower()
     if value not in _VALID_POSITIVE_BIJECTORS:
-        ValueError(f"Value '{value}' not in {sorted(_VALID_POSITIVE_BIJECTORS)}")
+        raise ValueError(f"'{value}' not found in {sorted(_VALID_POSITIVE_BIJECTORS)}")
 
     set_config(replace(config(), positive_bijector=value))
 

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -8,11 +8,18 @@ import numpy as np
 import tabulate
 import tensorflow as tf
 
+
 __all__ = [
-    "Config", "default_summary_fmt", "default_float", "default_jitter", "default_int", "set_default_summary_fmt",
-    "set_default_float", "set_default_jitter", "set_default_int", "as_context", "config", "set_config",
-    "default_positive_minimum", "set_default_positive_minimum"
+    "Config", "as_context",
+    "config", "set_config",
+    "default_float", "set_default_float",
+    "default_int", "set_default_int",
+    "default_jitter", "set_default_jitter",
+    "default_positive_bijector", "set_default_positive_bijector",
+    "default_positive_minimum", "set_default_positive_minimum",
+    "default_summary_fmt", "set_default_summary_fmt",
 ]
+
 
 __config = None
 
@@ -23,6 +30,7 @@ class _Values(enum.Enum):
     will be `GPFLOW_SUMMARY_FMT`."""
     INT = np.int32
     FLOAT = np.float64
+    POSITIVE_BIJECTOR = "softplus"
     POSITIVE_MINIMUM = None
     SUMMARY_FMT = None
     JITTER = 1e-6
@@ -33,7 +41,7 @@ class _Values(enum.Enum):
 
 
 def default(value: _Values):
-    """Checks if """
+    """Checks if value is set in the environment."""
     return os.getenv(value.name, default=value.value)
 
 
@@ -47,6 +55,8 @@ class Config:
         float: Float data type, float32 or float64
         jitter: Jitter value. Mainly used for for making badly conditioned matrices more stable.
             Default value is `1e-6`.
+        positive_bijector: Method for positive bijector, either "softplus" or "exp".
+            Default is "softplus".
         positive_minimum: Lower level for the positive transformation.
         summary_fmt: Summary format for module printing.
     """
@@ -54,6 +64,7 @@ class Config:
     int: type = field(default_factory=lambda: default(_Values.INT))
     float: type = field(default_factory=lambda: default(_Values.FLOAT))
     jitter: float = field(default_factory=lambda: default(_Values.JITTER))
+    positive_bijector: str = field(default_factory=lambda: default(_Values.POSITIVE_BIJECTOR))
     positive_minimum: float = field(default_factory=lambda: default(_Values.POSITIVE_MINIMUM))
     summary_fmt: str = field(default_factory=lambda: default(_Values.SUMMARY_FMT))
 
@@ -61,10 +72,6 @@ class Config:
 def config() -> Config:
     """Returns current active config."""
     return __config
-
-
-def default_summary_fmt():
-    return config().summary_fmt
 
 
 def default_int():
@@ -79,8 +86,16 @@ def default_jitter():
     return config().jitter
 
 
+def default_positive_bijector():
+    return config().positive_bijector
+
+
 def default_positive_minimum():
     return config().positive_minimum
+
+
+def default_summary_fmt():
+    return config().summary_fmt
 
 
 def set_config(new_config: Config):
@@ -124,12 +139,18 @@ def set_default_jitter(value: float):
     set_config(replace(config(), jitter=value))
 
 
-def set_default_summary_fmt(value: str):
-    formats = tabulate.tabulate_formats + ['notebook', None]
-    if value not in formats:
-        raise ValueError(f"Summary does not support '{value}' format")
+_VALID_POSITIVE_BIJECTORS = {"exp", "softplus"}
 
-    set_config(replace(config(), summary_fmt=value))
+
+def set_default_positive_bijector(value: str):
+    if not isinstance(value, str):
+        TypeError(f"Expected a string, but got a {type(value)}")
+
+    value = value.lower()
+    if value not in _VALID_POSITIVE_BIJECTORS:
+        ValueError(f"Value '{value}' not in {sorted(_VALID_POSITIVE_BIJECTORS)}")
+
+    set_config(replace(config(), positive_bijector=value))
 
 
 def set_default_positive_minimum(value: float):
@@ -143,10 +164,17 @@ def set_default_positive_minimum(value: float):
     set_config(replace(config(), positive_minimum=value))
 
 
+def set_default_summary_fmt(value: str):
+    formats = tabulate.tabulate_formats + ['notebook', None]
+    if value not in formats:
+        raise ValueError(f"Summary does not support '{value}' format")
+
+    set_config(replace(config(), summary_fmt=value))
+
+
 @contextlib.contextmanager
 def as_context(temporary_config: Optional[Config] = None):
-    '''Ensure that global configs defaults, with a context manager. Useful
-    for testing.'''
+    """Ensure that global configs defaults, with a context manager. Useful for testing."""
     current_config = config()
     temporary_config = replace(current_config) if temporary_config is None else temporary_config
     try:

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -139,16 +139,15 @@ def set_default_jitter(value: float):
     set_config(replace(config(), jitter=value))
 
 
-_VALID_POSITIVE_BIJECTORS = {"exp", "softplus"}
-
-
 def set_default_positive_bijector(value: str):
     if not isinstance(value, str):
         raise TypeError(f"Expected a string, but got a {type(value)}")
 
+    valid_bijectors = {"exp", "softplus"}
+
     value = value.lower()
-    if value not in _VALID_POSITIVE_BIJECTORS:
-        raise ValueError(f"'{value}' not found in {sorted(_VALID_POSITIVE_BIJECTORS)}")
+    if value not in valid_bijectors:
+        raise ValueError(f"'{value}' not found in {sorted(valid_bijectors)}")
 
     set_config(replace(config(), positive_bijector=value))
 

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -2,7 +2,7 @@ import contextlib
 import enum
 import os
 from dataclasses import dataclass, field, replace
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
 import tabulate
@@ -11,14 +11,14 @@ import tensorflow_probability as tfp
 
 
 __all__ = [
-    "Config", "as_context",
-    "config", "set_config",
+    "Config", "as_context", "config", "set_config",
     "default_float", "set_default_float",
     "default_int", "set_default_int",
     "default_jitter", "set_default_jitter",
     "default_positive_bijector", "set_default_positive_bijector",
     "default_positive_minimum", "set_default_positive_minimum",
     "default_summary_fmt", "set_default_summary_fmt",
+    "positive_bijector_type_map"
 ]
 
 
@@ -46,18 +46,6 @@ def default(value: _Values):
     return os.getenv(value.name, default=value.value)
 
 
-def _to_bijector(value: str) -> tfp.bijectors.Bijector:
-    bijector_map = {
-        "exp": tfp.bijectors.Exp,
-        "softplus": tfp.bijectors.Softplus,
-    }
-    if isinstance(value, str):
-        value = value.lower()
-    if value not in bijector_map:
-        raise ValueError(f"`{value}` not in set of valid bijectors: {sorted(bijector_map)}")
-    return bijector_map[value]()
-
-
 @dataclass(frozen=True)
 class Config:
     """
@@ -77,8 +65,7 @@ class Config:
     int: type = field(default_factory=lambda: default(_Values.INT))
     float: type = field(default_factory=lambda: default(_Values.FLOAT))
     jitter: float = field(default_factory=lambda: default(_Values.JITTER))
-    positive_bijector: tfp.bijectors.Bijector = field(
-        default_factory=lambda: _to_bijector(default(_Values.POSITIVE_BIJECTOR)))
+    positive_bijector: str = field(default_factory=lambda: default(_Values.POSITIVE_BIJECTOR))
     positive_minimum: float = field(default_factory=lambda: default(_Values.POSITIVE_MINIMUM))
     summary_fmt: str = field(default_factory=lambda: default(_Values.SUMMARY_FMT))
 
@@ -153,11 +140,12 @@ def set_default_jitter(value: float):
     set_config(replace(config(), jitter=value))
 
 
-def set_default_positive_bijector(value: Union[str, tfp.bijectors.Bijector]):
+def set_default_positive_bijector(value: str):
+    type_map = positive_bijector_type_map()
     if isinstance(value, str):
-        value = _to_bijector(value)
-    elif not isinstance(value, tfp.bijectors.Bijector):
-        raise TypeError(f"Expected a Bijector, but got a {type(value)}")
+        value = value.lower()
+    if value not in type_map:
+        raise ValueError(f"`{value}` not in set of valid bijectors: {sorted(type_map)}")
 
     set_config(replace(config(), positive_bijector=value))
 
@@ -179,6 +167,13 @@ def set_default_summary_fmt(value: str):
         raise ValueError(f"Summary does not support '{value}' format")
 
     set_config(replace(config(), summary_fmt=value))
+
+
+def positive_bijector_type_map() -> Dict[str, type]:
+    return {
+        "exp": tfp.bijectors.Exp,
+        "softplus": tfp.bijectors.Softplus,
+    }
 
 
 @contextlib.contextmanager

--- a/gpflow/utilities/bijectors.py
+++ b/gpflow/utilities/bijectors.py
@@ -47,7 +47,7 @@ def _get_base_positive_bijector(bijector_name: Optional[str] = None):
     return _POSITIVE_BIJECTOR_MAP[bijector_name]()
 
 
-def triangular():
+def triangular() -> tfp.bijectors.Bijector:
     """
     Returns instance of a triangular bijector.
     """

--- a/gpflow/utilities/bijectors.py
+++ b/gpflow/utilities/bijectors.py
@@ -9,22 +9,16 @@ from .utilities import to_default_float
 __all__ = ["positive", "triangular"]
 
 
-_POSITIVE_BIJECTOR_MAP = {
-    "exp": tfp.bijectors.Exp,
-    "softplus": tfp.bijectors.Softplus,
-}
-
-
 def positive(lower: Optional[float] = None,
-             bijector: Optional[str] = None) -> tfp.bijectors.Bijector:
+             base: Optional[tfp.bijectors.Bijector] = None) -> tfp.bijectors.Bijector:
     """
     Returns a positive bijector (a reversible transformation from real to positive numbers).
 
     :param lower: lower bound override (defaults to config.default_positive_minimum())
-    :param bijector: bijector method override (defaults to config.default_positive_bijector())
+    :param base: overrides the default base positive bijector (defaults to config.default_positive_bijector())
     :returns: a bijector instance
     """
-    bijector = _get_base_positive_bijector(bijector)
+    bijector = base if base is not None else config.default_positive_bijector()
     if lower is None:
         lower = config.default_positive_minimum()
     if lower is not None:
@@ -32,12 +26,6 @@ def positive(lower: Optional[float] = None,
         shift = tfp.bijectors.AffineScalar(shift=to_default_float(lower))
         bijector = tfp.bijectors.Chain([bijector, shift])
     return bijector
-
-
-def _get_base_positive_bijector(name: Optional[str] = None) -> tfp.bijectors.Bijector:
-    if name is None:
-        name = config.default_positive_bijector()
-    return _POSITIVE_BIJECTOR_MAP[name]()
 
 
 def triangular() -> tfp.bijectors.Bijector:

--- a/gpflow/utilities/bijectors.py
+++ b/gpflow/utilities/bijectors.py
@@ -15,13 +15,6 @@ _POSITIVE_BIJECTOR_MAP = {
 }
 
 
-class Shift(tfp.bijectors.AffineScalar):
-    """Simple subclass so printed name is cleaner."""
-
-    def __init__(self, shift=None, validate_args=False, name='shift'):
-        super().__init__(shift=shift, validate_args=validate_args, name=name)
-
-
 def positive(lower: Optional[float] = None,
              bijector: Optional[str] = None) -> tfp.bijectors.Bijector:
     """
@@ -36,7 +29,7 @@ def positive(lower: Optional[float] = None,
         lower = config.default_positive_minimum()
     if lower is not None:
         # Apply lower bound shift after applying base positive bijector
-        shift = Shift(shift=to_default_float(lower))
+        shift = tfp.bijectors.AffineScalar(shift=to_default_float(lower))
         bijector = tfp.bijectors.Chain([bijector, shift])
     return bijector
 

--- a/gpflow/utilities/bijectors.py
+++ b/gpflow/utilities/bijectors.py
@@ -42,4 +42,8 @@ def _get_base_positive_bijector(bijector_name: Optional[str] = None):
     return _POSITIVE_BIJECTOR_MAP[bijector_name]()
 
 
-triangular = tfp.bijectors.FillTriangular
+def triangular():
+    """
+    Returns instance of a triangular bijector.
+    """
+    return tfp.bijectors.FillTriangular()

--- a/gpflow/utilities/bijectors.py
+++ b/gpflow/utilities/bijectors.py
@@ -24,16 +24,14 @@ def positive(lower: Optional[float] = None,
     :param bijector: bijector method override (defaults to config.default_positive_bijector())
     :returns: a bijector instance
     """
+    bijector = _get_base_positive_bijector(bijector)
     if lower is None:
         lower = config.default_positive_minimum()
-    if lower is None:
-        return _get_base_positive_bijector(bijector)
-
-    shift = to_default_float(lower)
-    return tfp.bijectors.Chain([
-        tfp.bijectors.AffineScalar(shift=shift),
-        _get_base_positive_bijector(bijector),
-    ])
+    if lower is not None:
+        # Apply lower bound shift after applying base positive bijector
+        shift = tfp.bijectors.AffineScalar(shift=to_default_float(lower))
+        bijector = tfp.bijectors.Chain([bijector, shift])
+    return bijector
 
 
 def _get_base_positive_bijector(bijector_name: Optional[str] = None):

--- a/gpflow/utilities/bijectors.py
+++ b/gpflow/utilities/bijectors.py
@@ -9,22 +9,24 @@ from .utilities import to_default_float
 __all__ = ["positive", "triangular"]
 
 
-def positive(lower: Optional[float] = None,
-             base: Optional[tfp.bijectors.Bijector] = None) -> tfp.bijectors.Bijector:
+def positive(lower: Optional[float] = None, base: Optional[str] = None) -> tfp.bijectors.Bijector:
     """
     Returns a positive bijector (a reversible transformation from real to positive numbers).
 
     :param lower: lower bound override (defaults to config.default_positive_minimum())
-    :param base: overrides the default base positive bijector (defaults to config.default_positive_bijector())
+    :param base: overrides base positive bijector (defaults to config.default_positive_bijector())
     :returns: a bijector instance
     """
+    if isinstance(base, str):
+        base = base.lower()
     bijector = base if base is not None else config.default_positive_bijector()
+    bijector = config.positive_bijector_type_map()[bijector]()
     if lower is None:
         lower = config.default_positive_minimum()
     if lower is not None:
-        # Apply lower bound shift after applying base positive bijector
+        # Chain applies transformations in reverse order, so shift will be applied last
         shift = tfp.bijectors.AffineScalar(shift=to_default_float(lower))
-        bijector = tfp.bijectors.Chain([bijector, shift])
+        bijector = tfp.bijectors.Chain([shift, bijector])
     return bijector
 
 

--- a/gpflow/utilities/bijectors.py
+++ b/gpflow/utilities/bijectors.py
@@ -5,17 +5,41 @@ import tensorflow_probability as tfp
 from .. import config
 from .utilities import to_default_float
 
+
 __all__ = ["positive", "triangular"]
 
 
-def positive(lower: Optional[float] = None):
-    lower_value = config.default_positive_minimum()
-    if lower_value is None:
-        return tfp.bijectors.Softplus()
+_POSITIVE_BIJECTOR_MAP = {
+    "exp": tfp.bijectors.Exp,
+    "softplus": tfp.bijectors.Softplus,
+}
 
-    shift = to_default_float(lower_value)
-    bijectors = [tfp.bijectors.AffineScalar(shift=shift), tfp.bijectors.Softplus()]
-    return tfp.bijectors.Chain(bijectors)
+
+def positive(lower: Optional[float] = None,
+             bijector: Optional[str] = None) -> tfp.bijectors.Bijector:
+    """
+    Returns a positive bijector (a reversible transformation from real to positive numbers).
+
+    :param lower: lower bound override (defaults to config.default_positive_minimum())
+    :param bijector: bijector method override (defaults to config.default_positive_bijector())
+    :returns: a bijector instance
+    """
+    if lower is None:
+        lower = config.default_positive_minimum()
+    if lower is None:
+        return _get_base_positive_bijector(bijector)
+
+    shift = to_default_float(lower)
+    return tfp.bijectors.Chain([
+        tfp.bijectors.AffineScalar(shift=shift),
+        _get_base_positive_bijector(bijector),
+    ])
+
+
+def _get_base_positive_bijector(bijector_name: Optional[str] = None):
+    if bijector_name is None:
+        bijector_name = config.default_positive_bijector()
+    return _POSITIVE_BIJECTOR_MAP[bijector_name]()
 
 
 triangular = tfp.bijectors.FillTriangular

--- a/gpflow/utilities/bijectors.py
+++ b/gpflow/utilities/bijectors.py
@@ -15,6 +15,13 @@ _POSITIVE_BIJECTOR_MAP = {
 }
 
 
+class Shift(tfp.bijectors.AffineScalar):
+    """Simple subclass so printed name is cleaner."""
+
+    def __init__(self, shift=None, validate_args=False, name='shift'):
+        super().__init__(shift=shift, validate_args=validate_args, name=name)
+
+
 def positive(lower: Optional[float] = None,
              bijector: Optional[str] = None) -> tfp.bijectors.Bijector:
     """
@@ -29,7 +36,7 @@ def positive(lower: Optional[float] = None,
         lower = config.default_positive_minimum()
     if lower is not None:
         # Apply lower bound shift after applying base positive bijector
-        shift = tfp.bijectors.AffineScalar(shift=to_default_float(lower))
+        shift = Shift(shift=to_default_float(lower))
         bijector = tfp.bijectors.Chain([bijector, shift])
     return bijector
 

--- a/gpflow/utilities/bijectors.py
+++ b/gpflow/utilities/bijectors.py
@@ -41,10 +41,10 @@ def positive(lower: Optional[float] = None,
     return bijector
 
 
-def _get_base_positive_bijector(bijector_name: Optional[str] = None):
-    if bijector_name is None:
-        bijector_name = config.default_positive_bijector()
-    return _POSITIVE_BIJECTOR_MAP[bijector_name]()
+def _get_base_positive_bijector(name: Optional[str] = None) -> tfp.bijectors.Bijector:
+    if name is None:
+        name = config.default_positive_bijector()
+    return _POSITIVE_BIJECTOR_MAP[name]()
 
 
 def triangular() -> tfp.bijectors.Bijector:

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -145,7 +145,7 @@ def tabulate_module_summary(module: tf.Module, tablefmt: Optional[str] = None) -
     def get_transform(v):
         if hasattr(v, "transform") and v.transform is not None:
             if isinstance(v.transform, tfp.bijectors.Chain):
-                return " + ".join(b.__class__.__name__ for b in v.transform.bijectors)
+                return " + ".join(b.__class__.__name__ for b in v.transform.bijectors[::-1])
             return v.transform.__class__.__name__
         return None
 

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -144,6 +144,8 @@ def tabulate_module_summary(module: tf.Module, tablefmt: Optional[str] = None) -
 
     def get_transform(v):
         if hasattr(v, "transform") and v.transform is not None:
+            if isinstance(v.transform, tfp.bijectors.Chain):
+                return " + ".join(b.__class__.__name__ for b in v.transform.bijectors)
             return v.transform.__class__.__name__
         return None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,24 +63,19 @@ def test_jitter_errorcheck():
         set_default_jitter(-1e-10)
 
 
-@pytest.mark.parametrize("error_type, error_msg, value", [
-    (ValueError, r"`unknown` not in set of valid bijectors: \['exp', 'softplus'\]", 'Unknown'),
-    (TypeError, r"Expected a Bijector, but got a <class 'float'>", 1.0),
+@pytest.mark.parametrize("value, error_msg", [
+    ("Unknown", r"`unknown` not in set of valid bijectors: \['exp', 'softplus'\]"),
+    (1.0, r"`1.0` not in set of valid bijectors: \['exp', 'softplus'\]"),
 ])
-def test_positive_bijector_errors(error_type, error_msg, value):
-    with pytest.raises(error_type, match=error_msg):
+def test_positive_bijector_error(value, error_msg):
+    with pytest.raises(ValueError, match=error_msg):
         set_default_positive_bijector(value)
 
 
-@pytest.mark.parametrize("value, expected", [
-    ("exp", tfp.bijectors.Exp),
-    ("softplus", tfp.bijectors.Softplus),
-    (tfp.bijectors.Exp(), tfp.bijectors.Exp),
-    (tfp.bijectors.Softplus(hinge_softness=2.0), tfp.bijectors.Softplus),
-])
-def test_positive_bijector_setting(value, expected):
+@pytest.mark.parametrize("value", ["exp", "SoftPlus"])
+def test_positive_bijector_setting(value):
     set_default_positive_bijector(value)
-    assert isinstance(default_positive_bijector(), expected)
+    assert default_positive_bijector() == value.lower()
 
 
 def test_default_summary_fmt_setting():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -17,9 +17,10 @@ import pytest
 import tensorflow as tf
 
 import gpflow
-from gpflow.config import (default_float, default_int, default_jitter, set_default_float, set_default_int,
-                           set_default_jitter, set_default_summary_fmt, default_summary_fmt,
-                           set_default_positive_bijector, default_positive_bijector)
+from gpflow.config import (default_float, default_int, default_jitter, set_default_float,
+                           set_default_int, set_default_jitter, set_default_summary_fmt,
+                           default_summary_fmt, set_default_positive_bijector,
+                           default_positive_bijector)
 from gpflow.utilities import to_default_float, to_default_int
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,7 +18,8 @@ import tensorflow as tf
 
 import gpflow
 from gpflow.config import (default_float, default_int, default_jitter, set_default_float, set_default_int,
-                           set_default_jitter, set_default_summary_fmt, default_summary_fmt)
+                           set_default_jitter, set_default_summary_fmt, default_summary_fmt,
+                           set_default_positive_bijector, default_positive_bijector)
 from gpflow.utilities import to_default_float, to_default_int
 
 
@@ -58,6 +59,21 @@ def test_jitter_errorcheck():
         set_default_jitter("not a float")
     with pytest.raises(ValueError):
         set_default_jitter(-1e-10)
+
+
+@pytest.mark.parametrize("error_type, error_msg, value", [
+    (TypeError, r"Expected a string, but got a <class 'float'>", 1.0),
+    (ValueError, r"'unknown' not found in \['exp', 'softplus'\]", 'unknown'),
+])
+def test_positive_bijector_errors(error_type, error_msg, value):
+    with pytest.raises(error_type, match=error_msg):
+        set_default_positive_bijector(value)
+
+
+@pytest.mark.parametrize("value", ["exp", "softplus"])
+def test_positive_bijector_setting(value):
+    set_default_positive_bijector(value)
+    assert default_positive_bijector() == value
 
 
 def test_default_summary_fmt_setting():

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -333,7 +333,6 @@ def test_merge_leaf_components_merges_keys_with_same_values(dag_module, expected
     (B, example_module_list_variable_print_string),
 ])
 def test_print_summary_output_string(module_callable, expected_param_print_string):
-    
     assert tabulate_module_summary(module_callable()) == expected_param_print_string
 
 

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -186,32 +186,32 @@ example_dag_module_param_dict = {
 }
 
 compose_kernel_param_print_string = """\
-name                                       class      transform    trainable    shape    dtype      value\n\
------------------------------------------  ---------  -----------  -----------  -------  -------  -------\n\
-Product.kernels[0].kernels[0].variance     Parameter  Softplus     True         ()       float64        1\n\
-Product.kernels[0].kernels[0].lengthscale  Parameter  Softplus     False        ()       float64        2\n\
-Product.kernels[0].kernels[1].variance     Parameter  Softplus     True         ()       float64        1\n\
-Product.kernels[0].kernels[1].lengthscale  Parameter  Softplus     False        ()       float64        2\n\
-Product.kernels[1].kernels[0].variance     Parameter  Softplus     True         ()       float64        1\n\
-Product.kernels[1].kernels[0].lengthscale  Parameter  Softplus     False        ()       float64        2\n\
-Product.kernels[1].kernels[1].variance     Parameter  Softplus     True         ()       float64        1\n\
-Product.kernels[1].kernels[1].lengthscale  Parameter  Softplus     False        ()       float64        2"""
+name                                       class      transform         trainable    shape    dtype      value\n\
+-----------------------------------------  ---------  ----------------  -----------  -------  -------  -------\n\
+Product.kernels[0].kernels[0].variance     Parameter  Softplus + Shift  True         ()       float64        1\n\
+Product.kernels[0].kernels[0].lengthscale  Parameter  Softplus + Shift  False        ()       float64        2\n\
+Product.kernels[0].kernels[1].variance     Parameter  Softplus + Shift  True         ()       float64        1\n\
+Product.kernels[0].kernels[1].lengthscale  Parameter  Softplus + Shift  False        ()       float64        2\n\
+Product.kernels[1].kernels[0].variance     Parameter  Softplus + Shift  True         ()       float64        1\n\
+Product.kernels[1].kernels[0].lengthscale  Parameter  Softplus + Shift  False        ()       float64        2\n\
+Product.kernels[1].kernels[1].variance     Parameter  Softplus + Shift  True         ()       float64        1\n\
+Product.kernels[1].kernels[1].lengthscale  Parameter  Softplus + Shift  False        ()       float64        2"""
 
 kernel_param_print_string = """\
-name                            class      transform    trainable    shape    dtype      value\n\
-------------------------------  ---------  -----------  -----------  -------  -------  -------\n\
-SquaredExponential.variance     Parameter  Softplus     True         ()       float64        1\n\
-SquaredExponential.lengthscale  Parameter  Softplus     False        ()       float64        2"""
+name                            class      transform         trainable    shape    dtype      value\n\
+------------------------------  ---------  ----------------  -----------  -------  -------  -------\n\
+SquaredExponential.variance     Parameter  Softplus + Shift  True         ()       float64        1\n\
+SquaredExponential.lengthscale  Parameter  Softplus + Shift  False        ()       float64        2"""
 
 model_gp_param_print_string = """\
-name                      class      transform    trainable    shape    dtype    value\n\
-------------------------  ---------  -----------  -----------  -------  -------  --------\n\
-SVGP.kernel.variance      Parameter  Softplus     True         ()       float64  1.0\n\
-SVGP.kernel.lengthscale   Parameter  Softplus     False        ()       float64  2.0\n\
-SVGP.likelihood.variance  Parameter  Softplus     True         ()       float64  1.0\n\
-SVGP.inducing_variable.Z  Parameter               True         (10, 1)  float64  [[0.5...\n\
-SVGP.q_mu                 Parameter               False        (10, 1)  float64  [[0....\n\
-SVGP.q_sqrt               Parameter  Softplus     True         (10, 1)  float64  [[1...."""
+name                      class      transform         trainable    shape    dtype    value\n\
+------------------------  ---------  ----------------  -----------  -------  -------  --------\n\
+SVGP.kernel.variance      Parameter  Softplus + Shift  True         ()       float64  1.0\n\
+SVGP.kernel.lengthscale   Parameter  Softplus + Shift  False        ()       float64  2.0\n\
+SVGP.likelihood.variance  Parameter  Softplus + Shift  True         ()       float64  1.0\n\
+SVGP.inducing_variable.Z  Parameter                    True         (10, 1)  float64  [[0.5...\n\
+SVGP.q_mu                 Parameter                    False        (10, 1)  float64  [[0....\n\
+SVGP.q_sqrt               Parameter  Softplus + Shift  True         (10, 1)  float64  [[1...."""
 
 example_tf_module_variable_print_string = """\
 name             class             transform    trainable    shape      dtype    value\n\
@@ -333,6 +333,7 @@ def test_merge_leaf_components_merges_keys_with_same_values(dag_module, expected
     (B, example_module_list_variable_print_string),
 ])
 def test_print_summary_output_string(module_callable, expected_param_print_string):
+    
     assert tabulate_module_summary(module_callable()) == expected_param_print_string
 
 

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -205,10 +205,10 @@ SquaredExponential.variance     Parameter  Softplus     True         ()       fl
 SquaredExponential.lengthscale  Parameter  Softplus     False        ()       float64        2"""
 
 kernel_param_print_string_with_shift = """\
-name                            class      transform         trainable    shape    dtype      value\n\
-------------------------------  ---------  ----------------  -----------  -------  -------  -------\n\
-SquaredExponential.variance     Parameter  Softplus + Shift  True         ()       float64        1\n\
-SquaredExponential.lengthscale  Parameter  Softplus + Shift  False        ()       float64        2"""
+name                            class      transform                trainable    shape    dtype      value\n\
+------------------------------  ---------  -----------------------  -----------  -------  -------  -------\n\
+SquaredExponential.variance     Parameter  Softplus + AffineScalar  True         ()       float64        1\n\
+SquaredExponential.lengthscale  Parameter  Softplus + AffineScalar  False        ()       float64        2"""
 
 model_gp_param_print_string = """\
 name                      class      transform    trainable    shape    dtype    value\n\

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -13,21 +13,21 @@ from gpflow.utilities import positive, triangular
 ])
 def test_positive_lower(env_lower, override_lower):
     expected_lower = override_lower or env_lower
-    with as_context(Config(positive_bijector="softplus", positive_minimum=env_lower)):
+    with as_context(Config(positive_bijector=tfp.bijectors.Softplus(), positive_minimum=env_lower)):
         bijector = positive(lower=override_lower)
         assert isinstance(bijector, tfp.bijectors.Chain)
         assert np.isclose(bijector.bijectors[1].shift, expected_lower)
 
 
 @pytest.mark.parametrize("env_bijector, override_bijector, expected_class", [
-    ("softplus", None, tfp.bijectors.Softplus),
-    ("softplus", "exp", tfp.bijectors.Exp),
-    ("exp", None, tfp.bijectors.Exp),
-    ("exp", "softplus", tfp.bijectors.Softplus),
+    (tfp.bijectors.Softplus(), None, tfp.bijectors.Softplus),
+    (tfp.bijectors.Softplus(), tfp.bijectors.Exp(), tfp.bijectors.Exp),
+    (tfp.bijectors.Exp(), None, tfp.bijectors.Exp),
+    (tfp.bijectors.Exp(), tfp.bijectors.Softplus(hinge_softness=2.0), tfp.bijectors.Softplus),
 ])
 def test_positive_bijector(env_bijector, override_bijector, expected_class):
     with as_context(Config(positive_bijector=env_bijector, positive_minimum=None)):
-        bijector = positive(bijector=override_bijector)
+        bijector = positive(base=override_bijector)
         assert isinstance(bijector, expected_class)
 
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -37,6 +37,7 @@ def test_positive_calculation_order():
     with as_context(Config(positive_bijector="exp", positive_minimum=lower)):
         result = positive()(value).numpy()
     assert np.isclose(result, expected)
+    assert result >= lower
 
 
 def test_triangular():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -16,7 +16,7 @@ def test_positive_lower(env_lower, override_lower):
     with as_context(Config(positive_bijector="softplus", positive_minimum=env_lower)):
         bijector = positive(lower=override_lower)
         assert isinstance(bijector, tfp.bijectors.Chain)
-        assert np.isclose(bijector.bijectors[0].shift, expected_lower)
+        assert np.isclose(bijector.bijectors[1].shift, expected_lower)
 
 
 @pytest.mark.parametrize("env_bijector, override_bijector, expected_class", [

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+import tensorflow_probability as tfp
+
+from gpflow.config import Config, as_context
+from gpflow.utilities import positive, triangular
+
+
+@pytest.mark.parametrize("env_lower, override_lower", [
+    (0.1, None),  # ensure default from config is applied
+    (None, 0.2),  # ensure override is applied
+    (0.3, 0.4),  # ensure local overrides config
+])
+def test_positive_lower(env_lower, override_lower):
+    expected_lower = override_lower or env_lower
+    with as_context(Config(positive_bijector="softplus", positive_minimum=env_lower)):
+        bijector = positive(lower=override_lower)
+        assert isinstance(bijector, tfp.bijectors.Chain)
+        assert np.isclose(bijector.bijectors[0].shift, expected_lower)
+
+
+@pytest.mark.parametrize("env_bijector, override_bijector, expected_class", [
+    ("softplus", None, tfp.bijectors.Softplus),
+    ("softplus", "exp", tfp.bijectors.Exp),
+    ("exp", None, tfp.bijectors.Exp),
+    ("exp", "softplus", tfp.bijectors.Softplus),
+])
+def test_positive_bijector(env_bijector, override_bijector, expected_class):
+    with as_context(Config(positive_bijector=env_bijector, positive_minimum=None)):
+        bijector = positive(bijector=override_bijector)
+        assert isinstance(bijector, expected_class)
+
+
+def test_triangular():
+    assert isinstance(triangular(), tfp.bijectors.FillTriangular)


### PR DESCRIPTION
Based on @awav's second TODO list item in #1144: _"Current positive transform uses softplus, but in some cases it is "preferable" to use exp instead; it would be nice to have an option in the gpflow.config, such that the user could choose global positive transformation"_

Still a work in progress but putting it up here for early feedback (as I calibrate coding style for this project).