### PR TITLE
Fix issue with tf.cast() and implicit dtype conversion

### DIFF
--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -253,7 +253,10 @@ tf.register_tensor_conversion_function(Parameter, lambda x, *args, **kwds: x.rea
 def _cast_to_dtype(value: VariableData, dtype: Optional[DType] = None) -> tf.Tensor:
     if dtype is None:
         dtype = default_float()
-    return tf.cast(value, dtype)
+    if tf.is_tensor(value):
+        return tf.cast(value, dtype)
+    else:
+        return tf.convert_to_tensor(value, dtype)
 
 
 def _to_constrained(value: VariableData, transform: Transform) -> tf.Tensor:

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -14,9 +14,11 @@
 
 
 import gpflow
+import numpy as np
 import pytest
 import tensorflow as tf
 from gpflow.utilities import positive
+from gpflow.base import _cast_to_dtype
 
 
 def test_parameter_assign_validation():
@@ -27,3 +29,30 @@ def test_parameter_assign_validation():
     param.assign(0.2)
     with pytest.raises(tf.errors.InvalidArgumentError):
         param.assign(0.0)
+
+
+def test_cast_to_dtype_precision_issue():
+    """
+    TensorFlow's tf.cast(value, dtype) implicitly does a tf.convert_to_tensor(value)
+    *before* the cast when the value is not a tensor already. When value is a python float,
+    this results in the following behaviour:
+
+    >>> tf.cast(0.2, tf.float64)
+    <tf.Tensor: id=37, shape=(), dtype=float64, numpy=0.20000000298023224>
+    
+    instead of the expected expansion of 0.2 to float64 precision that you get when
+    passing in an object that already carries dtype information, such as a numpy array
+    (which has float64 precision by default):
+
+    >>> tf.cast(np.array(0.2), tf.float64)
+    <tf.Tensor: id=40, shape=(), dtype=float64, numpy=0.2>
+
+    This affected *all* gpflow.Parameter objects, resulting in numerical discrepancies
+    between GPflow 1 and 2, due to the pass through _cast_to_dtype, which is now fixed.
+    This is the corresponding regression test.
+    """
+    p = gpflow.Parameter(0.2, dtype=np.float64)
+    actual_value = p.numpy()
+    assert actual_value.dtype == np.float64
+    expected_value = np.float64(0.2)
+    assert actual_value == expected_value


### PR DESCRIPTION
TensorFlow's tf.cast(value, dtype) implicitly does a tf.convert_to_tensor(value)
*before* the cast when the value is not a tensor already. When value is a python float,
this results in the following behaviour:

```python
>>> tf.cast(0.2, tf.float64)
<tf.Tensor: id=37, shape=(), dtype=float64, numpy=0.20000000298023224>
```

instead of the expected expansion of 0.2 to float64 precision that you get when
passing in an object that already carries dtype information, such as a numpy array
(which has float64 precision by default):

```python
>>> tf.cast(np.array(0.2), tf.float64)
<tf.Tensor: id=40, shape=(), dtype=float64, numpy=0.2>
```

This affected *all* gpflow.Parameter objects, resulting in numerical discrepancies
between GPflow 1 and 2, due to the pass through _cast_to_dtype, which is fixed by this PR.