### PR TITLE
Add `kerndisc` to projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A few projects building on GPflow and demonstrating its usage are listed below.
 | [kernel_learning](https://github.com/frgsimpson/kernel_learning) | Implementation of "Differentiable Compositional Kernel Learning for Gaussian Processes".|
 | [VBPP](https://github.com/st--/vbpp) | Implementation of "Variational Bayes for Point Processes".|
 | [DGPs_with_IWVI](https://github.com/hughsalimbeni/DGPs_with_IWVI) | Deep Gaussian Processes with Importance-Weighted Variational Inference|
+| [kerndisc](https://github.com/BracketJohn/kernDisc) | Library for automated kernel structure discovery in univariate data|
 
 If you would like your project listed here, let us know - or simply [open a pull request](https://github.com/GPflow/GPflow/compare) that adds your project to the table above!
 


### PR DESCRIPTION
We've created `kerndisc` for time series modeling using health related data. This PR aims to add it to the GPflow projects section, as we hope that it might be useful to others.

Summary: `kerndisc` is a library for automated kernel structure discovery in univariate data. It aims to find the best composition of kernels in order to represent a time series. `kerndisc` currently possesses a test coverage of over 90 %. Still, there is no claim to correctness, contribution and correction is heavily desired.

Usage: [See here for an example.](https://github.com/BracketJohn/kernDisc#usage)