### PR TITLE
Improve previously skipped MultiClass tests

### DIFF
--- a/gpflow/likelihoods/robustmax.py
+++ b/gpflow/likelihoods/robustmax.py
@@ -26,7 +26,7 @@ class RobustMax(tf.Module):
         prior = tfp.distributions.Beta(to_default_float(0.2), to_default_float(5.))
         self.epsilon = Parameter(epsilon, transform=transform, prior=prior, trainable=False)
         self.num_classes = num_classes
-        self._squash = 1e-4
+        self._squash = 1e-6
 
     def __call__(self, F):
         i = tf.argmax(F, 1)


### PR DESCRIPTION
`test_likelihoods.py` had *all* MultiClass tests blanket-skipped as there was a bug (#1091). This PR cleans up the situation as follows:
- one test was actually passing - now unskipped.
- one test was made to pass by reducing the `_squash` attribute in the RobustMax class from 1e-4 to 1e-6.
- the other tests are now skipped individually.
(The failing tests are actually due to an issue in `ndiagquad` that can't seem to handle the integration over several latent GPs correctly as is required for the MultiClass case)