### PR TITLE
Improve documentation and behaviour of Periodic kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ GPflow implements modern Gaussian process inference for composable kernels and l
 GPflow 2.0 uses [TensorFlow 2.0](http://www.tensorflow.org) for running computations, which allows fast execution on GPUs, and uses Python ≥ 3.6.
 
 
-## Install GPflow
+## Install GPflow 2
 
 - From source
 
-  With the release of _TensorFlow 2.0_ and _Tensorflow Probability_ 0.8, you should
+  With the release of _TensorFlow_ 2.1 and _Tensorflow Probability_ 0.9, you should
   only need to run
 
   ```bash
@@ -39,11 +39,29 @@ GPflow 2.0 uses [TensorFlow 2.0](http://www.tensorflow.org) for running computat
 
   in a check-out of the `develop` branch of the GPflow github repository.
 
-- Using `pip`
+- Using `pip`:
 
-  ```bash
-  pip install gpflow
-  ```
+  - latest `develop` version:
+    ```bash
+    pip install git+https://github.com/GPflow/GPflow.git@develop#egg=gpflow
+    ```
+    (this will automatically install all required dependencies).
+
+  - latest PyPI package: currently not recommended
+    (the latest version released on PyPI is 2.0.0rc1; this release candidate is missing several bugfixes and improvements, and does not support _TensorFlow_ 2.1)
+    but you can install it as follows:
+    ```bash
+    pip install gpflow==2.0.0rc1 tensorflow==2.0 tensorflow_probability==0.8
+    ```
+    (replace `tensorflow==2.0` with `tensorflow-gpu==2.0` for the GPU version)
+
+## Install GPflow 1.5.1 (last official release)
+
+Using `pip`:
+```bash
+pip install 'gpflow<2.0' 'tensorflow<2.0'
+```
+GPflow leaves installing tensorflow to the user so that you can choose whether you want the CPU-only or the GPU-support package. Replace `tensorflow<2.0` with `tensorflow-gpu<2.0` for the GPU version.
 
 
 ## Getting Started with GPflow 2.0
@@ -55,21 +73,27 @@ There is an ["Intro to GPflow 2.0"](https://github.com/GPflow/GPflow/blob/develo
   *We have stopped development and support for GPflow based on TensorFlow 1.0. We now accept only bug fixes to GPflow 1.0 in the **develop-1.0** branch. The latest available release is [v1.5.1](https://github.com/GPflow/GPflow/releases/tag/v1.5.1). [Documentation](https://gpflow.readthedocs.io/en/v1.5.1-docs/) and [tutorials](https://nbviewer.jupyter.org/github/GPflow/GPflow/blob/develop/doc/source/notebooks/intro.ipynb) will remain available.*
 
 
-## Getting help
+## The GPflow Community
 
-Please use GitHub issues to start discussion on the use of GPflow. Tagging enquiries `discussion` helps us distinguish them from bugs.
+### Getting help
 
-## Contributing
+**Bugs, feature requests, pain points:**
+Please use [GitHub issues](https://github.com/GPflow/GPflow/issues/) to flag up bugs/issues/pain points, suggest new features, and discuss anything else related to the use of GPflow that in some sense involves changing the GPflow code itself. Please make use of the labels such as `bug`, `discussion`, `feature`, etc.
+
+We aim to respond to issues promptly, but if you believe we may have forgotten about an issue, please feel free to add another comment to remind us.
+
+**How-to-use questions:**
+Please use [StackOverflow (gpflow tag)](https://stackoverflow.com/tags/gpflow) to ask questions that relate to "how to use GPflow", i.e. questions of understanding rather than issues that require changing GPflow code.
+
+### Slack workspace
+
+We have a public [GPflow slack workspace](https://gpflow.slack.com/). Please use this [invite link](https://join.slack.com/t/gpflow/shared_invite/enQtOTE5MDA0Nzg5NjA2LTYwZWI3MzhjYjNlZWI1MWExYzZjMGNhOWIwZWMzMGY0YjVkYzAyYjQ4NjgzNDUyZTgyNzcwYjAyY2QzMWRmYjE) if you'd like to join, whether to ask short informal questions or to be involved in the discussion and future development of GPflow.
+
+### Contributing
 
 All constructive input is gratefully received. For more information, see the [notes for contributors](contributing.md).
 
-## Compatibility
-
-GPflow heavily depends on TensorFlow and as far as TensorFlow supports forward compatibility, GPflow should as well. The version of GPflow can give you a hint about backward compatibility. If the major version has changed then you need to check the release notes to find out how the API has been changed.
-
-Unfortunately, there is no such thing as backward compatibility for GPflow _models_, which means that a model implementation can change without changing interfaces. In other words, the TensorFlow graph can be different for the same models from different versions of GPflow.
-
-## Projects using GPflow
+### Projects using GPflow
 
 A few projects building on GPflow and demonstrating its usage are listed below.
 
@@ -88,6 +112,12 @@ A few projects building on GPflow and demonstrating its usage are listed below.
 
 
 Let us know if you would like your project listed here.
+
+## Compatibility
+
+GPflow heavily depends on TensorFlow and as far as TensorFlow supports forward compatibility, GPflow should as well. The version of GPflow can give you a hint about backward compatibility. If the major version has changed then you need to check the release notes to find out how the API has been changed.
+
+Unfortunately, there is no such thing as backward compatibility for GPflow _models_, which means that a model implementation can change without changing interfaces. In other words, the TensorFlow graph can be different for the same models from different versions of GPflow.
 
 ## Citing GPflow
 

--- a/doc/source/notebooks/gpflow_2_upgrade/gpflow2_upgrade_guide.ipynb
+++ b/doc/source/notebooks/gpflow_2_upgrade/gpflow2_upgrade_guide.ipynb
@@ -199,7 +199,7 @@
    "source": [
     "# Periodic Base Kernel\n",
     "\n",
-    "The base kernel for the `Periodic` kernel must now be specified explicitly. Previously the default was  `SquaredExponential`, so to maintain the same behaviour as before this must be passed-in to the `Periodic` kernel’s initialiser. \n",
+    "The base kernel for the `Periodic` kernel must now be specified explicitly. Previously the default was  `SquaredExponential`, so to maintain the same behaviour as before this must be passed-in to the `Periodic` kernel’s initialiser (note that `active_dims` is specified in the base kernel). \n",
     "\n",
     "For example:\n",
     "\n",

--- a/gpflow/kernels/base.py
+++ b/gpflow/kernels/base.py
@@ -40,9 +40,15 @@ class Kernel(tf.Module, metaclass=abc.ABCMeta):
         :param name: optional kernel name.
         """
         super().__init__(name=name)
-        if isinstance(active_dims, list):
-            active_dims = np.array(active_dims)
-        self._active_dims = active_dims
+        self._active_dims = self._normalize_active_dims(active_dims)
+
+    @staticmethod
+    def _normalize_active_dims(value):
+        if value is None:
+            value = slice(None, None, None)
+        if not isinstance(value, slice):
+            value = np.array(value, dtype=int)
+        return value
 
     @property
     def active_dims(self):
@@ -50,11 +56,7 @@ class Kernel(tf.Module, metaclass=abc.ABCMeta):
 
     @active_dims.setter
     def active_dims(self, value):
-        if value is None:
-            value = slice(None, None, None)
-        if not isinstance(value, slice):
-            value = np.array(value, dtype=int)
-        self._active_dims = value
+        self._active_dims = self._normalize_active_dims(value)
 
     def on_separate_dims(self, other):
         """

--- a/gpflow/kernels/base.py
+++ b/gpflow/kernels/base.py
@@ -35,7 +35,8 @@ class Kernel(tf.Module, metaclass=abc.ABCMeta):
                  active_dims: Optional[Union[slice, list]] = None,
                  name: Optional[str] = None):
         """
-        :param active_dims: active dimensions, has the slice type.
+        :param active_dims: active dimensions, either a slice or list of
+            indices into the columns of X.
         :param name: optional kernel name.
         """
         super().__init__(name=name)

--- a/gpflow/kernels/periodic.py
+++ b/gpflow/kernels/periodic.py
@@ -9,6 +9,9 @@ from .base import Kernel
 from .stationaries import Stationary
 
 
+_ACTIVE_DIMS_ON_BASE_KERNEL = 'active_dims should be specified through the base kernel'
+
+
 class Periodic(Kernel):
     """
     The periodic family of kernels. Can be used to wrap any Stationary kernel
@@ -35,7 +38,8 @@ class Periodic(Kernel):
     is absorbed into the lengthscale hyperparameter).
     """
 
-    def __init__(self, base: Stationary, period: Union[float, List[float]] = 1.0):
+    def __init__(self, base: Stationary, period: Union[float, List[float]] = 1.0,
+                 active_dims=_ACTIVE_DIMS_ON_BASE_KERNEL):
         """
         :param base: the base kernel to make periodic; must inherit from Stationary
             Note that active_dims should be specified in the base kernel.
@@ -45,6 +49,10 @@ class Periodic(Kernel):
         """
         if not isinstance(base, Stationary):
             raise TypeError("Periodic requires a Stationary kernel as the `base`")
+
+        if active_dims != _ACTIVE_DIMS_ON_BASE_KERNEL:
+            if active_dims != base.active_dims:
+                raise ValueError("active_dims must be consistent with base.active_dims")
 
         super().__init__()
         self.base = base

--- a/gpflow/kernels/periodic.py
+++ b/gpflow/kernels/periodic.py
@@ -77,6 +77,7 @@ class Periodic(Kernel):
             X2 = X
 
         # Introduce dummy dimension so we can use broadcasting
+        # TODO: does not support kernel broadcasting
         f = tf.expand_dims(X, 1)  # now [N, 1, D]
         f2 = tf.expand_dims(X2, 0)  # now [1, M, D]
 

--- a/gpflow/kernels/periodic.py
+++ b/gpflow/kernels/periodic.py
@@ -51,13 +51,20 @@ class Periodic(Kernel):
         self.period = Parameter(period, transform=positive())
         self.base._validate_ard_active_dims(self.period)
 
+    @property
+    def active_dims(self):
+        return self.base.active_dims
+
+    @active_dims.setter
+    def active_dims(self, value):
+        self.base.active_dims = value
+
     def K_diag(self, X: tf.Tensor, presliced: bool = False) -> tf.Tensor:
         return self.base.K_diag(X)
 
     def K(self, X: tf.Tensor, X2: Optional[tf.Tensor] = None, presliced: bool = False) -> tf.Tensor:
         if not presliced:
-            # active_dims is specified in the base, so use base.slice
-            X, X2 = self.base.slice(X, X2)
+            X, X2 = self.slice(X, X2)
         if X2 is None:
             X2 = X
 

--- a/gpflow/kernels/periodic.py
+++ b/gpflow/kernels/periodic.py
@@ -40,7 +40,7 @@ class Periodic(Kernel):
         """
         :param base: the base kernel to make periodic; must inherit from Stationary
             Note that active_dims should be specified in the base kernel.
-        :param period: the period; to induce a different period per active dimention
+        :param period: the period; to induce a different period per active dimension
             this must be initialized with an array the same length as the number
             of active dimensions e.g. [1., 1., 1.]
         """

--- a/gpflow/kernels/periodic.py
+++ b/gpflow/kernels/periodic.py
@@ -51,7 +51,7 @@ class Periodic(Kernel):
             raise TypeError("Periodic requires a Stationary kernel as the `base`")
 
         if active_dims != _ACTIVE_DIMS_ON_BASE_KERNEL:
-            if active_dims != base.active_dims:
+            if self._normalize_active_dims(active_dims) != base.active_dims:
                 raise ValueError("active_dims must be consistent with base.active_dims")
 
         super().__init__()

--- a/gpflow/kernels/periodic.py
+++ b/gpflow/kernels/periodic.py
@@ -32,15 +32,16 @@ class Periodic(Kernel):
     γ is the period parameter.
 
     (note that usually we have a factor of 4 instead of 0.5 in front but this
-    is absorbed into lengthscale hyperparameter).
+    is absorbed into the lengthscale hyperparameter).
     """
 
     def __init__(self, base: Stationary, period: Union[float, List[float]] = 1.0):
         """
         :param base: the base kernel to make periodic; must inherit from Stationary
+            Note that active_dims should be specified in the base kernel.
         :param period: the period; to induce a different period per active dimention
-            this must be initialized with an array the same length as the the number
-            of active dimensions in the base e.g. [1., 1., 1.]
+            this must be initialized with an array the same length as the number
+            of active dimensions e.g. [1., 1., 1.]
         """
         if not isinstance(base, Stationary):
             raise TypeError("Periodic requires a Stationary kernel as the `base`")

--- a/gpflow/kernels/periodic.py
+++ b/gpflow/kernels/periodic.py
@@ -9,9 +9,6 @@ from .base import Kernel
 from .stationaries import Stationary
 
 
-_ACTIVE_DIMS_ON_BASE_KERNEL = 'active_dims should be specified through the base kernel'
-
-
 class Periodic(Kernel):
     """
     The periodic family of kernels. Can be used to wrap any Stationary kernel
@@ -39,7 +36,7 @@ class Periodic(Kernel):
     """
 
     def __init__(self, base: Stationary, period: Union[float, List[float]] = 1.0,
-                 active_dims=_ACTIVE_DIMS_ON_BASE_KERNEL):
+                 **kwargs):
         """
         :param base: the base kernel to make periodic; must inherit from Stationary
             Note that active_dims should be specified in the base kernel.
@@ -50,8 +47,8 @@ class Periodic(Kernel):
         if not isinstance(base, Stationary):
             raise TypeError("Periodic requires a Stationary kernel as the `base`")
 
-        if active_dims != _ACTIVE_DIMS_ON_BASE_KERNEL:
-            if self._normalize_active_dims(active_dims) != base.active_dims:
+        if 'active_dims' in kwargs:
+            if self._normalize_active_dims(kwargs['active_dims']) != base.active_dims:
                 raise ValueError("active_dims must be consistent with base.active_dims")
 
         super().__init__()

--- a/gpflow/kernels/stationaries.py
+++ b/gpflow/kernels/stationaries.py
@@ -20,12 +20,14 @@ class Stationary(Kernel):
 
     def __init__(self, variance=1.0, lengthscale=1.0, **kwargs):
         """
-        :param variance: the (initial) value for the variance parameter
-        :param lengthscale: the (initial) value for the lengthscale parameter(s),
-            to induce ARD behaviour this must be initialised as an array the same
-            length as the the number of active dimensions e.g. [1., 1., 1.]
-        :param kwargs: accepts `name` and `active_dims`, which is a list of
-            length input_dim which controls which columns of X are used
+        :param variance: the (initial) value for the variance parameter.
+        :param lengthscale: the (initial) value for the lengthscale
+            parameter(s), to induce ARD behaviour this must be initialised as
+            an array the same length as the the number of active dimensions
+            e.g. [1., 1., 1.]
+        :param kwargs: accepts `name` and `active_dims`, which is a list or
+            slice of indices which controls which columns of X are used (by
+            default, all columns are used).
         """
         for kwarg in kwargs:
             if kwarg not in {'name', 'active_dims'}:

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -36,7 +36,7 @@ def leading_transpose(tensor: tf.Tensor, perm: List[Union[int, type(...)]], lead
             # B is 2nd element and
             # C is 3rd element in
             # permutation list,
-            # leading dimentions are [1, 2, 3]
+            # leading dimensions are [1, 2, 3]
             # which are 0th element in permutation
             # list
         b = leading_transpose(a, [3, -3, ..., -2])  # [C, A, ..., B]

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -532,3 +532,35 @@ def test_on_separate_dims(active_dims_1, active_dims_2, is_separate):
     assert kernel_2.on_separate_dims(kernel_1) == is_separate
     assert kernel_1.on_separate_dims(kernel_1) is False
     assert kernel_2.on_separate_dims(kernel_2) is False
+
+
+@pytest.mark.parametrize('kernel', kernel_setups_extended)
+def test_kernel_call_diag_and_X2_errors(kernel):
+    X = rng.randn(4, 1)
+    X2 = rng.randn(5, 1)
+
+    with pytest.raises(ValueError):
+        kernel(X, X2, diag=True)
+
+
+def test_periodic_active_dims_mismatch_check():
+    active_dims_1 = [0]
+    active_dims_2 = [1]
+    with pytest.raises(ValueError):
+        base = gpflow.kernels.SquaredExponential(active_dims=active_dims_1)
+        _ = gpflow.kernels.Periodic(base=base, active_dims=active_dims_2)
+
+def test_periodic_active_dims_matches():
+    active_dims = [1]
+    base = gpflow.kernels.SquaredExponential(active_dims=active_dims)
+    kernel = gpflow.kernels.Periodic(base=base, active_dims=active_dims)
+
+    assert kernel.active_dims == base.active_dims
+
+    kernel.active_dims = [2]
+
+    assert kernel.active_dims == base.active_dims
+
+    base.active_dims = [3]
+
+    assert kernel.active_dims == base.active_dims

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -540,7 +540,7 @@ def test_kernel_call_diag_and_X2_errors(kernel):
     X2 = rng.randn(5, 1)
 
     with pytest.raises(ValueError):
-        kernel(X, X2, diag=True)
+        kernel(X, X2, full=False)
 
 
 def test_periodic_active_dims_mismatch_check():


### PR DESCRIPTION
Addresses unclear/insufficient documentation (closes #1230).

Previously, `Periodic` did not take `active_dims`, and only the first code example in #1230 would have worked - but the `Kernel` base class specifies `active_dims` as part of the interface, so this PR adds getter/setter that pass through to the `base` kernel, as well as accepting `active_dims` in the `Periodic()` constructor but raising an error when it is not consistent with `base.active_dims`.