### PR TITLE
TensorFlow 2.1 compatibility, and identify as gpflow.Parameter in repr() to ease debugging

### DIFF
--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -179,7 +179,12 @@ class Parameter(tf.Module):
         return self.shape
 
     def _should_act_as_resource_variable(self):
-        pass
+        """
+        This is needed for compatibility with TensorFlow 2.0.
+        In TensorFlow 2.1, this got superseded by the is_tensor_like property.
+        """
+        pass  # TensorFlow's is_resource_variable() in resource_variable_ops.py
+              # only checks with hasattr()
 
     @property
     def handle(self):

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -179,12 +179,9 @@ class Parameter(tf.Module):
         return self.shape
 
     def _should_act_as_resource_variable(self):
-        """
-        This is needed for compatibility with TensorFlow 2.0.
-        In TensorFlow 2.1, this got superseded by the is_tensor_like property.
-        """
-        pass  # TensorFlow's is_resource_variable() in resource_variable_ops.py
-              # only checks with hasattr()
+        # needed so that Parameters are correctly identified by TensorFlow's
+        # is_resource_variable() in resource_variable_ops.py
+        pass  # only checked by TensorFlow using hasattr()
 
     @property
     def handle(self):

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -139,6 +139,14 @@ class Parameter(tf.Module):
         return self._unconstrained.assign(unconstrained_value, read_value=read_value, use_locking=use_locking)
 
     @property
+    def is_tensor_like(self):
+        """
+        This method means that TensorFlow's `tensor_util.is_tensor` function
+        will return `True`
+        """
+        return True
+
+    @property
     def name(self):
         return self._unconstrained.name
 

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -178,9 +178,6 @@ class Parameter(tf.Module):
     def get_shape(self):
         return self.shape
 
-    def _should_act_as_resource_variable(self):
-        pass
-
     @property
     def handle(self):
         return self._unconstrained.handle

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -191,10 +191,10 @@ class Parameter(tf.Module):
         unconstrained = self.unconstrained_variable
         constrained = self.read_value()
         info = f"dtype={self.dtype.name} " \
-               f"unconstrained shape={unconstrained.shape} " \
-               f"unconstrained numpy={unconstrained.numpy()} " \
-               f"constrained shape={constrained.shape} " \
-               f"constrained numpy={constrained.numpy()}"
+               f"unconstrained-shape={unconstrained.shape} " \
+               f"unconstrained-numpy={unconstrained.numpy()} " \
+               f"constrained-shape={constrained.shape} " \
+               f"constrained-numpy={constrained.numpy()}"
 
         return f"<gpflow.Parameter {self.name!r} {info}>"
 

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -188,9 +188,15 @@ class Parameter(tf.Module):
         return self._unconstrained.handle
 
     def __repr__(self):
-        return "<gpflow.Parameter " \
-               f"unconstrained_variable={self._unconstrained!r} " \
-               f"constrained_tensor={self.read_value()!r}>"
+        unconstrained = self.unconstrained_variable
+        constrained = self.read_value()
+        info = f"dtype={self.dtype.name} " \
+               f"unconstrained shape={unconstrained.shape} " \
+               f"unconstrained numpy={unconstrained.numpy()} " \
+               f"constrained shape={constrained.shape} " \
+               f"constrained numpy={constrained.numpy()}"
+
+        return f"<gpflow.Parameter {self.name!r} {info}>"
 
     # Below
     # TensorFlow copy-paste code to make variable-like object to work

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -178,7 +178,9 @@ class Parameter(tf.Module):
         return self._unconstrained.handle
 
     def __repr__(self):
-        return self.read_value().__repr__()
+        return "<gpflow.Parameter " \
+               f"unconstrained_variable={self._unconstrained!r} " \
+               f"constrained_tensor={self.read_value()!r}>"
 
     # Below
     # TensorFlow copy-paste code to make variable-like object to work

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -178,6 +178,9 @@ class Parameter(tf.Module):
     def get_shape(self):
         return self.shape
 
+    def _should_act_as_resource_variable(self):
+        pass
+
     @property
     def handle(self):
         return self._unconstrained.handle


### PR DESCRIPTION
1. Adds `is_tensor_like` property to `Parameter` to ensure compatibility with TensorFlow 2.1

2. Adds explanation to `Parameter._should_act_as_resource_variable`

3. Clarify in repr(Parameter()) that it is a gpflow.Parameter, not a tf.Tensor. Changes `gpflow.Parameter.__repr__` to identify itself as a gpflow object to ease debugging.

   Examples:
   - `gpflow.Parameter(1.0, transform=gpflow.utilities.positive(), name="variance")`:
     ```
     <gpflow.Parameter 'Variable:0' dtype=float64 unconstrained shape=() unconstrained numpy=0.5413248546129181 constrained shape=() constrained numpy=1.0>
     ```
   - `gpflow.Parameter(np.eye(3), transform=gpflow.utilities.triangular())`:
     ```
     <gpflow.Parameter 'Variable:0' dtype=float64 unconstrained shape=(6,) unconstrained numpy=[1. 0. 0. 1. 1. 0.] constrained shape=(3, 3) constrained numpy=[[1. 0. 0.]
      [0. 1. 0.]
      [0. 0. 1.]]>
     ```