### PR TITLE
preserve types in deepcopy

### DIFF
--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -246,7 +246,10 @@ def reset_cache_bijectors(input_module: tf.Module) -> tf.Module:
     return input_module
 
 
-def deepcopy_components(input_module: tf.Module) -> tf.Module:
+M = TypeVar('M', bound=tf.Module)
+
+
+def deepcopy_components(input_module: M) -> M:
     """
     Returns a deepcopy of the input tf.Module. To do that first resets the caches stored inside each
     tfp.bijectors.Bijector to allow the deepcopy of the tf.Module.


### PR DESCRIPTION
## PR content:

* [Preserve types in deepcopy_components](#title)
* [Description](#description)
* [Minimal working example](#minimal-working-example)

### Description

Bug fix: type information was lost in deepcopy

### Minimal working example

The following would fail before this fix, as the type information isn't preserved
```python3
import tensorflow as tf
from gpflow.utilities import deepcopy_components

class Mod(tf.Module):
    pass

mod: Mod = deepcopy_components(Mod())
```