### PR TITLE
Add validation to Parameter.assign() to increase robustness of transforms

### DIFF
--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -56,7 +56,7 @@ class Parameter(tf.Module):
         if isinstance(value, tf.Variable):
             self._unconstrained = value
         else:
-            unconstrained_value = self.verified_unconstrained_value(value, dtype)
+            unconstrained_value = self.validate_unconstrained_value(value, dtype)
             self._unconstrained = tf.Variable(unconstrained_value,
                                               dtype=dtype, name=name, trainable=trainable)
 
@@ -113,11 +113,11 @@ class Parameter(tf.Module):
     def initial_value(self):
         return self._unconstrained.initial_value
 
-    def verified_unconstrained_value(self, value: tf.Tensor, dtype: DType) -> tf.Tensor:
+    def validate_unconstrained_value(self, value: tf.Tensor, dtype: DType) -> tf.Tensor:
         value = _cast_to_dtype(value, dtype)
         unconstrained_value = _to_unconstrained(value, self.transform)
         return tf.debugging.assert_all_finite(unconstrained_value,
-                message=f"gpflow.Parameter.verified_unconstrained_value")
+                message=f"gpflow.Parameter.validate_unconstrained_value")
 
 
     def assign(self, value: tf.Tensor, use_locking=False, name=None, read_value=True) -> tf.Variable:
@@ -141,7 +141,7 @@ class Parameter(tf.Module):
         :param read_value: if True, will return something which evaluates to the new
             value of the variable; if False will return the assign op.
         """
-        unconstrained_value = self.verified_unconstrained_value(value, self.dtype)
+        unconstrained_value = self.validate_unconstrained_value(value, self.dtype)
         return self._unconstrained.assign(unconstrained_value,
                 use_locking=use_locking, name=name, read_value=read_value)
 

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -120,7 +120,6 @@ class Parameter(tf.Module):
                   "has NaN or Inf and cannot be assigned."
         return tf.debugging.assert_all_finite(unconstrained_value, message=message)
 
-
     def assign(self, value: tf.Tensor, use_locking=False, name=None, read_value=True) -> tf.Variable:
         """
         Assigns constrained `value` to the unconstrained parameter's variable.

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -116,8 +116,9 @@ class Parameter(tf.Module):
     def validate_unconstrained_value(self, value: tf.Tensor, dtype: DType) -> tf.Tensor:
         value = _cast_to_dtype(value, dtype)
         unconstrained_value = _to_unconstrained(value, self.transform)
-        return tf.debugging.assert_all_finite(unconstrained_value,
-                message=f"gpflow.Parameter.validate_unconstrained_value")
+        message = "gpflow.Parameter: unconstrained value of passed value " \
+                  "has NaN or Inf and cannot be assigned."
+        return tf.debugging.assert_all_finite(unconstrained_value, message=message)
 
 
     def assign(self, value: tf.Tensor, use_locking=False, name=None, read_value=True) -> tf.Variable:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,29 @@
+# Copyright 2020 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import gpflow
+import pytest
+import tensorflow as tf
+from gpflow.utilities import positive
+
+
+def test_parameter_assign_validation():
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        param = gpflow.Parameter(0.0, transform=positive())
+
+    param = gpflow.Parameter(0.1, transform=positive())
+    param.assign(0.2)
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        param.assign(0.0)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -50,24 +50,20 @@ def test_multi_scale_inducing_equivalence_inducing_points(N, M, D):
     # Multiscale must be equivalent to inducing points when variance is zero
     Xnew, Z = np.random.randn(N, D), np.random.randn(M, D)
     rbf = gpflow.kernels.SquaredExponential(1.3441, lengthscale=np.random.uniform(0.5, 3., D))
-    inducing_variable_zero_lengthscale = Multiscale(Z, scales=np.zeros(Z.shape))
+    inducing_variable_zero_lengthscale = Multiscale(Z, scales=np.zeros(Z.shape) + 1e-10)
     inducing_variable_inducing_point = InducingPoints(Z)
 
     multi_scale_Kuf = Kuf(inducing_variable_zero_lengthscale, rbf, Xnew)
     inducing_point_Kuf = Kuf(inducing_variable_inducing_point, rbf, Xnew)
 
-    deviation_percent_Kuf = np.max(
-        np.abs(multi_scale_Kuf - inducing_point_Kuf) / inducing_point_Kuf *
-        100)
-    assert deviation_percent_Kuf < 0.1
+    relative_error_Kuf = np.abs(multi_scale_Kuf - inducing_point_Kuf) / inducing_point_Kuf
+    assert np.max(relative_error_Kuf) < 0.1e-2  # 0.1 %
 
     multi_scale_Kuu = Kuu(inducing_variable_zero_lengthscale, rbf)
     inducing_point_Kuu = Kuu(inducing_variable_inducing_point, rbf)
 
-    deviation_percent_Kuu = np.max(
-        np.abs(multi_scale_Kuu - inducing_point_Kuu) / inducing_point_Kuu *
-        100)
-    assert deviation_percent_Kuu < 0.1
+    relative_error_Kuu = np.abs(multi_scale_Kuu - inducing_point_Kuu) / inducing_point_Kuu
+    assert np.max(relative_error_Kuu) < 0.1e-2  # 0.1 %
 
 
 _inducing_variables_and_kernels = [


### PR DESCRIPTION
In GPflow2, `Parameter` behaves differently from GPflow1, as noted in #1197.
Specifically, when using a positive transform, initializing or assigning the value 0.0 is perfectly fine in the forward pass: `p = gpflow.Parameter(0.0, transform=gpflow.utilities.positive())`, and it looks like nothing is wrong; the constrained representation is 0.0 as expected. (In GPflow1, it would implicitly force the value to be the lower bound of 1e-6.) However, the *unconstrained* representation is then `-inf`, which leads to `nan`s when computing gradients in the backward pass. This is error-prone and hard to debug. To make this issue more obvious, this PR adds an error check.