### PR TITLE
Improve pretty-printing of GPflow objects in IPython shell and jupyter notebook

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,7 +5,7 @@ exclude_lines =
     def __repr__
     def __str__
     def _repr_html_
-    def _html_table_rows
+    def _repr_pretty_
     if self.debug:
     if settings.DEBUG
     raise AssertionError

--- a/gpflow/__init__.py
+++ b/gpflow/__init__.py
@@ -14,10 +14,25 @@
 
 # flake8: noqa
 
-from . import (conditionals, config, expectations, inducing_variables, kernels, likelihoods, logdensities, models,
-               optimizers, probability_distributions, utilities)
-from .base import Parameter
-from .config import default_float, default_jitter
+from .base import Module, Parameter
+from .config import default_int, default_float, default_jitter
+from . import (
+    conditionals,
+    config,
+    covariances,
+    expectations,
+    inducing_variables,
+    kernels,
+    kullback_leiblers,
+    likelihoods,
+    logdensities,
+    mean_functions,
+    models,
+    optimizers,
+    probability_distributions,
+    quadrature,
+    utilities,
+)
 from .versions import __version__
 
 __all__ = [export for export in dir()]

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -32,6 +32,15 @@ class Module(tf.Module):
     def trainable_parameters(self):
         return tuple(self._flatten(predicate=_IS_TRAINABLE_PARAMETER))
 
+    def _repr_html_(self):
+        from IPython.display import HTML
+        from .utilities import tabulate_module_summary
+        return HTML(tabulate_module_summary(self, tablefmt='html'))
+
+    def _repr_pretty_(self, p, cycle):
+        from .utilities import tabulate_module_summary
+        p.text(tabulate_module_summary(self, tablefmt=''))
+
 
 class Parameter(tf.Module):
     def __init__(self,

--- a/gpflow/inducing_variables/inducing_variables.py
+++ b/gpflow/inducing_variables/inducing_variables.py
@@ -16,12 +16,12 @@ import abc
 
 import tensorflow as tf
 
-from ..base import Parameter
+from ..base import Module, Parameter
 from ..config import default_float
 from ..utilities import positive
 
 
-class InducingVariables(tf.Module):
+class InducingVariables(Module):
     """
     Abstract base class for inducing variables.
     """

--- a/gpflow/kernels/base.py
+++ b/gpflow/kernels/base.py
@@ -25,8 +25,9 @@ from typing import List, Optional, Union
 import numpy as np
 import tensorflow as tf
 
+from ..base import Module
 
-class Kernel(tf.Module, metaclass=abc.ABCMeta):
+class Kernel(Module, metaclass=abc.ABCMeta):
     """
     The basic kernel class. Handles active dims.
     """

--- a/gpflow/likelihoods/likelihoods.py
+++ b/gpflow/likelihoods/likelihoods.py
@@ -56,7 +56,7 @@ import numpy as np
 import tensorflow as tf
 
 from .. import logdensities
-from ..base import Parameter
+from ..base import Module, Parameter
 from ..config import default_float, default_int
 from ..quadrature import hermgauss, ndiag_mc, ndiagquad
 from ..utilities import positive
@@ -69,7 +69,7 @@ def inv_probit(x):
         * (1 - 2 * jitter) + jitter
 
 
-class Likelihood(tf.Module):
+class Likelihood(Module):
     def __init__(self):
         super().__init__()
         self.num_gauss_hermite_points = 20

--- a/gpflow/likelihoods/robustmax.py
+++ b/gpflow/likelihoods/robustmax.py
@@ -2,12 +2,12 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 
-from ..base import Parameter
+from ..base import Module, Parameter
 from ..config import default_int
 from ..utilities import to_default_float
 
 
-class RobustMax(tf.Module):
+class RobustMax(Module):
     """
     This class represent a multi-class inverse-link function. Given a vector
     f=[f_1, f_2, ... f_k], the result of the mapping is

--- a/gpflow/mean_functions.py
+++ b/gpflow/mean_functions.py
@@ -28,11 +28,11 @@ parametric function.
 import numpy as np
 import tensorflow as tf
 
-from .base import Parameter
+from .base import Module, Parameter
 from .config import default_float
 
 
-class MeanFunction(tf.Module):
+class MeanFunction(Module):
     """
     The base mean function class.
     To implement a mean function, write the __call__ method. This takes a

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -16,6 +16,7 @@ __all__ = [
     "multiple_assign",
     "training_loop",
     "print_summary",
+    "tabulate_module_summary",
     "deepcopy_components",
     "leaf_components",
     "parameter_dict",


### PR DESCRIPTION
Makes all GPflow objects (kernels, likelihoods, ...) inherit from `gpflow.base.Module` (not `tf.Module`), and adds `_repr_html_` and `_repr_pretty_` methods to `gpflow.base.Module` that return appropriate rich representation for jupyter notebook and IPython shell, respectively.