### PR TITLE
Assign lower bound directly to likelihood variance.

### DIFF
--- a/gpflow/likelihoods/likelihoods.py
+++ b/gpflow/likelihoods/likelihoods.py
@@ -164,9 +164,9 @@ class Gaussian(Likelihood):
     optimization process. A lower bound of 1e-6 is therefore imposed on the likelihood variance
     by default.
     """
-    def __init__(self, variance=1.0, **kwargs):
+    def __init__(self, variance=1.0, variance_lower_bound=1e-6, **kwargs):
         super().__init__(**kwargs)
-        self.variance = Parameter(variance, transform=positive(lower=1e-6))
+        self.variance = Parameter(variance, transform=positive(lower=variance_lower_bound))
 
     def log_prob(self, F, Y):
         return logdensities.gaussian(Y, F, self.variance)

--- a/gpflow/likelihoods/likelihoods.py
+++ b/gpflow/likelihoods/likelihoods.py
@@ -156,6 +156,14 @@ class Likelihood(tf.Module):
 
 
 class Gaussian(Likelihood):
+    r"""
+    The Gaussian likelihood is appropriate where uncertainties associated with the data are
+    believed to follow a normal distribution, with constant variance.
+
+    Very small uncertainties can lead to numerical instability during the
+    optimization process. A lower bound of 1e-6 is therefore imposed on the likelihood variance
+    by default.
+    """
     def __init__(self, variance=1.0, **kwargs):
         super().__init__(**kwargs)
         self.variance = Parameter(variance, transform=positive(lower=1e-6))

--- a/gpflow/likelihoods/likelihoods.py
+++ b/gpflow/likelihoods/likelihoods.py
@@ -158,7 +158,7 @@ class Likelihood(tf.Module):
 class Gaussian(Likelihood):
     def __init__(self, variance=1.0, **kwargs):
         super().__init__(**kwargs)
-        self.variance = Parameter(variance, transform=positive())
+        self.variance = Parameter(variance, transform=positive(lower=1e-6))
 
     def log_prob(self, F, Y):
         return logdensities.gaussian(Y, F, self.variance)


### PR DESCRIPTION
For an easier transition from v1, and improved stability during optimisation, this sets a lower bound on the likelihood variance. 

Compared to imposing the lower bound within the positive transform, this is (a) more transparent to the user and (b) does not impose the restriction on other Parameters. 
