### PR TITLE
Ship type information as specified by PEP 561

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include README.md
 include RELEASE.md
 include LICENSE
 include VERSION
+include gpflow/py.typed

--- a/gpflow/py.typed
+++ b/gpflow/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.


### PR DESCRIPTION
## PR content:

* [Title](#title)
* [Description](#description)
* [Minimal working example](#minimal-working-example)

### Title

Ship GPflow with type information

### Description

The latest GPflow2 release candidate has a lot of type hints. This is great, we love type hints!

Unfortunately, GPflow consumers (that is, anyone creating a new repo with modules containing something along the lines of `import gpflow`) will not be able to use MyPy to check they're consuming GPflow objects correctly. This is due to [how MyPy locates type hints](https://mypy.readthedocs.io/en/stable/running_mypy.html#how-mypy-handles-imports). See the section below for an example.

This PR ensures that whenever GPflow is installed via `pip`, users will be able to get type hints for GPflow objects.

### Minimal working example

Create a standalone Python script with the following lines (I've stored it under `mypy/gpflow2.py` for demonstration purposes below):

```
from gpflow.kernels import RBF, Periodic

r = Periodic(RBF(variance=1.0), period="1.0")
```

This usage is incorrect, but let's now see what happens when you run MyPy against this script.

#### Current pip install

Let's create a fresh virtual environment and install [a recent version of GPflow](https://github.com/GPflow/GPflow/commit/056e59f2c5aa2b5021de9b7b91ce1cee2ea0bb92):

```
elvijs@elvijs-tank:~/dev/probmodels$ python3 -m venv gpflow2-current-venv
elvijs@elvijs-tank:~/dev/probmodels$ source gpflow2-current-venv/bin/activate
(gpflow2-current-venv) elvijs@elvijs-tank:~/dev/probmodels$ pip install git+https://github.com/GPflow/GPflow.git@056e59f2c5aa2b5021de9b7b91ce1cee2ea0bb92#egg=gpflow
...
(gpflow2-current-venv) elvijs@elvijs-tank:~/dev/probmodels$ pip install mypy
...
(gpflow2-current-venv) elvijs@elvijs-tank:~/dev/probmodels$ mypy mypy/gpflow2.py
mypy/gpflow2.py:1: error: Cannot find implementation or library stub for module named 'gpflow.kernels'
mypy/gpflow2.py:1: note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

This is not great - in practice these warnings are muted.

#### Proposed pip install

Let's create a fresh virtual environment and install [the version in this PR](https://github.com/elvijs/GPflow/commit/7ad5ac9d00abfe3d772333f659054f7ed84ff672):

```
elvijs@elvijs-tank:~/dev/probmodels$ python3 -m venv gpflow2-proposed-venv
elvijs@elvijs-tank:~/dev/probmodels$ source gpflow2-proposed-venv/bin/activate
(gpflow2-proposed-venv) elvijs@elvijs-tank:~/dev/probmodels$ pip install git+https://github.com/elvijs/GPflow.git@7ad5ac9d00abfe3d772333f659054f7ed84ff672#egg=gpflow
...
(gpflow2-proposed-venv) elvijs@elvijs-tank:~/dev/probmodels$ pip install mypy
...
(gpflow2-proposed-venv) elvijs@elvijs-tank:~/dev/probmodels$ mypy mypy/gpflow2.py 
mypy/gpflow2.py:3: error: Argument "period" to "Periodic" has incompatible type "str"; expected "Union[float, List[float]]"
Found 1 error in 1 file (checked 1 source file)
```

There we go - the error message we wanted to see!
