### PR TITLE
Inconisistency on whether q_sqrt is triangular fixed.

### DIFF
--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -82,7 +82,7 @@ def base_conditional(Kmn: tf.Tensor,
         if q_sqrt_dims == 2:
             LTA = A * tf.expand_dims(tf.transpose(q_sqrt), 2)  # [R, M, N]
         elif q_sqrt_dims == 3:
-            L = q_sqrt
+            L =  tf.linalg.band_part(q_sqrt, -1, 0)  # force lower triangle # [R, M, M]
             L_shape = tf.shape(L)
             L = tf.broadcast_to(L, tf.concat([leading_dims, L_shape], 0))
 

--- a/tests/test_conditionals.py
+++ b/tests/test_conditionals.py
@@ -18,6 +18,8 @@ import tensorflow as tf
 from numpy.testing import assert_allclose
 
 import gpflow
+from gpflow import Parameter
+from gpflow.utilities.bijectors import triangular
 from gpflow.conditionals import conditional
 from gpflow.config import default_float
 
@@ -128,3 +130,40 @@ def test_gaussian_whiten(Xdata, Xnew, kernel, mu, sqrt):
 
     assert_allclose(mean_diff, 0, atol=4)
     assert_allclose(var_diff, 0, atol=4)
+
+@pytest.mark.parametrize('white', [True, False])
+def test_q_sqrt_constraints(Xdata, Xnew, kernel, mu, white):
+    """ Test that sending in an unconstrained q_sqrt returns the same conditional
+    evaluation and gradients. This is important to match the behaviour of the KL, which
+    enforces q_sqrt is triangular.
+    """
+
+    tril = np.tril(rng.randn(Ln, Nn, Nn))
+
+    q_sqrt_constrained = Parameter(tril, transform=triangular())
+    q_sqrt_unconstrained = Parameter(tril)
+
+    diff_before_gradient_step = (q_sqrt_constrained - q_sqrt_unconstrained).numpy()
+    assert_allclose(diff_before_gradient_step, 0)
+
+    Fstars = []
+    for q_sqrt in [q_sqrt_constrained, q_sqrt_unconstrained]:
+
+        with tf.GradientTape() as g:
+            _, Fstar_var = conditional(Xnew,
+                                       Xdata,
+                                       kernel,
+                                       mu,
+                                       q_sqrt=q_sqrt,
+                                       white=white)
+
+        grad = g.gradient(Fstar_var, q_sqrt.unconstrained_variable)
+        q_sqrt.unconstrained_variable.assign_sub(grad)
+        Fstars.append(Fstar_var)
+
+
+    diff_Fstar_before_gradient_step = Fstars[0] - Fstars[1]
+    assert_allclose(diff_Fstar_before_gradient_step, 0)
+
+    diff_after_gradient_step = (q_sqrt_constrained - q_sqrt_unconstrained).numpy()
+    assert_allclose(diff_after_gradient_step, 0)

--- a/tests/test_conditionals.py
+++ b/tests/test_conditionals.py
@@ -27,7 +27,7 @@ rng = np.random.RandomState(123)
 
 Ln = 2
 Nn = 10
-Mn = 50
+Mn = 20
 
 
 @pytest.fixture(scope='module')
@@ -149,7 +149,7 @@ def test_q_sqrt_constraints(Xdata, Xnew, kernel, mu, white):
     Fstars = []
     for q_sqrt in [q_sqrt_constrained, q_sqrt_unconstrained]:
 
-        with tf.GradientTape() as g:
+        with tf.GradientTape() as tape:
             _, Fstar_var = conditional(Xnew,
                                        Xdata,
                                        kernel,
@@ -157,7 +157,7 @@ def test_q_sqrt_constraints(Xdata, Xnew, kernel, mu, white):
                                        q_sqrt=q_sqrt,
                                        white=white)
 
-        grad = g.gradient(Fstar_var, q_sqrt.unconstrained_variable)
+        grad = tape.gradient(Fstar_var, q_sqrt.unconstrained_variable)
         q_sqrt.unconstrained_variable.assign_sub(grad)
         Fstars.append(Fstar_var)
 

--- a/tests/test_kldiv.py
+++ b/tests/test_kldiv.py
@@ -197,10 +197,10 @@ def test_q_sqrt_constraints(inducing_points, kernel, mu, white):
     kls = []
     for q_sqrt in [q_sqrt_constrained, q_sqrt_unconstrained]:
 
-        with tf.GradientTape() as g:
+        with tf.GradientTape() as tape:
             kl = prior_kl(inducing_points, kernel, mu, q_sqrt, whiten=white)
 
-        grad = g.gradient(kl, q_sqrt.unconstrained_variable)
+        grad = tape.gradient(kl, q_sqrt.unconstrained_variable)
         q_sqrt.unconstrained_variable.assign_sub(grad)
         kls.append(kl)
 

--- a/tests/test_kldiv.py
+++ b/tests/test_kldiv.py
@@ -17,12 +17,39 @@
 import numpy as np
 import pytest
 import tensorflow as tf
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_allclose, assert_almost_equal
 
-from gpflow.kullback_leiblers import gauss_kl
-from gpflow import default_float, default_jitter
+import gpflow
+from gpflow import default_float, default_jitter, Parameter
+from gpflow.inducing_variables import InducingPoints
+from gpflow.kullback_leiblers import gauss_kl, prior_kl
+from gpflow.utilities.bijectors import triangular
 
 rng = np.random.RandomState(0)
+
+# ------------------------------------------
+# Fixtures
+# ------------------------------------------
+
+Ln = 2
+Nn = 10
+Mn = 50
+
+
+@pytest.fixture(scope='module')
+def kernel():
+    k = gpflow.kernels.Matern32() + gpflow.kernels.White()
+    k.kernels[1].variance.assign(0.01)
+    return k
+
+@pytest.fixture(scope='module')
+def inducing_points():
+    return InducingPoints(rng.randn(Nn, 1))
+
+@pytest.fixture(scope='module')
+def mu():
+    return Parameter(rng.randn(Nn, Ln))
+
 
 # ------------------------------------------
 # Helpers
@@ -150,3 +177,37 @@ def test_unknown_size_inputs():
     unknown_shape = gauss_kl(mu, sqrt)
 
     np.testing.assert_allclose(known_shape, unknown_shape)
+
+
+@pytest.mark.parametrize('white', [True, False])
+def test_q_sqrt_constraints(inducing_points, kernel, mu, white):
+    """ Test that sending in an unconstrained q_sqrt returns the same conditional
+    evaluation and gradients. This is important to match the behaviour of the KL, which
+    enforces q_sqrt is triangular.
+    """
+
+    tril = np.tril(rng.randn(Ln, Nn, Nn))
+
+    q_sqrt_constrained = Parameter(tril, transform=triangular())
+    q_sqrt_unconstrained = Parameter(tril)
+
+    diff_before_gradient_step = (q_sqrt_constrained - q_sqrt_unconstrained).numpy()
+    assert_allclose(diff_before_gradient_step, 0)
+
+    kls = []
+    for q_sqrt in [q_sqrt_constrained, q_sqrt_unconstrained]:
+
+        with tf.GradientTape() as g:
+            kl = prior_kl(inducing_points, kernel, mu, q_sqrt, whiten=white)
+
+        grad = g.gradient(kl, q_sqrt.unconstrained_variable)
+        q_sqrt.unconstrained_variable.assign_sub(grad)
+        kls.append(kl)
+
+
+    diff_kls_before_gradient_step = kls[0] - kls[1]
+
+    assert_allclose(diff_kls_before_gradient_step, 0)
+
+    diff_after_gradient_step = (q_sqrt_constrained - q_sqrt_unconstrained).numpy()
+    assert_allclose(diff_after_gradient_step, 0)


### PR DESCRIPTION
Problem:
* KL divergence calculations only take lower triangle parts of q_sqrt in
their calculation (implying a lower triangular parameterisation of
covariance)
* Conditional calculations perform calculations using the whole of
q_sqrt.
* The end result is if you forgot to add the triangular transform
to the q_sqrt, your forward pass may be the same (if you initialise with
a triangular matrix), but your gradients will immediately stop q_sqrt
being triangular.

Fix:
* Conditional calulcations now only take the lower triangle parts of q_sqrt
in their calculation