### PR TITLE
Clean up `presliced` argument to kernel calls

### DIFF
--- a/doc/source/notebooks/tailor/gp_nn.ipynb
+++ b/doc/source/notebooks/tailor/gp_nn.ipynb
@@ -120,14 +120,14 @@
     "            \n",
     "            self.cnn.build()\n",
     "    \n",
-    "    def K(self, a_input: tf.Tensor, b_input: Optional[tf.Tensor] = None, presliced: bool = False) -> tf.Tensor:\n",
+    "    def K(self, a_input: tf.Tensor, b_input: Optional[tf.Tensor] = None) -> tf.Tensor:\n",
     "        transformed_a = self.cnn(a_input)\n",
     "        transformed_b = self.cnn(b_input) if b_input is not None else b_input\n",
-    "        return self.base_kernel.K(transformed_a, transformed_b, presliced)\n",
+    "        return self.base_kernel.K(transformed_a, transformed_b)\n",
     "    \n",
-    "    def K_diag(self, a_input: tf.Tensor, presliced: bool = False) -> tf.Tensor:\n",
+    "    def K_diag(self, a_input: tf.Tensor) -> tf.Tensor:\n",
     "        transformed_a = self.cnn(a_input)\n",
-    "        return self.base_kernel.K_diag(transformed_a, presliced)"
+    "        return self.base_kernel.K_diag(transformed_a)"
    ]
   },
   {

--- a/gpflow/kernels/base.py
+++ b/gpflow/kernels/base.py
@@ -84,11 +84,13 @@ class Kernel(Module, metaclass=abc.ABCMeta):
         dims = self.active_dims
         if isinstance(dims, slice):
             X = X[..., dims]
-            X2 = X2[..., dims] if X2 is not None else X
+            if X2 is not None:
+                X2 = X2[..., dims]
         elif dims is not None:
             # TODO(@awav): Convert when TF2.0 will support proper slicing.
             X = tf.gather(X, dims, axis=-1)
-            X2 = tf.gather(X2, dims, axis=-1) if X2 is not None else X
+            if X2 is not None:
+                X2 = tf.gather(X2, dims, axis=-1)
         return X, X2
 
     def slice_cov(self, cov: tf.Tensor) -> tf.Tensor:

--- a/gpflow/kernels/base.py
+++ b/gpflow/kernels/base.py
@@ -145,7 +145,7 @@ class Kernel(Module, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     def __call__(self, X, X2=None, full=True, presliced=False):
-        if (not full) and (X2 is not None):
+        if (not full) and (X2 is not None):  # pragma: no cover
             raise ValueError("Ambiguous inputs: `not full` and `X2` are not compatible.")
 
         if not presliced:
@@ -220,9 +220,6 @@ class Combination(Kernel):
 
 class ReducingCombination(Combination):
     def __call__(self, X, X2=None, full=True, presliced=False):
-        if (not full) and (X2 is not None):
-            raise ValueError("Ambiguous inputs: `not full` and `X2` are not compatible.")
-
         return self._reduce(
             [k(X, X2, full=full, presliced=presliced) for k in self.kernels]
         )

--- a/gpflow/kernels/base.py
+++ b/gpflow/kernels/base.py
@@ -145,7 +145,7 @@ class Kernel(Module, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     def __call__(self, X, X2=None, full=True, presliced=False):
-        if (not full) and (X2 is not None):  # pragma: no cover
+        if (not full) and (X2 is not None):
             raise ValueError("Ambiguous inputs: `not full` and `X2` are not compatible.")
 
         if not presliced:
@@ -180,8 +180,7 @@ class Combination(Kernel):
         super().__init__(name=name)
 
         if not all(isinstance(k, Kernel) for k in kernels):
-            raise TypeError(
-                "can only combine Kernel instances")  # pragma: no cover
+            raise TypeError("can only combine Kernel instances")  # pragma: no cover
 
         self._set_kernels(kernels)
 

--- a/gpflow/kernels/changepoints.py
+++ b/gpflow/kernels/changepoints.py
@@ -62,7 +62,7 @@ class ChangePoints(Combination):
         # it is not clear how to flatten out nested change-points
         self.kernels = list(kernels)
 
-    def K(self, X: tf.Tensor, X2: Optional[tf.Tensor] = None, presliced: bool = False) -> tf.Tensor:
+    def K(self, X: tf.Tensor, X2: Optional[tf.Tensor] = None) -> tf.Tensor:
         sig_X = self._sigmoids(X)  # N x 1 x Ncp
         sig_X2 = self._sigmoids(X2) if X2 is not None else sig_X
 
@@ -82,7 +82,7 @@ class ChangePoints(Combination):
         kernel_stack = tf.stack([k(X, X2) for k in self.kernels], axis=2)
         return tf.reduce_sum(kernel_stack * starters * stoppers, axis=2)
 
-    def K_diag(self, X: tf.Tensor, presliced: bool = False) -> tf.Tensor:
+    def K_diag(self, X: tf.Tensor) -> tf.Tensor:
         N = tf.shape(X)[0]
         sig_X = tf.reshape(self._sigmoids(X), (N, -1))  # N x Ncp
 

--- a/gpflow/kernels/linears.py
+++ b/gpflow/kernels/linears.py
@@ -33,18 +33,13 @@ class Linear(Kernel):
         """
         return self.variance.shape.ndims > 0
 
-    def K(self, X, X2=None, presliced=False):
-        if not presliced:
-            X, X2 = self.slice(X, X2)
-
+    def K(self, X, X2=None):
         if X2 is None:
-            return tf.linalg.matmul(X * self.variance, X, transpose_b=True)
+            X2 = X
 
         return tf.linalg.matmul(X * self.variance, X2, transpose_b=True)
 
-    def K_diag(self, X, presliced=False):
-        if not presliced:
-            X, _ = self.slice(X, None)
+    def K_diag(self, X):
         return tf.reduce_sum(tf.square(X) * self.variance, 1)
 
 
@@ -73,8 +68,8 @@ class Polynomial(Linear):
         self.degree = degree
         self.offset = Parameter(offset, transform=positive())
 
-    def K(self, X, X2=None, presliced=False):
-        return (super().K(X, X2, presliced=presliced) + self.offset)**self.degree
+    def K(self, X, X2=None):
+        return (super().K(X, X2) + self.offset)**self.degree
 
-    def K_diag(self, X, presliced=False):
-        return (super().K_diag(X, presliced=presliced) + self.offset)**self.degree
+    def K_diag(self, X):
+        return (super().K_diag(X) + self.offset)**self.degree

--- a/gpflow/kernels/misc.py
+++ b/gpflow/kernels/misc.py
@@ -134,7 +134,6 @@ class Coregion(Kernel):
         self.kappa = Parameter(kappa, transform=positive())
 
     def K(self, X, X2=None):
-        X, X2 = self.slice(X, X2)
         X = tf.cast(X[:, 0], tf.int32)
         if X2 is None:
             X2 = X
@@ -144,7 +143,6 @@ class Coregion(Kernel):
         return tf.gather(tf.transpose(tf.gather(B, X2)), X)
 
     def K_diag(self, X):
-        X, _ = self.slice(X, None)
         X = tf.cast(X[:, 0], tf.int32)
         Bdiag = tf.reduce_sum(tf.square(self.W), 1) + self.kappa
         return tf.gather(Bdiag, X)

--- a/gpflow/kernels/misc.py
+++ b/gpflow/kernels/misc.py
@@ -74,10 +74,7 @@ class ArcCosine(Kernel):
         elif self.order == 2:
             return 3. * tf.sin(theta) * tf.cos(theta) + (np.pi - theta) * (1. + 2. * tf.cos(theta)**2)
 
-    def K(self, X, X2=None, presliced=False):
-        if not presliced:
-            X, X2 = self.slice(X, X2)
-
+    def K(self, X, X2=None):
         X_denominator = tf.sqrt(self._weighted_product(X))
         if X2 is None:
             X2 = X
@@ -94,10 +91,7 @@ class ArcCosine(Kernel):
                X_denominator[:, None] ** self.order * \
                X2_denominator[None, :] ** self.order
 
-    def K_diag(self, X, presliced=False):
-        if not presliced:
-            X, _ = self.slice(X, None)
-
+    def K_diag(self, X):
         X_product = self._weighted_product(X)
         const = tf.cast((1. / np.pi) * self._J(0.), default_float())
         return self.variance * const * X_product**self.order
@@ -139,7 +133,7 @@ class Coregion(Kernel):
         self.W = Parameter(W)
         self.kappa = Parameter(kappa, transform=positive())
 
-    def K(self, X, X2=None, presliced=False):
+    def K(self, X, X2=None):
         X, X2 = self.slice(X, X2)
         X = tf.cast(X[:, 0], tf.int32)
         if X2 is None:
@@ -149,7 +143,7 @@ class Coregion(Kernel):
         B = tf.linalg.matmul(self.W, self.W, transpose_b=True) + tf.linalg.diag(self.kappa)
         return tf.gather(tf.transpose(tf.gather(B, X2)), X)
 
-    def K_diag(self, X, presliced=False):
+    def K_diag(self, X):
         X, _ = self.slice(X, None)
         X = tf.cast(X[:, 0], tf.int32)
         Bdiag = tf.reduce_sum(tf.square(self.W), 1) + self.kappa

--- a/gpflow/kernels/mo_kernels.py
+++ b/gpflow/kernels/mo_kernels.py
@@ -36,7 +36,7 @@ class MultioutputKernel(Kernel):
     until the appropriate size is reached.
     """
     @abc.abstractmethod
-    def K(self, X, X2=None, full_output_cov=True, presliced=False):
+    def K(self, X, X2=None, full_output_cov=True):
         """
         Returns the correlation of f(X) and f(X2), where f(.) can be multi-dimensional.
         :param X: data matrix, [N1, D]
@@ -49,7 +49,7 @@ class MultioutputKernel(Kernel):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def K_diag(self, X, full_output_cov=True, presliced=False):
+    def K_diag(self, X, full_output_cov=True):
         """
         Returns the correlation of f(X) and f(X), where f(.) can be multi-dimensional.
         :param X: data matrix, [N, D]
@@ -60,7 +60,7 @@ class MultioutputKernel(Kernel):
         """
         raise NotImplementedError
 
-    def __call__(self, X, X2=None, full=False, full_output_cov=True, presliced=False):
+    def __call__(self, X, X2=None, full=False, full_output_cov=True):
         if not full and X2 is not None:
             raise ValueError("Ambiguous inputs: `diagonal` and `y` are not compatible.")
         if not full:
@@ -80,7 +80,7 @@ class SharedIndependent(MultioutputKernel):
         self.kernel = kernel
         self.P = output_dimensionality
 
-    def K(self, X, X2=None, full_output_cov=True, presliced=False):
+    def K(self, X, X2=None, full_output_cov=True):
         K = self.kernel.K(X, X2)  # [N, N2]
         if full_output_cov:
             Ks = tf.tile(K[..., None], [1, 1, self.P])  # [N, N2, P]
@@ -88,7 +88,7 @@ class SharedIndependent(MultioutputKernel):
         else:
             return tf.tile(K[None, ...], [self.P, 1, 1])  # [P, N, N2]
 
-    def K_diag(self, X, full_output_cov=True, presliced=False):
+    def K_diag(self, X, full_output_cov=True):
         K = self.kernel.K_diag(X)  # N
         Ks = tf.tile(K[:, None], [1, self.P])  # [N, P]
         return tf.linalg.diag(Ks) if full_output_cov else Ks  # [N, P, P] or [N, P]
@@ -102,14 +102,14 @@ class SeparateIndependent(MultioutputKernel, Combination):
     def __init__(self, kernels, name=None):
         Combination.__init__(self, kernels, name)
 
-    def K(self, X, X2=None, full_output_cov=True, presliced=False):
+    def K(self, X, X2=None, full_output_cov=True):
         if full_output_cov:
             Kxxs = tf.stack([k.K(X, X2) for k in self.kernels], axis=2)  # [N, N2, P]
             return tf.transpose(tf.linalg.diag(Kxxs), [0, 2, 1, 3])  # [N, P, N2, P]
         else:
             return tf.stack([k.K(X, X2) for k in self.kernels], axis=0)  # [P, N, N2]
 
-    def K_diag(self, X, full_output_cov=False, presliced=False):
+    def K_diag(self, X, full_output_cov=False):
         stacked = tf.stack([k.K_diag(X) for k in self.kernels], axis=1)  # [N, P]
         return tf.linalg.diag(stacked) if full_output_cov else stacked  # [N, P, P]  or  [N, P]
 
@@ -143,7 +143,7 @@ class LinearCoregionalization(IndependentLatent, Combination):
     def Kgg(self, X, X2):
         return tf.stack([k.K(X, X2) for k in self.kernels], axis=0)  # [L, N, N2]
 
-    def K(self, X, X2=None, full_output_cov=True, presliced=False):
+    def K(self, X, X2=None, full_output_cov=True):
         Kxx = self.Kgg(X, X2)  # [L, N, N2]
         KxxW = Kxx[None, :, :, :] * self.W[:, :, None, None]  # [P, L, N, N2]
         if full_output_cov:
@@ -154,7 +154,7 @@ class LinearCoregionalization(IndependentLatent, Combination):
             # return tf.einsum('lnm,kl,kl->knm', Kxx, self.W, self.W)
             return tf.reduce_sum(self.W[:, :, None, None] * KxxW, [1])  # [P, N, N2]
 
-    def K_diag(self, X, full_output_cov=True, presliced=False):
+    def K_diag(self, X, full_output_cov=True):
         K = tf.stack([k.K_diag(X) for k in self.kernels], axis=1)  # [N, L]
         if full_output_cov:
             # Can currently not use einsum due to unknown shape from `tf.stack()`

--- a/gpflow/kernels/periodic.py
+++ b/gpflow/kernels/periodic.py
@@ -50,13 +50,13 @@ class Periodic(Kernel):
         self.period = Parameter(period, transform=positive())
         self.base._validate_ard_active_dims(self.period)
 
-    def K_diag(self, X: tf.Tensor, presliced: bool = False) -> tf.Tensor:
+    def slice(self, X, X2):
+        return self.base.slice(X, X2)
+
+    def K_diag(self, X: tf.Tensor) -> tf.Tensor:
         return self.base.K_diag(X)
 
-    def K(self, X: tf.Tensor, X2: Optional[tf.Tensor] = None, presliced: bool = False) -> tf.Tensor:
-        if not presliced:
-            # active_dims is specified in the base, so use base.slice
-            X, X2 = self.base.slice(X, X2)
+    def K(self, X: tf.Tensor, X2: Optional[tf.Tensor] = None) -> tf.Tensor:
         if X2 is None:
             X2 = X
 

--- a/gpflow/kernels/statics.py
+++ b/gpflow/kernels/statics.py
@@ -15,7 +15,7 @@ class Static(Kernel):
         super().__init__(active_dims)
         self.variance = Parameter(variance, transform=positive())
 
-    def K_diag(self, X, presliced=False):
+    def K_diag(self, X):
         return tf.fill((tf.shape(X)[0],), tf.squeeze(self.variance))
 
 
@@ -30,7 +30,7 @@ class White(Static):
     σ²  is the variance parameter.
     """
 
-    def K(self, X, X2=None, presliced=False):
+    def K(self, X, X2=None):
         if X2 is None:
             d = tf.fill((tf.shape(X)[0],), tf.squeeze(self.variance))
             return tf.linalg.diag(d)
@@ -50,7 +50,7 @@ class Constant(Static):
     σ²  is the variance parameter.
     """
 
-    def K(self, X, X2=None, presliced=False):
+    def K(self, X, X2=None):
         if X2 is None:
             shape = [tf.shape(X)[0], tf.shape(X)[0]]
         else:

--- a/gpflow/kernels/stationaries.py
+++ b/gpflow/kernels/stationaries.py
@@ -51,13 +51,11 @@ class Stationary(Kernel):
         X2_scaled = X2 / self.lengthscale if X2 is not None else X2
         return square_distance(X_scaled, X2_scaled)
 
-    def K(self, X, X2=None, presliced=False):
-        if not presliced:
-            X, X2 = self.slice(X, X2)
+    def K(self, X, X2=None):
         r2 = self.scaled_squared_euclid_dist(X, X2)
         return self.K_r2(r2)
 
-    def K_diag(self, X, presliced=False):
+    def K_diag(self, X):
         return tf.fill(tf.shape(X)[:-1], tf.squeeze(self.variance))
 
     def K_r2(self, r2):

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -328,7 +328,8 @@ def test_conv_diag():
 # the kernels separately.
 _kernel_setups_add = [
     gpflow.kernels.SquaredExponential(),
-    gpflow.kernels.Linear(), (gpflow.kernels.SquaredExponential() + gpflow.kernels.Linear())
+    gpflow.kernels.Linear(),
+    gpflow.kernels.SquaredExponential() + gpflow.kernels.Linear(),
 ]
 
 
@@ -398,7 +399,7 @@ def test_slice_asymmetric(kernel_triple, N, M, D):
 _kernel_setups_prod = [
     gpflow.kernels.Matern32(),
     gpflow.kernels.Matern52(lengthscale=0.3),
-    gpflow.kernels.Matern32() * gpflow.kernels.Matern52(lengthscale=0.3)
+    gpflow.kernels.Matern32() * gpflow.kernels.Matern52(lengthscale=0.3),
 ]
 
 
@@ -532,3 +533,12 @@ def test_on_separate_dims(active_dims_1, active_dims_2, is_separate):
     assert kernel_2.on_separate_dims(kernel_1) == is_separate
     assert kernel_1.on_separate_dims(kernel_1) is False
     assert kernel_2.on_separate_dims(kernel_2) is False
+
+
+@pytest.mark.parametrize('kernel', kernel_setups_extended)
+def test_kernel_call_diag_and_X2_errors(kernel):
+    X = rng.randn(4, 1)
+    X2 = rng.randn(5, 1)
+
+    with pytest.raises(ValueError):
+        kernel(X, X2, full=False)


### PR DESCRIPTION
In GPflow 1, each kernel's `K` and `K_diag` method was supposed to take a `presliced` argument. Not all kernels actually had this signature, and not all kernels who had this signature actually did anything with the argument. This PR makes `presliced` an argument solely to the kernel's `__call__`, with the intent of making the entire set-up a lot cleaner.