### PR TITLE
fix Parameter.__repr__ for tf.function mode

### DIFF
--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -206,13 +206,19 @@ class Parameter(tf.Module):
     def __repr__(self):
         unconstrained = self.unconstrained_variable
         constrained = self.read_value()
-        info = f"dtype={self.dtype.name} " \
-               f"unconstrained-shape={unconstrained.shape} " \
-               f"unconstrained-numpy={unconstrained.numpy()} " \
-               f"constrained-shape={constrained.shape} " \
-               f"constrained-numpy={constrained.numpy()}"
+        if tf.executing_eagerly():
+            info = f"unconstrained-shape={unconstrained.shape} " \
+                   f"unconstrained-value={unconstrained.numpy()} " \
+                   f"constrained-shape={constrained.shape} " \
+                   f"constrained-value={constrained.numpy()}"
+        else:
+            if unconstrained.shape == constrained.shape:
+                info = f"shape={constrained.shape}"
+            else:
+                info = f"unconstrained-shape={unconstrained.shape} " \
+                       f"constrained-shape={constrained.shape}"
 
-        return f"<gpflow.Parameter {self.name!r} {info}>"
+        return f"<gpflow.Parameter {self.name!r} dtype={self.dtype.name} {info}>"
 
     # Below
     # TensorFlow copy-paste code to make variable-like object to work


### PR DESCRIPTION
`Parameter.__repr__` called `.numpy()` on the constrained and unconstrained representations - this throws an error when in graph mode (tf.function-wrapped), which can lead to errors-in-exception-handling, so this PR makes use of `tf.eagerly_executing()` to check whether we are in graph mode, and if so, only print shapes and dtype, not values.