### PR TITLE
Add jit flag to gpflow.optimizers.Scipy

### DIFF
--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -38,6 +38,9 @@ class Scipy:
                 above, and `values` is the corresponding list of tensors of
                 matching shape that contains their value at this optimisation
                 step.
+            jit: If True, wraps the evaluation function (the passed `closure` as
+                well as its gradient computation) inside a `tf.function()`,
+                which will improve optimization speed in most cases.
 
             scipy_kwargs: Arguments passed through to `scipy.optimize.minimize`
 

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -19,6 +19,7 @@ class Scipy:
                  variables: Variables,
                  method: Optional[str] = "L-BFGS-B",
                  step_callback: Optional[StepCallback] = None,
+                 jit: bool = True,
                  **scipy_kwargs) -> OptimizeResult:
         """
         Minimize is a wrapper around the `scipy.optimize.minimize` function
@@ -48,7 +49,7 @@ class Scipy:
             raise TypeError('Callable object expected.')  # pragma: no cover
         initial_params = self.initial_parameters(variables)
 
-        func = self.eval_func(closure, variables)
+        func = self.eval_func(closure, variables, jit=jit)
         if step_callback is not None:
             if 'callback' in scipy_kwargs:
                 raise ValueError("Callback passed both via `step_callback` and `callback`")
@@ -64,13 +65,20 @@ class Scipy:
         return cls.pack_tensors(variables)
 
     @classmethod
-    def eval_func(cls, closure: LossClosure, variables: Variables):
-        def _eval(x):
+    def eval_func(cls, closure: LossClosure, variables: Variables, jit: bool = True):
+        def _tf_eval(x: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
             values = cls.unpack_tensors(variables, x)
             cls.assign_tensors(variables, values)
 
             loss, grads = _compute_loss_and_gradients(closure, variables)
-            return loss.numpy().astype(np.float64), cls.pack_tensors(grads).astype(np.float64)
+            return loss, cls.pack_tensors(grads)
+
+        if jit:
+            _tf_eval = tf.function(_tf_eval)
+
+        def _eval(x):
+            loss, grad = _tf_eval(tf.convert_to_tensor(x))
+            return loss.numpy().astype(np.float64), grad.numpy().astype(np.float64)
 
         return _eval
 
@@ -87,19 +95,19 @@ class Scipy:
         return _callback
 
     @staticmethod
-    def pack_tensors(tensors: Iterator[tf.Tensor]) -> np.ndarray:
+    def pack_tensors(tensors: Iterator[tf.Tensor]) -> tf.Tensor:
         flats = [tf.reshape(tensor, (-1, )) for tensor in tensors]
         tensors_vector = tf.concat(flats, axis=0)
-        return tensors_vector.numpy()
+        return tensors_vector
 
     @staticmethod
-    def unpack_tensors(to_tensors: Iterator[tf.Tensor], from_vector: np.ndarray) -> List[tf.Tensor]:
+    def unpack_tensors(to_tensors: Iterator[tf.Tensor], from_vector: tf.Tensor) -> List[tf.Tensor]:
         s = 0
         values = []
         for tensor in to_tensors:
             shape = tf.shape(tensor)
-            tensor_size = int(np.prod(shape))
-            tensor_vector = from_vector[s:s + tensor_size].astype(tensor.dtype.as_numpy_dtype())
+            tensor_size = tf.reduce_prod(shape)
+            tensor_vector = tf.cast(from_vector[s:s + tensor_size], tensor.dtype)
             tensor_vector = tf.reshape(tensor_vector, shape)
             values.append(tensor_vector)
             s += tensor_size

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -52,7 +52,8 @@ def test_scipy_jit():
     def closure1():
         return - m1.log_marginal_likelihood()
 
-    def closure2(autograph=False):
+    @tf.function(autograph=False)
+    def closure2():
         return - m2.log_marginal_likelihood()
 
     opt1.minimize(closure1, variables=m1.trainable_variables, options=dict(maxiter=50), jit=False)

--- a/tests/test_optimizers.py
+++ b/tests/test_optimizers.py
@@ -1,0 +1,64 @@
+# Copyright 2019 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from numpy.testing import assert_allclose
+
+import gpflow
+from gpflow.config import default_jitter
+from gpflow.mean_functions import Constant
+
+rng = np.random.RandomState(0)
+
+
+class Datum:
+    X = rng.rand(20, 1) * 10
+    Y = np.sin(X) + 0.9 * np.cos(X * 1.6) + rng.randn(*X.shape) * 0.8
+    Y = np.tile(Y, 2)  # two identical columns
+    Xtest = rng.rand(10, 1) * 10
+    data = (X, Y)
+
+
+def _create_full_gp_model():
+    """
+    GP Regression
+    """
+    return gpflow.models.GPR(
+        (Datum.X, Datum.Y),
+        kernel=gpflow.kernels.SquaredExponential(),
+        mean_function=gpflow.mean_functions.Constant(),
+    )
+
+def test_scipy_jit():
+    m1 = _create_full_gp_model()
+    m2 = _create_full_gp_model()
+
+    opt1 = gpflow.optimizers.Scipy()
+    opt2 = gpflow.optimizers.Scipy()
+
+    def closure1():
+        return - m1.log_marginal_likelihood()
+
+    def closure2(autograph=False):
+        return - m2.log_marginal_likelihood()
+
+    opt1.minimize(closure1, variables=m1.trainable_variables, options=dict(maxiter=50), jit=False)
+    opt2.minimize(closure2, variables=m2.trainable_variables, options=dict(maxiter=50), jit=True)
+
+    def get_values(model):
+        return np.array([var.value().numpy().squeeze() for var in model.trainable_variables])
+
+    np.testing.assert_allclose(get_values(m1), get_values(m2), rtol=1e-14, atol=1e-15)


### PR DESCRIPTION
As the Scipy optimizer combines numpy with tensorflow, we can't simply wrap its `minimize()` method in `tf.function()`. Instead, this PR adds a `jit` flag (True by default) which wraps the evaluation of objective and its gradients in `tf.function()`.
