### PR TITLE
Run black on tests directory

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,5 +5,5 @@ import tensorflow as tf
 
 import gpflow
 
-warnings.filterwarnings('ignore')
+warnings.filterwarnings("ignore")
 gpflow.config.set_default_float(np.float64)

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -7,7 +7,11 @@ import gpflow
 import gpflow.inducing_variables.mo_inducing_variables as mf
 import gpflow.kernels.mo_kernels as mk
 from gpflow.conditionals import sample_conditional
-from gpflow.conditionals.util import fully_correlated_conditional, fully_correlated_conditional_repeat, sample_mvn
+from gpflow.conditionals.util import (
+    fully_correlated_conditional,
+    fully_correlated_conditional_repeat,
+    sample_mvn,
+)
 from gpflow.inducing_variables import InducingPoints
 from gpflow.kernels import SquaredExponential
 from gpflow.likelihoods import Gaussian
@@ -69,13 +73,21 @@ def check_equality_predictions(data, models, decimal=3):
     assert_all_array_elements_almost_equal(log_likelihoods, decimal=5)
 
     # Predict: full_cov = True and full_output_cov = True
-    means_tt, vars_tt = predict_all(models, Data.Xs, full_cov=True, full_output_cov=True)
+    means_tt, vars_tt = predict_all(
+        models, Data.Xs, full_cov=True, full_output_cov=True
+    )
     # Predict: full_cov = True and full_output_cov = False
-    means_tf, vars_tf = predict_all(models, Data.Xs, full_cov=True, full_output_cov=False)
+    means_tf, vars_tf = predict_all(
+        models, Data.Xs, full_cov=True, full_output_cov=False
+    )
     # Predict: full_cov = False and full_output_cov = True
-    means_ft, vars_ft = predict_all(models, Data.Xs, full_cov=False, full_output_cov=True)
+    means_ft, vars_ft = predict_all(
+        models, Data.Xs, full_cov=False, full_output_cov=True
+    )
     # Predict: full_cov = False and full_output_cov = False
-    means_ff, vars_ff = predict_all(models, Data.Xs, full_cov=False, full_output_cov=False)
+    means_ff, vars_ff = predict_all(
+        models, Data.Xs, full_cov=False, full_output_cov=False
+    )
 
     # check equality of all the means
     all_means = means_tt + means_tf + means_ft + means_ff
@@ -84,7 +96,9 @@ def check_equality_predictions(data, models, decimal=3):
     # check equality of all the variances within a category
     # (e.g. full_cov=True and full_output_cov=False)
     all_vars = [vars_tt, vars_tf, vars_ft, vars_ff]
-    _ = [assert_all_array_elements_almost_equal(var, decimal=decimal) for var in all_vars]
+    _ = [
+        assert_all_array_elements_almost_equal(var, decimal=decimal) for var in all_vars
+    ]
 
     # Here we check that the variance in different categories are equal
     # after transforming to the right shape.
@@ -93,13 +107,19 @@ def check_equality_predictions(data, models, decimal=3):
     var_ft = vars_ft[0]  # N x P x P
     var_ff = vars_ff[0]  # N x P
 
-    np.testing.assert_almost_equal(np.diagonal(var_tt, axis1=1, axis2=3),
-                                   np.transpose(var_tf, [1, 2, 0]),
-                                   decimal=decimal)
-    np.testing.assert_almost_equal(np.diagonal(var_tt, axis1=0, axis2=2),
-                                   np.transpose(var_ft, [1, 2, 0]),
-                                   decimal=decimal)
-    np.testing.assert_almost_equal(np.diagonal(np.diagonal(var_tt, axis1=0, axis2=2)), var_ff, decimal=decimal)
+    np.testing.assert_almost_equal(
+        np.diagonal(var_tt, axis1=1, axis2=3),
+        np.transpose(var_tf, [1, 2, 0]),
+        decimal=decimal,
+    )
+    np.testing.assert_almost_equal(
+        np.diagonal(var_tt, axis1=0, axis2=2),
+        np.transpose(var_ft, [1, 2, 0]),
+        decimal=decimal,
+    )
+    np.testing.assert_almost_equal(
+        np.diagonal(np.diagonal(var_tt, axis1=0, axis2=2)), var_ff, decimal=decimal
+    )
 
 
 def expand_cov(q_sqrt, W):
@@ -137,7 +157,9 @@ class Data:
 
     Y = tf.convert_to_tensor(G @ Ptrue)
     G = tf.convert_to_tensor(np.hstack((0.5 * np.sin(3 * X) + X, 3.0 * np.cos(X) - X)))
-    Ptrue = tf.convert_to_tensor(np.array([[0.5, -0.3, 1.5], [-0.4, 0.43, 0.0]]))  # [L, P]
+    Ptrue = tf.convert_to_tensor(
+        np.array([[0.5, -0.3, 1.5], [-0.4, 0.43, 0.0]])
+    )  # [L, P]
     Y += tf.random.normal(Y.shape, dtype=tf.float64) * [0.2, 0.2, 0.2]
     Xs = tf.convert_to_tensor(np.linspace(-6, 6, Ntest)[:, None])
     data = (X, Y)
@@ -145,10 +167,13 @@ class Data:
 
 class DataMixedKernelWithEye(Data):
     """ Note in this class L == P """
+
     M, L = 4, 3
     W = np.eye(L)
 
-    G = np.hstack([0.5 * np.sin(3 * Data.X) + Data.X, 3.0 * np.cos(Data.X) - Data.X, 1.0 + Data.X])  # [N, P]
+    G = np.hstack(
+        [0.5 * np.sin(3 * Data.X) + Data.X, 3.0 * np.cos(Data.X) - Data.X, 1.0 + Data.X]
+    )  # [N, P]
 
     mu_data = tf.random.uniform((M, L), dtype=tf.float64)  # [M, L]
     sqrt_data = create_q_sqrt(M, L)  # [L, M, M]
@@ -161,7 +186,11 @@ class DataMixedKernelWithEye(Data):
     W = tf.convert_to_tensor(W)
     sqrt_data = tf.convert_to_tensor(sqrt_data)
     sqrt_data_full = tf.convert_to_tensor(sqrt_data_full)
-    Y += tf.random.normal(Y.shape, dtype=tf.float64) * tf.ones((L,), dtype=tf.float64) * 0.2
+    Y += (
+        tf.random.normal(Y.shape, dtype=tf.float64)
+        * tf.ones((L,), dtype=tf.float64)
+        * 0.2
+    )
     data = (Data.X, Y)
 
 
@@ -170,7 +199,9 @@ class DataMixedKernel(Data):
     L = 2
     P = 3
     W = rng.randn(P, L)
-    G = np.hstack([0.5 * np.sin(3 * Data.X) + Data.X, 3.0 * np.cos(Data.X) - Data.X])  # [N, L]
+    G = np.hstack(
+        [0.5 * np.sin(3 * Data.X) + Data.X, 3.0 * np.cos(Data.X) - Data.X]
+    )  # [N, L]
 
     mu_data = tf.random.normal((M, L), dtype=tf.float64)  # [M, L]
     sqrt_data = create_q_sqrt(M, L)  # [L, M, M]
@@ -179,8 +210,13 @@ class DataMixedKernel(Data):
     G = tf.convert_to_tensor(G)
     W = tf.convert_to_tensor(W)
     sqrt_data = tf.convert_to_tensor(sqrt_data)
-    Y += tf.random.normal(Y.shape, dtype=tf.float64) * tf.ones((P,), dtype=tf.float64) * 0.1
+    Y += (
+        tf.random.normal(Y.shape, dtype=tf.float64)
+        * tf.ones((P,), dtype=tf.float64)
+        * 0.1
+    )
     data = (Data.X, Y)
+
 
 # ------------------------------------------
 # Test sample conditional
@@ -208,8 +244,10 @@ def test_sample_mvn(cov_structure):
     samples_mean = np.mean(samples, axis=0)
     samples_cov = np.cov(samples, rowvar=False)
 
-    np.testing.assert_array_almost_equal(samples_mean, [1., 1.], decimal=1)
-    np.testing.assert_array_almost_equal(samples_cov, [[1., 0.], [0., 1.]], decimal=1)
+    np.testing.assert_array_almost_equal(samples_mean, [1.0, 1.0], decimal=1)
+    np.testing.assert_array_almost_equal(
+        samples_cov, [[1.0, 0.0], [0.0, 1.0]], decimal=1
+    )
 
 
 @pytest.mark.parametrize("whiten", [True, False])
@@ -221,44 +259,58 @@ def test_sample_conditional(whiten, full_cov, full_output_cov):
 
     q_mu = tf.random.uniform((Data.M, Data.P), dtype=tf.float64)  # [M, P]
     q_sqrt = tf.convert_to_tensor(
-        [np.tril(tf.random.uniform((Data.M, Data.M), dtype=tf.float64)) for _ in range(Data.P)])  # [P, M, M]
+        [
+            np.tril(tf.random.uniform((Data.M, Data.M), dtype=tf.float64))
+            for _ in range(Data.P)
+        ]
+    )  # [P, M, M]
 
-    Z = Data.X[:Data.M, ...]  # [M, D]
+    Z = Data.X[: Data.M, ...]  # [M, D]
     Xs = np.ones((Data.N, Data.D), dtype=float_type)
 
     inducing_variable = InducingPoints(Z)
     kernel = SquaredExponential()
 
     # Path 1
-    value_f, mean_f, var_f = sample_conditional(Xs,
-                                                inducing_variable,
-                                                kernel,
-                                                q_mu,
-                                                q_sqrt=q_sqrt,
-                                                white=whiten,
-                                                full_cov=full_cov,
-                                                full_output_cov=full_output_cov,
-                                                num_samples=int(1e5))
+    value_f, mean_f, var_f = sample_conditional(
+        Xs,
+        inducing_variable,
+        kernel,
+        q_mu,
+        q_sqrt=q_sqrt,
+        white=whiten,
+        full_cov=full_cov,
+        full_output_cov=full_output_cov,
+        num_samples=int(1e5),
+    )
     value_f = value_f.numpy().reshape((-1,) + value_f.numpy().shape[2:])
 
     # Path 2
     if full_output_cov:
-        pytest.skip("sample_conditional with X instead of inducing_variable does not support full_output_cov")
+        pytest.skip(
+            "sample_conditional with X instead of inducing_variable does not support full_output_cov"
+        )
 
-    value_x, mean_x, var_x = sample_conditional(Xs,
-                                                Z,
-                                                kernel,
-                                                q_mu,
-                                                q_sqrt=q_sqrt,
-                                                white=whiten,
-                                                full_cov=full_cov,
-                                                full_output_cov=full_output_cov,
-                                                num_samples=int(1e5))
+    value_x, mean_x, var_x = sample_conditional(
+        Xs,
+        Z,
+        kernel,
+        q_mu,
+        q_sqrt=q_sqrt,
+        white=whiten,
+        full_cov=full_cov,
+        full_output_cov=full_output_cov,
+        num_samples=int(1e5),
+    )
     value_x = value_x.numpy().reshape((-1,) + value_x.numpy().shape[2:])
 
     # check if mean and covariance of samples are similar
-    np.testing.assert_array_almost_equal(np.mean(value_x, axis=0), np.mean(value_f, axis=0), decimal=1)
-    np.testing.assert_array_almost_equal(np.cov(value_x, rowvar=False), np.cov(value_f, rowvar=False), decimal=1)
+    np.testing.assert_array_almost_equal(
+        np.mean(value_x, axis=0), np.mean(value_f, axis=0), decimal=1
+    )
+    np.testing.assert_array_almost_equal(
+        np.cov(value_x, rowvar=False), np.cov(value_f, rowvar=False), decimal=1
+    )
     np.testing.assert_allclose(mean_x, mean_f)
     np.testing.assert_allclose(var_x, var_f)
 
@@ -266,33 +318,52 @@ def test_sample_conditional(whiten, full_cov, full_output_cov):
 def test_sample_conditional_mixedkernel():
     q_mu = tf.random.uniform((Data.M, Data.L), dtype=tf.float64)  # M x L
     q_sqrt = tf.convert_to_tensor(
-        [np.tril(tf.random.uniform((Data.M, Data.M), dtype=tf.float64)) for _ in range(Data.L)])  # L x M x M
+        [
+            np.tril(tf.random.uniform((Data.M, Data.M), dtype=tf.float64))
+            for _ in range(Data.L)
+        ]
+    )  # L x M x M
 
-    Z = Data.X[:Data.M, ...]  # M x D
+    Z = Data.X[: Data.M, ...]  # M x D
     N = int(10e5)
     Xs = np.ones((N, Data.D), dtype=float_type)
 
     # Path 1: mixed kernel: most efficient route
     W = np.random.randn(Data.P, Data.L)
-    mixed_kernel = mk.LinearCoregionalization([SquaredExponential() for _ in range(Data.L)], W)
+    mixed_kernel = mk.LinearCoregionalization(
+        [SquaredExponential() for _ in range(Data.L)], W
+    )
     optimal_inducing_variable = mf.SharedIndependentInducingVariables(InducingPoints(Z))
 
-    value, mean, var = sample_conditional(Xs, optimal_inducing_variable, mixed_kernel, q_mu, q_sqrt=q_sqrt, white=True)
+    value, mean, var = sample_conditional(
+        Xs, optimal_inducing_variable, mixed_kernel, q_mu, q_sqrt=q_sqrt, white=True
+    )
 
     # Path 2: independent kernels, mixed later
-    separate_kernel = mk.SeparateIndependent([SquaredExponential() for _ in range(Data.L)])
-    fallback_inducing_variable = mf.SharedIndependentInducingVariables(InducingPoints(Z))
+    separate_kernel = mk.SeparateIndependent(
+        [SquaredExponential() for _ in range(Data.L)]
+    )
+    fallback_inducing_variable = mf.SharedIndependentInducingVariables(
+        InducingPoints(Z)
+    )
 
-    value2, mean2, var2 = sample_conditional(Xs, fallback_inducing_variable, separate_kernel, q_mu, q_sqrt=q_sqrt,
-                                             white=True)
+    value2, mean2, var2 = sample_conditional(
+        Xs, fallback_inducing_variable, separate_kernel, q_mu, q_sqrt=q_sqrt, white=True
+    )
     value2 = np.matmul(value2, W.T)
     # check if mean and covariance of samples are similar
-    np.testing.assert_array_almost_equal(np.mean(value, axis=0), np.mean(value2, axis=0), decimal=1)
-    np.testing.assert_array_almost_equal(np.cov(value, rowvar=False), np.cov(value2, rowvar=False), decimal=1)
+    np.testing.assert_array_almost_equal(
+        np.mean(value, axis=0), np.mean(value2, axis=0), decimal=1
+    )
+    np.testing.assert_array_almost_equal(
+        np.cov(value, rowvar=False), np.cov(value2, rowvar=False), decimal=1
+    )
 
 
-@pytest.mark.parametrize('R', [1, 5])
-@pytest.mark.parametrize("func", [fully_correlated_conditional_repeat, fully_correlated_conditional])
+@pytest.mark.parametrize("R", [1, 5])
+@pytest.mark.parametrize(
+    "func", [fully_correlated_conditional_repeat, fully_correlated_conditional]
+)
 def test_fully_correlated_conditional_repeat_shapes(func, R):
     L, M, N, P = Data.L, Data.M, Data.N, Data.P
 
@@ -303,13 +374,24 @@ def test_fully_correlated_conditional_repeat_shapes(func, R):
     q_sqrt = None
     white = True
 
-    m, v = func(Kmn, Kmm, Knn, f, full_cov=False, full_output_cov=False, q_sqrt=q_sqrt, white=white)
+    m, v = func(
+        Kmn,
+        Kmm,
+        Knn,
+        f,
+        full_cov=False,
+        full_output_cov=False,
+        q_sqrt=q_sqrt,
+        white=white,
+    )
 
     assert v.shape.as_list() == m.shape.as_list()
+
 
 # ------------------------------------------
 # Test Mok Output Dims
 # ------------------------------------------
+
 
 def test_shapes_of_mok():
     data = DataMixedKernel
@@ -368,53 +450,96 @@ def test_shared_independent_mok():
     np.random.seed(0)
     # Model 1
     q_mu_1 = np.random.randn(Data.M * Data.P, 1)  # MP x 1
-    q_sqrt_1 = np.tril(np.random.randn(Data.M * Data.P, Data.M * Data.P))[None, ...]  # 1 x MP x MP
-    kernel_1 = mk.SharedIndependent(SquaredExponential(variance=0.5, lengthscale=1.2), Data.P)
-    inducing_variable = InducingPoints(Data.X[:Data.M, ...])
-    model_1 = SVGP(kernel_1, Gaussian(), inducing_variable, q_mu=q_mu_1, q_sqrt=q_sqrt_1, num_latent=Data.Y.shape[-1])
+    q_sqrt_1 = np.tril(np.random.randn(Data.M * Data.P, Data.M * Data.P))[
+        None, ...
+    ]  # 1 x MP x MP
+    kernel_1 = mk.SharedIndependent(
+        SquaredExponential(variance=0.5, lengthscale=1.2), Data.P
+    )
+    inducing_variable = InducingPoints(Data.X[: Data.M, ...])
+    model_1 = SVGP(
+        kernel_1,
+        Gaussian(),
+        inducing_variable,
+        q_mu=q_mu_1,
+        q_sqrt=q_sqrt_1,
+        num_latent=Data.Y.shape[-1],
+    )
     set_trainable(model_1, False)
     model_1.q_sqrt.trainable = True
 
     @tf.function
     def closure1():
-        return - model_1.log_marginal_likelihood(Data.data)
+        return -model_1.log_marginal_likelihood(Data.data)
 
-    gpflow.optimizers.Scipy().minimize(closure1, variables=model_1.trainable_variables, options=dict(maxiter=500),
-                                       method='BFGS')
-
+    gpflow.optimizers.Scipy().minimize(
+        closure1,
+        variables=model_1.trainable_variables,
+        options=dict(maxiter=500),
+        method="BFGS",
+    )
 
     # Model 2
     q_mu_2 = np.reshape(q_mu_1, [Data.M, Data.P])  # M x P
-    q_sqrt_2 = np.array([np.tril(np.random.randn(Data.M, Data.M)) for _ in range(Data.P)])  # P x M x M
+    q_sqrt_2 = np.array(
+        [np.tril(np.random.randn(Data.M, Data.M)) for _ in range(Data.P)]
+    )  # P x M x M
     kernel_2 = SquaredExponential(variance=0.5, lengthscale=1.2)
-    inducing_variable_2 = InducingPoints(Data.X[:Data.M, ...])
-    model_2 = SVGP(kernel_2, Gaussian(), inducing_variable_2, num_latent=Data.P, q_mu=q_mu_2, q_sqrt=q_sqrt_2)
+    inducing_variable_2 = InducingPoints(Data.X[: Data.M, ...])
+    model_2 = SVGP(
+        kernel_2,
+        Gaussian(),
+        inducing_variable_2,
+        num_latent=Data.P,
+        q_mu=q_mu_2,
+        q_sqrt=q_sqrt_2,
+    )
     set_trainable(model_2, False)
     model_2.q_sqrt.trainable = True
 
     @tf.function
     def closure2():
-        return - model_2.log_marginal_likelihood(Data.data)
+        return -model_2.log_marginal_likelihood(Data.data)
 
-    gpflow.optimizers.Scipy().minimize(closure2, variables=model_2.trainable_variables, options=dict(maxiter=500),
-                                       method='BFGS')
-
+    gpflow.optimizers.Scipy().minimize(
+        closure2,
+        variables=model_2.trainable_variables,
+        options=dict(maxiter=500),
+        method="BFGS",
+    )
 
     # Model 3
     q_mu_3 = np.reshape(q_mu_1, [Data.M, Data.P])  # M x P
-    q_sqrt_3 = np.array([np.tril(np.random.randn(Data.M, Data.M)) for _ in range(Data.P)])  # P x M x M
-    kernel_3 = mk.SharedIndependent(SquaredExponential(variance=0.5, lengthscale=1.2), Data.P)
-    inducing_variable_3 = mf.SharedIndependentInducingVariables(InducingPoints(Data.X[:Data.M, ...]))
-    model_3 = SVGP(kernel_3, Gaussian(), inducing_variable_3, num_latent=Data.P, q_mu=q_mu_3, q_sqrt=q_sqrt_3)
+    q_sqrt_3 = np.array(
+        [np.tril(np.random.randn(Data.M, Data.M)) for _ in range(Data.P)]
+    )  # P x M x M
+    kernel_3 = mk.SharedIndependent(
+        SquaredExponential(variance=0.5, lengthscale=1.2), Data.P
+    )
+    inducing_variable_3 = mf.SharedIndependentInducingVariables(
+        InducingPoints(Data.X[: Data.M, ...])
+    )
+    model_3 = SVGP(
+        kernel_3,
+        Gaussian(),
+        inducing_variable_3,
+        num_latent=Data.P,
+        q_mu=q_mu_3,
+        q_sqrt=q_sqrt_3,
+    )
     set_trainable(model_3, False)
     model_3.q_sqrt.trainable = True
 
     @tf.function
     def closure3():
-        return - model_3.log_marginal_likelihood(Data.data)
+        return -model_3.log_marginal_likelihood(Data.data)
 
-    gpflow.optimizers.Scipy().minimize(closure3, variables=model_3.trainable_variables, options=dict(maxiter=500),
-                                       method='BFGS')
+    gpflow.optimizers.Scipy().minimize(
+        closure3,
+        variables=model_3.trainable_variables,
+        options=dict(maxiter=500),
+        method="BFGS",
+    )
 
     check_equality_predictions(Data.data, [model_1, model_2, model_3])
 
@@ -430,38 +555,66 @@ def test_separate_independent_mok():
     """
     # Model 1 (Inefficient)
     q_mu_1 = np.random.randn(Data.M * Data.P, 1)
-    q_sqrt_1 = np.tril(np.random.randn(Data.M * Data.P, Data.M * Data.P))[None, ...]  # 1 x MP x MP
+    q_sqrt_1 = np.tril(np.random.randn(Data.M * Data.P, Data.M * Data.P))[
+        None, ...
+    ]  # 1 x MP x MP
 
-    kern_list_1 = [SquaredExponential(variance=0.5, lengthscale=1.2) for _ in range(Data.P)]
+    kern_list_1 = [
+        SquaredExponential(variance=0.5, lengthscale=1.2) for _ in range(Data.P)
+    ]
     kernel_1 = mk.SeparateIndependent(kern_list_1)
-    inducing_variable_1 = InducingPoints(Data.X[:Data.M, ...])
-    model_1 = SVGP(kernel_1, Gaussian(), inducing_variable_1, num_latent=1, q_mu=q_mu_1, q_sqrt=q_sqrt_1)
+    inducing_variable_1 = InducingPoints(Data.X[: Data.M, ...])
+    model_1 = SVGP(
+        kernel_1,
+        Gaussian(),
+        inducing_variable_1,
+        num_latent=1,
+        q_mu=q_mu_1,
+        q_sqrt=q_sqrt_1,
+    )
     set_trainable(model_1, False)
     model_1.q_sqrt.trainable = True
     model_1.q_mu.trainable = True
 
     @tf.function
     def closure1():
-        return - model_1.log_marginal_likelihood(Data.data)
+        return -model_1.log_marginal_likelihood(Data.data)
 
-    gpflow.optimizers.Scipy().minimize(closure1, variables=model_1.trainable_variables, method='BFGS')
+    gpflow.optimizers.Scipy().minimize(
+        closure1, variables=model_1.trainable_variables, method="BFGS"
+    )
 
     # Model 2 (efficient)
     q_mu_2 = np.random.randn(Data.M, Data.P)
-    q_sqrt_2 = np.array([np.tril(np.random.randn(Data.M, Data.M)) for _ in range(Data.P)])  # P x M x M
-    kern_list_2 = [SquaredExponential(variance=0.5, lengthscale=1.2) for _ in range(Data.P)]
+    q_sqrt_2 = np.array(
+        [np.tril(np.random.randn(Data.M, Data.M)) for _ in range(Data.P)]
+    )  # P x M x M
+    kern_list_2 = [
+        SquaredExponential(variance=0.5, lengthscale=1.2) for _ in range(Data.P)
+    ]
     kernel_2 = mk.SeparateIndependent(kern_list_2)
-    inducing_variable_2 = mf.SharedIndependentInducingVariables(InducingPoints(Data.X[:Data.M, ...]))
-    model_2 = SVGP(kernel_2, Gaussian(), inducing_variable_2, num_latent=Data.P, q_mu=q_mu_2, q_sqrt=q_sqrt_2)
+    inducing_variable_2 = mf.SharedIndependentInducingVariables(
+        InducingPoints(Data.X[: Data.M, ...])
+    )
+    model_2 = SVGP(
+        kernel_2,
+        Gaussian(),
+        inducing_variable_2,
+        num_latent=Data.P,
+        q_mu=q_mu_2,
+        q_sqrt=q_sqrt_2,
+    )
     set_trainable(model_2, False)
     model_2.q_sqrt.trainable = True
     model_2.q_mu.trainable = True
 
     @tf.function
     def closure2():
-        return - model_2.log_marginal_likelihood(Data.data)
+        return -model_2.log_marginal_likelihood(Data.data)
 
-    gpflow.optimizers.Scipy().minimize(closure2, variables=model_2.trainable_variables, method='BFGS')
+    gpflow.optimizers.Scipy().minimize(
+        closure2, variables=model_2.trainable_variables, method="BFGS"
+    )
 
     check_equality_predictions(Data.data, [model_1, model_2])
 
@@ -475,56 +628,88 @@ def test_separate_independent_mof():
 
     # Model 1 (INefficient)
     q_mu_1 = np.random.randn(Data.M * Data.P, 1)
-    q_sqrt_1 = np.tril(np.random.randn(Data.M * Data.P, Data.M * Data.P))[None, ...]  # 1 x MP x MP
+    q_sqrt_1 = np.tril(np.random.randn(Data.M * Data.P, Data.M * Data.P))[
+        None, ...
+    ]  # 1 x MP x MP
 
-    kernel_1 = mk.SharedIndependent(SquaredExponential(variance=0.5, lengthscale=1.2), Data.P)
-    inducing_variable_1 = InducingPoints(Data.X[:Data.M, ...])
-    model_1 = SVGP(kernel_1, Gaussian(), inducing_variable_1, q_mu=q_mu_1, q_sqrt=q_sqrt_1)
+    kernel_1 = mk.SharedIndependent(
+        SquaredExponential(variance=0.5, lengthscale=1.2), Data.P
+    )
+    inducing_variable_1 = InducingPoints(Data.X[: Data.M, ...])
+    model_1 = SVGP(
+        kernel_1, Gaussian(), inducing_variable_1, q_mu=q_mu_1, q_sqrt=q_sqrt_1
+    )
     set_trainable(model_1, False)
     model_1.q_sqrt.trainable = True
     model_1.q_mu.trainable = True
 
     @tf.function
     def closure1():
-        return - model_1.log_marginal_likelihood(Data.data)
+        return -model_1.log_marginal_likelihood(Data.data)
 
-    gpflow.optimizers.Scipy().minimize(closure1, variables=model_1.trainable_variables, method='BFGS')
+    gpflow.optimizers.Scipy().minimize(
+        closure1, variables=model_1.trainable_variables, method="BFGS"
+    )
 
     # Model 2 (efficient)
     q_mu_2 = np.random.randn(Data.M, Data.P)
-    q_sqrt_2 = np.array([np.tril(np.random.randn(Data.M, Data.M)) for _ in range(Data.P)])  # P x M x M
-    kernel_2 = mk.SharedIndependent(SquaredExponential(variance=0.5, lengthscale=1.2), Data.P)
-    inducing_variable_list_2 = [InducingPoints(Data.X[:Data.M, ...]) for _ in range(Data.P)]
-    inducing_variable_2 = mf.SeparateIndependentInducingVariables(inducing_variable_list_2)
-    model_2 = SVGP(kernel_2, Gaussian(), inducing_variable_2, q_mu=q_mu_2, q_sqrt=q_sqrt_2)
+    q_sqrt_2 = np.array(
+        [np.tril(np.random.randn(Data.M, Data.M)) for _ in range(Data.P)]
+    )  # P x M x M
+    kernel_2 = mk.SharedIndependent(
+        SquaredExponential(variance=0.5, lengthscale=1.2), Data.P
+    )
+    inducing_variable_list_2 = [
+        InducingPoints(Data.X[: Data.M, ...]) for _ in range(Data.P)
+    ]
+    inducing_variable_2 = mf.SeparateIndependentInducingVariables(
+        inducing_variable_list_2
+    )
+    model_2 = SVGP(
+        kernel_2, Gaussian(), inducing_variable_2, q_mu=q_mu_2, q_sqrt=q_sqrt_2
+    )
     set_trainable(model_2, False)
     model_2.q_sqrt.trainable = True
     model_2.q_mu.trainable = True
 
     @tf.function
     def closure2():
-        return - model_2.log_marginal_likelihood(Data.data)
+        return -model_2.log_marginal_likelihood(Data.data)
 
-    gpflow.optimizers.Scipy().minimize(closure2, variables=model_2.trainable_variables, method='BFGS')
+    gpflow.optimizers.Scipy().minimize(
+        closure2, variables=model_2.trainable_variables, method="BFGS"
+    )
 
     # Model 3 (Inefficient): an idenitical inducing variable is used P times,
     # and treated as a separate one.
     q_mu_3 = np.random.randn(Data.M, Data.P)
-    q_sqrt_3 = np.array([np.tril(np.random.randn(Data.M, Data.M)) for _ in range(Data.P)])  # P x M x M
-    kern_list = [SquaredExponential(variance=0.5, lengthscale=1.2) for _ in range(Data.P)]
+    q_sqrt_3 = np.array(
+        [np.tril(np.random.randn(Data.M, Data.M)) for _ in range(Data.P)]
+    )  # P x M x M
+    kern_list = [
+        SquaredExponential(variance=0.5, lengthscale=1.2) for _ in range(Data.P)
+    ]
     kernel_3 = mk.SeparateIndependent(kern_list)
-    inducing_variable_list_3 = [InducingPoints(Data.X[:Data.M, ...]) for _ in range(Data.P)]
-    inducing_variable_3 = mf.SeparateIndependentInducingVariables(inducing_variable_list_3)
-    model_3 = SVGP(kernel_3, Gaussian(), inducing_variable_3, q_mu=q_mu_3, q_sqrt=q_sqrt_3)
+    inducing_variable_list_3 = [
+        InducingPoints(Data.X[: Data.M, ...]) for _ in range(Data.P)
+    ]
+    inducing_variable_3 = mf.SeparateIndependentInducingVariables(
+        inducing_variable_list_3
+    )
+    model_3 = SVGP(
+        kernel_3, Gaussian(), inducing_variable_3, q_mu=q_mu_3, q_sqrt=q_sqrt_3
+    )
     set_trainable(model_3, False)
     model_3.q_sqrt.trainable = True
     model_3.q_mu.trainable = True
 
     @tf.function
     def closure3():
-        return - model_3.log_marginal_likelihood(Data.data)
+        return -model_3.log_marginal_likelihood(Data.data)
 
-    gpflow.optimizers.Scipy().minimize(closure3, variables=model_3.trainable_variables, method='BFGS')
+    gpflow.optimizers.Scipy().minimize(
+        closure3, variables=model_3.trainable_variables, method="BFGS"
+    )
 
     check_equality_predictions(Data.data, [model_1, model_2, model_3])
 
@@ -533,30 +718,40 @@ def test_mixed_mok_with_Id_vs_independent_mok():
     data = DataMixedKernelWithEye
     # Independent model
     k1 = mk.SharedIndependent(SquaredExponential(variance=0.5, lengthscale=1.2), data.L)
-    f1 = InducingPoints(data.X[:data.M, ...])
-    model_1 = SVGP(k1, Gaussian(), f1, q_mu=data.mu_data_full, q_sqrt=data.sqrt_data_full)
+    f1 = InducingPoints(data.X[: data.M, ...])
+    model_1 = SVGP(
+        k1, Gaussian(), f1, q_mu=data.mu_data_full, q_sqrt=data.sqrt_data_full
+    )
     set_trainable(model_1, False)
     model_1.q_sqrt.trainable = True
 
     @tf.function
     def closure1():
-        return - model_1.log_marginal_likelihood(Data.data)
+        return -model_1.log_marginal_likelihood(Data.data)
 
-    gpflow.optimizers.Scipy().minimize(closure1, variables=model_1.trainable_variables, method='BFGS')
+    gpflow.optimizers.Scipy().minimize(
+        closure1, variables=model_1.trainable_variables, method="BFGS"
+    )
 
     # Mixed Model
-    kern_list = [SquaredExponential(variance=0.5, lengthscale=1.2) for _ in range(data.L)]
+    kern_list = [
+        SquaredExponential(variance=0.5, lengthscale=1.2) for _ in range(data.L)
+    ]
     k2 = mk.LinearCoregionalization(kern_list, data.W)
-    f2 = InducingPoints(data.X[:data.M, ...])
-    model_2 = SVGP(k2, Gaussian(), f2, q_mu=data.mu_data_full, q_sqrt=data.sqrt_data_full)
+    f2 = InducingPoints(data.X[: data.M, ...])
+    model_2 = SVGP(
+        k2, Gaussian(), f2, q_mu=data.mu_data_full, q_sqrt=data.sqrt_data_full
+    )
     set_trainable(model_2, False)
     model_2.q_sqrt.trainable = True
 
     @tf.function
     def closure2():
-        return - model_2.log_marginal_likelihood(Data.data)
+        return -model_2.log_marginal_likelihood(Data.data)
 
-    gpflow.optimizers.Scipy().minimize(closure2, variables=model_2.trainable_variables, method='BFGS')
+    gpflow.optimizers.Scipy().minimize(
+        closure2, variables=model_2.trainable_variables, method="BFGS"
+    )
 
     check_equality_predictions(Data.data, [model_1, model_2])
 
@@ -566,13 +761,17 @@ def test_compare_mixed_kernel():
 
     kern_list = [SquaredExponential() for _ in range(data.L)]
     k1 = mk.LinearCoregionalization(kern_list, W=data.W)
-    f1 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[:data.M, ...]))
-    model_1 = SVGP(k1, Gaussian(), inducing_variable=f1, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
+    f1 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[: data.M, ...]))
+    model_1 = SVGP(
+        k1, Gaussian(), inducing_variable=f1, q_mu=data.mu_data, q_sqrt=data.sqrt_data
+    )
 
     kern_list = [SquaredExponential() for _ in range(data.L)]
     k2 = mk.LinearCoregionalization(kern_list, W=data.W)
-    f2 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[:data.M, ...]))
-    model_2 = SVGP(k2, Gaussian(), inducing_variable=f2, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
+    f2 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[: data.M, ...]))
+    model_2 = SVGP(
+        k2, Gaussian(), inducing_variable=f2, q_mu=data.mu_data, q_sqrt=data.sqrt_data
+    )
 
     check_equality_predictions(Data.data, [model_1, model_2])
 
@@ -585,13 +784,27 @@ def test_multioutput_with_diag_q_sqrt():
 
     kern_list = [SquaredExponential() for _ in range(data.L)]
     k1 = mk.LinearCoregionalization(kern_list, W=data.W)
-    f1 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[:data.M, ...]))
-    model_1 = SVGP(k1, Gaussian(), inducing_variable=f1, q_mu=data.mu_data, q_sqrt=q_sqrt_diag, q_diag=True)
+    f1 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[: data.M, ...]))
+    model_1 = SVGP(
+        k1,
+        Gaussian(),
+        inducing_variable=f1,
+        q_mu=data.mu_data,
+        q_sqrt=q_sqrt_diag,
+        q_diag=True,
+    )
 
     kern_list = [SquaredExponential() for _ in range(data.L)]
     k2 = mk.LinearCoregionalization(kern_list, W=data.W)
-    f2 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[:data.M, ...]))
-    model_2 = SVGP(k2, Gaussian(), inducing_variable=f2, q_mu=data.mu_data, q_sqrt=q_sqrt, q_diag=False)
+    f2 = mf.SharedIndependentInducingVariables(InducingPoints(data.X[: data.M, ...]))
+    model_2 = SVGP(
+        k2,
+        Gaussian(),
+        inducing_variable=f2,
+        q_mu=data.mu_data,
+        q_sqrt=q_sqrt,
+        q_diag=False,
+    )
 
     check_equality_predictions(Data.data, [model_1, model_2])
 
@@ -600,15 +813,23 @@ def test_MixedKernelSeparateMof():
     data = DataMixedKernel
 
     kern_list = [SquaredExponential() for _ in range(data.L)]
-    inducing_variable_list = [InducingPoints(data.X[:data.M, ...]) for _ in range(data.L)]
+    inducing_variable_list = [
+        InducingPoints(data.X[: data.M, ...]) for _ in range(data.L)
+    ]
     k1 = mk.LinearCoregionalization(kern_list, W=data.W)
     f1 = mf.SeparateIndependentInducingVariables(inducing_variable_list)
-    model_1 = SVGP(k1, Gaussian(), inducing_variable=f1, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
+    model_1 = SVGP(
+        k1, Gaussian(), inducing_variable=f1, q_mu=data.mu_data, q_sqrt=data.sqrt_data
+    )
 
     kern_list = [SquaredExponential() for _ in range(data.L)]
-    inducing_variable_list = [InducingPoints(data.X[:data.M, ...]) for _ in range(data.L)]
+    inducing_variable_list = [
+        InducingPoints(data.X[: data.M, ...]) for _ in range(data.L)
+    ]
     k2 = mk.LinearCoregionalization(kern_list, W=data.W)
     f2 = mf.SeparateIndependentInducingVariables(inducing_variable_list)
-    model_2 = SVGP(k2, Gaussian(), inducing_variable=f2, q_mu=data.mu_data, q_sqrt=data.sqrt_data)
+    model_2 = SVGP(
+        k2, Gaussian(), inducing_variable=f2, q_mu=data.mu_data, q_sqrt=data.sqrt_data
+    )
 
     check_equality_predictions(Data.data, [model_1, model_2])

--- a/tests/gpflow/conditionals/test_uncertain_conditional.py
+++ b/tests/gpflow/conditionals/test_uncertain_conditional.py
@@ -37,21 +37,25 @@ rng = np.random.RandomState(1)
 
 class MomentMatchingSVGP(gpflow.models.SVGP):
     def uncertain_predict_f_moment_matching(self, Xmu, Xcov):
-        return uncertain_conditional(Xmu,
-                                     Xcov,
-                                     self.inducing_variable,
-                                     self.kernel,
-                                     self.q_mu,
-                                     self.q_sqrt,
-                                     mean_function=self.mean_function,
-                                     white=self.whiten,
-                                     full_output_cov=self.full_output_cov)
+        return uncertain_conditional(
+            Xmu,
+            Xcov,
+            self.inducing_variable,
+            self.kernel,
+            self.q_mu,
+            self.q_sqrt,
+            mean_function=self.mean_function,
+            white=self.whiten,
+            full_output_cov=self.full_output_cov,
+        )
 
     def uncertain_predict_f_monte_carlo(self, Xmu, Xchol, mc_iter=int(1e6)):
         D_in = Xchol.shape[0]
-        X_samples = Xmu + np.reshape(Xchol[None, :, :] @ rng.randn(mc_iter, D_in)[:, :, None], [mc_iter, D_in])
+        X_samples = Xmu + np.reshape(
+            Xchol[None, :, :] @ rng.randn(mc_iter, D_in)[:, :, None], [mc_iter, D_in]
+        )
         F_mu, F_var = self.predict_f(X_samples)
-        F_samples = (F_mu + rng.randn(*F_var.shape) * (F_var**0.5)).numpy()
+        F_samples = (F_mu + rng.randn(*F_var.shape) * (F_var ** 0.5)).numpy()
         mean = np.mean(F_samples, axis=0)
         covar = np.cov(F_samples.T)
         return mean, covar
@@ -62,9 +66,10 @@ def gen_L(n, *shape):
 
 
 def gen_q_sqrt(D_out, *shape):
-    return tf.convert_to_tensor(np.array(
-        [np.tril(rng.randn(*shape)) for _ in range(D_out)]
-        ), dtype=default_float())
+    return tf.convert_to_tensor(
+        np.array([np.tril(rng.randn(*shape)) for _ in range(D_out)]),
+        dtype=default_float(),
+    )
 
 
 def mean_function_factory(mean_function_name, D_in, D_out):
@@ -89,14 +94,14 @@ class Data:
     D_out = 3
     D_in = 1
     X = np.linspace(-5, 5, N)[:, None] + rng.randn(N, 1)
-    Y = np.hstack([np.sin(X), np.cos(X), X**2])
+    Y = np.hstack([np.sin(X), np.cos(X), X ** 2])
     Xnew_mu = rng.randn(N_new, 1)
     Xnew_covar = np.zeros((N_new, 1, 1))
     data = (X, Y)
 
 
 class DataMC1(Data):
-    Y = np.hstack([np.sin(Data.X), np.sin(Data.X) * 2, Data.X**2])
+    Y = np.hstack([np.sin(Data.X), np.sin(Data.X) * 2, Data.X ** 2])
     data = (Data.X, Y)
 
 
@@ -130,92 +135,120 @@ class DataQuad:
 MEANS = ["Constant", "Linear", "Zero", None]
 
 
-@pytest.mark.parametrize('white', [True, False])
-@pytest.mark.parametrize('mean', MEANS)
+@pytest.mark.parametrize("white", [True, False])
+@pytest.mark.parametrize("mean", MEANS)
 def test_no_uncertainty(white, mean):
     mean_function = mean_function_factory(mean, Data.D_in, Data.D_out)
     kernel = gpflow.kernels.SquaredExponential(variance=rng.rand())
-    model = MomentMatchingSVGP(kernel,
-                               gpflow.likelihoods.Gaussian(),
-                               num_latent=Data.D_out,
-                               mean_function=mean_function,
-                               inducing_variable=Data.X.copy(),
-                               whiten=white)
+    model = MomentMatchingSVGP(
+        kernel,
+        gpflow.likelihoods.Gaussian(),
+        num_latent=Data.D_out,
+        mean_function=mean_function,
+        inducing_variable=Data.X.copy(),
+        whiten=white,
+    )
     model.full_output_cov = False
 
     @tf.function
     def closure():
-        return - model.log_marginal_likelihood(Data.data)
+        return -model.log_marginal_likelihood(Data.data)
 
-    training_loop(closure, optimizer=tf.optimizers.Adam(), var_list=model.trainable_variables, maxiter=100)
+    training_loop(
+        closure,
+        optimizer=tf.optimizers.Adam(),
+        var_list=model.trainable_variables,
+        maxiter=100,
+    )
 
     mean1, var1 = model.predict_f(Data.Xnew_mu)
     mean2, var2 = model.uncertain_predict_f_moment_matching(
-        *map(tf.convert_to_tensor, [Data.Xnew_mu, Data.Xnew_covar]))
+        *map(tf.convert_to_tensor, [Data.Xnew_mu, Data.Xnew_covar])
+    )
 
     assert_allclose(mean1, mean2)
     for n in range(Data.N_new):
         assert_allclose(var1[n, :], var2[n, ...])
 
 
-@pytest.mark.parametrize('white', [True, False])
-@pytest.mark.parametrize('mean', MEANS)
+@pytest.mark.parametrize("white", [True, False])
+@pytest.mark.parametrize("mean", MEANS)
 def test_monte_carlo_1_din(white, mean):
     kernel = gpflow.kernels.SquaredExponential(variance=rng.rand())
     mean_function = mean_function_factory(mean, DataMC1.D_in, DataMC1.D_out)
-    model = MomentMatchingSVGP(kernel,
-                               gpflow.likelihoods.Gaussian(),
-                               num_latent=DataMC1.D_out,
-                               mean_function=mean_function,
-                               inducing_variable=DataMC1.X.copy(),
-                               whiten=white)
+    model = MomentMatchingSVGP(
+        kernel,
+        gpflow.likelihoods.Gaussian(),
+        num_latent=DataMC1.D_out,
+        mean_function=mean_function,
+        inducing_variable=DataMC1.X.copy(),
+        whiten=white,
+    )
     model.full_output_cov = True
 
     @tf.function
     def closure():
-        return - model.log_marginal_likelihood(DataMC1.data)
+        return -model.log_marginal_likelihood(DataMC1.data)
 
-    training_loop(closure, optimizer=tf.optimizers.Adam(), var_list=model.trainable_variables, maxiter=200)
+    training_loop(
+        closure,
+        optimizer=tf.optimizers.Adam(),
+        var_list=model.trainable_variables,
+        maxiter=200,
+    )
 
     mean1, var1 = model.uncertain_predict_f_moment_matching(
-        *map(tf.convert_to_tensor, [DataMC1.Xnew_mu, DataMC1.Xnew_covar]))
+        *map(tf.convert_to_tensor, [DataMC1.Xnew_mu, DataMC1.Xnew_covar])
+    )
 
     for n in range(DataMC1.N_new):
-        mean2, var2 = model.uncertain_predict_f_monte_carlo(DataMC1.Xnew_mu[n, ...], DataMC1.Xnew_covar[n, ...]**0.5)
+        mean2, var2 = model.uncertain_predict_f_monte_carlo(
+            DataMC1.Xnew_mu[n, ...], DataMC1.Xnew_covar[n, ...] ** 0.5
+        )
         assert_allclose(mean1[n, ...], mean2, atol=1e-3, rtol=1e-1)
         assert_allclose(var1[n, ...], var2, atol=1e-2, rtol=1e-1)
 
 
-@pytest.mark.parametrize('white', [True, False])
-@pytest.mark.parametrize('mean', MEANS)
+@pytest.mark.parametrize("white", [True, False])
+@pytest.mark.parametrize("mean", MEANS)
 def test_monte_carlo_2_din(white, mean):
     kernel = gpflow.kernels.SquaredExponential(variance=rng.rand())
     mean_function = mean_function_factory(mean, DataMC2.D_in, DataMC2.D_out)
-    model = MomentMatchingSVGP(kernel,
-                               gpflow.likelihoods.Gaussian(),
-                               num_latent=DataMC2.D_out,
-                               mean_function=mean_function,
-                               inducing_variable=DataMC2.X.copy(),
-                               whiten=white)
+    model = MomentMatchingSVGP(
+        kernel,
+        gpflow.likelihoods.Gaussian(),
+        num_latent=DataMC2.D_out,
+        mean_function=mean_function,
+        inducing_variable=DataMC2.X.copy(),
+        whiten=white,
+    )
     model.full_output_cov = True
 
     @tf.function
     def closure():
-        return - model.log_marginal_likelihood(DataMC2.data)
+        return -model.log_marginal_likelihood(DataMC2.data)
 
-    training_loop(closure, optimizer=tf.optimizers.Adam(), var_list=model.trainable_variables, maxiter=100)
+    training_loop(
+        closure,
+        optimizer=tf.optimizers.Adam(),
+        var_list=model.trainable_variables,
+        maxiter=100,
+    )
 
     mean1, var1 = model.uncertain_predict_f_moment_matching(
-        *map(tf.convert_to_tensor, [DataMC2.Xnew_mu, DataMC2.Xnew_covar]))
+        *map(tf.convert_to_tensor, [DataMC2.Xnew_mu, DataMC2.Xnew_covar])
+    )
 
     for n in range(DataMC2.N_new):
-        mean2, var2 = model.uncertain_predict_f_monte_carlo(DataMC2.Xnew_mu[n, ...], DataMC2.L[n, ...])
+        mean2, var2 = model.uncertain_predict_f_monte_carlo(
+            DataMC2.Xnew_mu[n, ...], DataMC2.L[n, ...]
+        )
         assert_allclose(mean1[n, ...], mean2, atol=1e-2)
         assert_allclose(var1[n, ...], var2, atol=1e-2)
 
 
-@pytest.mark.parametrize('mean', MEANS)
-@pytest.mark.parametrize('white', [True, False])
+@pytest.mark.parametrize("mean", MEANS)
+@pytest.mark.parametrize("white", [True, False])
 def test_quadrature(white, mean):
     kernel = gpflow.kernels.SquaredExponential()
     inducing_variable = gpflow.inducing_variables.InducingPoints(DataQuad.Z)
@@ -224,7 +257,14 @@ def test_quadrature(white, mean):
     effective_mean = mean_function or (lambda X: 0.0)
 
     def conditional_fn(X):
-        return conditional(X, inducing_variable, kernel, DataQuad.q_mu, q_sqrt=DataQuad.q_sqrt, white=white)
+        return conditional(
+            X,
+            inducing_variable,
+            kernel,
+            DataQuad.q_mu,
+            q_sqrt=DataQuad.q_sqrt,
+            white=white,
+        )
 
     def mean_fn(X):
         return conditional_fn(X)[0] + effective_mean(X)
@@ -232,25 +272,33 @@ def test_quadrature(white, mean):
     def var_fn(X):
         return conditional_fn(X)[1]
 
-    quad_args = DataQuad.Xmu, DataQuad.Xvar, DataQuad.H, DataQuad.D_in, (DataQuad.D_out,)
+    quad_args = (
+        DataQuad.Xmu,
+        DataQuad.Xvar,
+        DataQuad.H,
+        DataQuad.D_in,
+        (DataQuad.D_out,),
+    )
     mean_quad = mvnquad(mean_fn, *quad_args)
     var_quad = mvnquad(var_fn, *quad_args)
 
     def mean_sq_fn(X):
-        return mean_fn(X)**2
+        return mean_fn(X) ** 2
 
     mean_sq_quad = mvnquad(mean_sq_fn, *quad_args)
-    var_quad = var_quad + (mean_sq_quad - mean_quad**2)
+    var_quad = var_quad + (mean_sq_quad - mean_quad ** 2)
 
-    mean_analytic, var_analytic = uncertain_conditional(DataQuad.Xmu,
-                                                        DataQuad.Xvar,
-                                                        inducing_variable,
-                                                        kernel,
-                                                        DataQuad.q_mu,
-                                                        DataQuad.q_sqrt,
-                                                        mean_function=mean_function,
-                                                        full_output_cov=False,
-                                                        white=white)
+    mean_analytic, var_analytic = uncertain_conditional(
+        DataQuad.Xmu,
+        DataQuad.Xvar,
+        inducing_variable,
+        kernel,
+        DataQuad.q_mu,
+        DataQuad.q_sqrt,
+        mean_function=mean_function,
+        full_output_cov=False,
+        white=white,
+    )
 
     assert_allclose(mean_quad, mean_analytic, rtol=1e-6)
     assert_allclose(var_quad, var_analytic, rtol=1e-6)

--- a/tests/gpflow/config/test_config.py
+++ b/tests/gpflow/config/test_config.py
@@ -68,10 +68,13 @@ def test_env_variables_failures(attr_name):
             gpflow.config.Config()
 
 
-@pytest.mark.parametrize('getter, setter, valid_type_1, valid_type_2', [
-    (default_int, set_default_int, tf.int64, np.int32),
-    (default_float, set_default_float, tf.float32, np.float64),
-])
+@pytest.mark.parametrize(
+    "getter, setter, valid_type_1, valid_type_2",
+    [
+        (default_int, set_default_int, tf.int64, np.int32),
+        (default_float, set_default_float, tf.float32, np.float64),
+    ],
+)
 def test_dtype_setting(getter, setter, valid_type_1, valid_type_2):
     if valid_type_1 == valid_type_2:
         raise ValueError("cannot test config setting/getting when both types are equal")
@@ -81,12 +84,15 @@ def test_dtype_setting(getter, setter, valid_type_1, valid_type_2):
     assert getter() == valid_type_2
 
 
-@pytest.mark.parametrize('setter, invalid_type', [
-    (set_default_int, str),
-    (set_default_int, np.float64),
-    (set_default_float, list),
-    (set_default_float, tf.int32),
-])
+@pytest.mark.parametrize(
+    "setter, invalid_type",
+    [
+        (set_default_int, str),
+        (set_default_int, np.float64),
+        (set_default_float, list),
+        (set_default_float, tf.int32),
+    ],
+)
 def test_dtype_errorcheck(setter, invalid_type):
     with pytest.raises(TypeError):
         setter(invalid_type)
@@ -106,10 +112,13 @@ def test_jitter_errorcheck():
         set_default_jitter(-1e-10)
 
 
-@pytest.mark.parametrize("value, error_msg", [
-    ("Unknown", r"`unknown` not in set of valid bijectors: \['exp', 'softplus'\]"),
-    (1.0, r"`1.0` not in set of valid bijectors: \['exp', 'softplus'\]"),
-])
+@pytest.mark.parametrize(
+    "value, error_msg",
+    [
+        ("Unknown", r"`unknown` not in set of valid bijectors: \['exp', 'softplus'\]"),
+        (1.0, r"`1.0` not in set of valid bijectors: \['exp', 'softplus'\]"),
+    ],
+)
 def test_positive_bijector_error(value, error_msg):
     with pytest.raises(ValueError, match=error_msg):
         set_default_positive_bijector(value)
@@ -133,16 +142,37 @@ def test_default_summary_fmt_errorcheck():
         set_default_summary_fmt("this_format_definitely_does_not_exist")
 
 
-@pytest.mark.parametrize('setter, getter, converter, dtype, value', [
-    (set_default_int, default_int, to_default_int, np.int32, 3),
-    (set_default_int, default_int, to_default_int, tf.int32, 3),
-    (set_default_int, default_int, to_default_int, tf.int64, [3, 1, 4, 1, 5, 9]),
-    (set_default_int, default_int, to_default_int, np.int64, [3, 1, 4, 1, 5, 9]),
-    (set_default_float, default_float, to_default_float, np.float32, 3.14159),
-    (set_default_float, default_float, to_default_float, tf.float32, [3.14159, 3.14159, 3.14159]),
-    (set_default_float, default_float, to_default_float, np.float64, [3.14159, 3.14159, 3.14159]),
-    (set_default_float, default_float, to_default_float, tf.float64, [3.14159, 3.14159, 3.14159]),
-])
+@pytest.mark.parametrize(
+    "setter, getter, converter, dtype, value",
+    [
+        (set_default_int, default_int, to_default_int, np.int32, 3),
+        (set_default_int, default_int, to_default_int, tf.int32, 3),
+        (set_default_int, default_int, to_default_int, tf.int64, [3, 1, 4, 1, 5, 9]),
+        (set_default_int, default_int, to_default_int, np.int64, [3, 1, 4, 1, 5, 9]),
+        (set_default_float, default_float, to_default_float, np.float32, 3.14159),
+        (
+            set_default_float,
+            default_float,
+            to_default_float,
+            tf.float32,
+            [3.14159, 3.14159, 3.14159],
+        ),
+        (
+            set_default_float,
+            default_float,
+            to_default_float,
+            np.float64,
+            [3.14159, 3.14159, 3.14159],
+        ),
+        (
+            set_default_float,
+            default_float,
+            to_default_float,
+            tf.float64,
+            [3.14159, 3.14159, 3.14159],
+        ),
+    ],
+)
 def test_native_to_default_dtype(setter, getter, converter, dtype, value):
     with gpflow.config.as_context():
         setter(dtype)

--- a/tests/gpflow/covariances/test_base_covariances.py
+++ b/tests/gpflow/covariances/test_base_covariances.py
@@ -21,7 +21,7 @@ from gpflow.covariances import Kuu, Kuf
 from gpflow.config import default_jitter
 
 
-@pytest.mark.parametrize('N, D', [[17, 3], [10, 7]])
+@pytest.mark.parametrize("N, D", [[17, 3], [10, 7]])
 def test_inducing_points_inducing_variable_len(N, D):
     Z = np.random.randn(N, D)
     inducing_variable = InducingPoints(Z)
@@ -29,15 +29,17 @@ def test_inducing_points_inducing_variable_len(N, D):
 
 
 _kernel_setups = [
-    gpflow.kernels.SquaredExponential(variance=0.46,
-                                      lengthscale=np.random.uniform(0.5, 3., 5)),
-    gpflow.kernels.Periodic(base=gpflow.kernels.SquaredExponential(variance=1.8),
-                            period=0.4)
+    gpflow.kernels.SquaredExponential(
+        variance=0.46, lengthscale=np.random.uniform(0.5, 3.0, 5)
+    ),
+    gpflow.kernels.Periodic(
+        base=gpflow.kernels.SquaredExponential(variance=1.8), period=0.4
+    ),
 ]
 
 
-@pytest.mark.parametrize('N', [10, 101])
-@pytest.mark.parametrize('kernel', _kernel_setups)
+@pytest.mark.parametrize("N", [10, 101])
+@pytest.mark.parametrize("kernel", _kernel_setups)
 def test_inducing_equivalence(N, kernel):
     # Inducing inducing must be the same as the kernel evaluations
     Z = np.random.randn(N, 5)
@@ -45,24 +47,30 @@ def test_inducing_equivalence(N, kernel):
     assert_allclose(Kuu(inducing_variable, kernel), kernel(Z))
 
 
-@pytest.mark.parametrize('N, M, D', [[23, 13, 3], [10, 5, 7]])
+@pytest.mark.parametrize("N, M, D", [[23, 13, 3], [10, 5, 7]])
 def test_multi_scale_inducing_equivalence_inducing_points(N, M, D):
     # Multiscale must be equivalent to inducing points when variance is zero
     Xnew, Z = np.random.randn(N, D), np.random.randn(M, D)
-    rbf = gpflow.kernels.SquaredExponential(1.3441, lengthscale=np.random.uniform(0.5, 3., D))
+    rbf = gpflow.kernels.SquaredExponential(
+        1.3441, lengthscale=np.random.uniform(0.5, 3.0, D)
+    )
     inducing_variable_zero_lengthscale = Multiscale(Z, scales=np.zeros(Z.shape) + 1e-10)
     inducing_variable_inducing_point = InducingPoints(Z)
 
     multi_scale_Kuf = Kuf(inducing_variable_zero_lengthscale, rbf, Xnew)
     inducing_point_Kuf = Kuf(inducing_variable_inducing_point, rbf, Xnew)
 
-    relative_error_Kuf = np.abs(multi_scale_Kuf - inducing_point_Kuf) / inducing_point_Kuf
+    relative_error_Kuf = (
+        np.abs(multi_scale_Kuf - inducing_point_Kuf) / inducing_point_Kuf
+    )
     assert np.max(relative_error_Kuf) < 0.1e-2  # 0.1 %
 
     multi_scale_Kuu = Kuu(inducing_variable_zero_lengthscale, rbf)
     inducing_point_Kuu = Kuu(inducing_variable_inducing_point, rbf)
 
-    relative_error_Kuu = np.abs(multi_scale_Kuu - inducing_point_Kuu) / inducing_point_Kuu
+    relative_error_Kuu = (
+        np.abs(multi_scale_Kuu - inducing_point_Kuu) / inducing_point_Kuu
+    )
     assert np.max(relative_error_Kuu) < 0.1e-2  # 0.1 %
 
 
@@ -70,31 +78,37 @@ _inducing_variables_and_kernels = [
     [
         2,
         InducingPoints(np.random.randn(71, 2)),
-        gpflow.kernels.SquaredExponential(variance=1.84,
-                                          lengthscale=np.random.uniform(0.5, 3., 2))
+        gpflow.kernels.SquaredExponential(
+            variance=1.84, lengthscale=np.random.uniform(0.5, 3.0, 2)
+        ),
     ],
     [
         2,
         InducingPoints(np.random.randn(71, 2)),
-        gpflow.kernels.Matern12(variance=1.84,
-                                lengthscale=np.random.uniform(0.5, 3., 2))
+        gpflow.kernels.Matern12(
+            variance=1.84, lengthscale=np.random.uniform(0.5, 3.0, 2)
+        ),
     ],
     [
         2,
-        Multiscale(np.random.randn(71, 2),
-                   np.random.uniform(0.5, 3, size=(71, 2))),
-        gpflow.kernels.SquaredExponential(variance=1.84,
-                                          lengthscale=np.random.uniform(0.5, 3., 2))
+        Multiscale(np.random.randn(71, 2), np.random.uniform(0.5, 3, size=(71, 2))),
+        gpflow.kernels.SquaredExponential(
+            variance=1.84, lengthscale=np.random.uniform(0.5, 3.0, 2)
+        ),
     ],
     [
         9,
         InducingPatches(np.random.randn(71, 4)),
-        gpflow.kernels.Convolutional(gpflow.kernels.SquaredExponential(), [3, 3], [2, 2])
-    ]
+        gpflow.kernels.Convolutional(
+            gpflow.kernels.SquaredExponential(), [3, 3], [2, 2]
+        ),
+    ],
 ]
 
 
-@pytest.mark.parametrize('input_dim, inducing_variable, kernel', _inducing_variables_and_kernels)
+@pytest.mark.parametrize(
+    "input_dim, inducing_variable, kernel", _inducing_variables_and_kernels
+)
 def test_inducing_variables_psd_schur(input_dim, inducing_variable, kernel):
     # Conditional variance must be PSD.
     X = np.random.randn(5, input_dim)

--- a/tests/gpflow/covariances/test_multioutput.py
+++ b/tests/gpflow/covariances/test_multioutput.py
@@ -24,7 +24,7 @@ def make_kernels(num):
 
 def make_ip():
     x = rng.permutation(Datum.X)
-    return gpflow.inducing_variables.InducingPoints(x[:Datum.M, ...])
+    return gpflow.inducing_variables.InducingPoints(x[: Datum.M, ...])
 
 
 def make_ips(num):
@@ -49,30 +49,30 @@ class Datum:
 
 multioutput_inducing_variable_list = [
     mf.SharedIndependentInducingVariables(make_ip()),
-    mf.SeparateIndependentInducingVariables(make_ips(Datum.P))
+    mf.SeparateIndependentInducingVariables(make_ips(Datum.P)),
 ]
 
 multioutput_kernel_list = [
     mk.SharedIndependent(make_kernel(), Datum.P),
     mk.SeparateIndependent(make_kernels(Datum.L)),
-    mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W)
+    mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W),
 ]
 
 
-@pytest.mark.parametrize('inducing_variable', multioutput_inducing_variable_list)
-@pytest.mark.parametrize('kernel', multioutput_kernel_list)
+@pytest.mark.parametrize("inducing_variable", multioutput_inducing_variable_list)
+@pytest.mark.parametrize("kernel", multioutput_kernel_list)
 def test_kuu(inducing_variable, kernel):
     Kuu = mo_kuus.Kuu(inducing_variable, kernel, jitter=1e-9)
     tf.linalg.cholesky(Kuu)
 
 
-@pytest.mark.parametrize('inducing_variable', multioutput_inducing_variable_list)
-@pytest.mark.parametrize('kernel', multioutput_kernel_list)
+@pytest.mark.parametrize("inducing_variable", multioutput_inducing_variable_list)
+@pytest.mark.parametrize("kernel", multioutput_kernel_list)
 def test_kuf(inducing_variable, kernel):
     Kuf = mo_kufs.Kuf(inducing_variable, kernel, Datum.Xnew)
 
 
-@pytest.mark.parametrize('fun', [mo_kuus.Kuu, mo_kufs.Kuf])
+@pytest.mark.parametrize("fun", [mo_kuus.Kuu, mo_kufs.Kuf])
 def test_mixed_shared(fun):
     inducing_variable = mf.SharedIndependentInducingVariables(make_ip())
     kernel = mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W)

--- a/tests/gpflow/expectations/test_expectations.py
+++ b/tests/gpflow/expectations/test_expectations.py
@@ -23,8 +23,7 @@ from gpflow import inducing_variables, kernels
 from gpflow import mean_functions as mf
 from gpflow.config import default_float
 from gpflow.expectations import expectation, quadrature_expectation
-from gpflow.probability_distributions import (DiagonalGaussian, Gaussian,
-                                              MarkovGaussian)
+from gpflow.probability_distributions import DiagonalGaussian, Gaussian, MarkovGaussian
 
 rng = np.random.RandomState(1)
 RTOL = 1e-6
@@ -42,75 +41,74 @@ Z = rng.randn(num_ind, D_in)
 
 
 def markov_gauss():
-    cov_params = rng.randn(num_data + 1, D_in, 2 * D_in) / 2.  # (N+1)xDx2D
+    cov_params = rng.randn(num_data + 1, D_in, 2 * D_in) / 2.0  # (N+1)xDx2D
     Xcov = cov_params @ np.transpose(cov_params, (0, 2, 1))  # (N+1)xDxD
     Xcross = cov_params[:-1] @ np.transpose(cov_params[1:], (0, 2, 1))  # NxDxD
-    Xcross = np.concatenate((Xcross, np.zeros((1, D_in, D_in))),
-                            0)  # (N+1)xDxD
+    Xcross = np.concatenate((Xcross, np.zeros((1, D_in, D_in))), 0)  # (N+1)xDxD
     Xcov = np.stack([Xcov, Xcross])  # 2x(N+1)xDxD
     return MarkovGaussian(Xmu_markov, ctt(Xcov))
 
 
 _means = {
-    'lin': mf.Linear(A=rng.randn(D_in, D_out), b=rng.randn(D_out)),
-    'identity': mf.Identity(input_dim=D_in),
-    'const': mf.Constant(c=rng.randn(D_out)),
-    'zero': mf.Zero(output_dim=D_out)
+    "lin": mf.Linear(A=rng.randn(D_in, D_out), b=rng.randn(D_out)),
+    "identity": mf.Identity(input_dim=D_in),
+    "const": mf.Constant(c=rng.randn(D_out)),
+    "zero": mf.Zero(output_dim=D_out),
 }
 
 _distrs = {
-    'gauss':
-    Gaussian(Xmu, Xcov),
-    'dirac_gauss':
-    Gaussian(Xmu, np.zeros((num_data, D_in, D_in))),
-    'gauss_diag':
-    DiagonalGaussian(Xmu, rng.rand(num_data, D_in)),
-    'dirac_diag':
-    DiagonalGaussian(Xmu, np.zeros((num_data, D_in))),
-    'dirac_markov_gauss':
-    MarkovGaussian(Xmu_markov, np.zeros((2, num_data + 1, D_in, D_in))),
-    'markov_gauss':
-    markov_gauss()
+    "gauss": Gaussian(Xmu, Xcov),
+    "dirac_gauss": Gaussian(Xmu, np.zeros((num_data, D_in, D_in))),
+    "gauss_diag": DiagonalGaussian(Xmu, rng.rand(num_data, D_in)),
+    "dirac_diag": DiagonalGaussian(Xmu, np.zeros((num_data, D_in))),
+    "dirac_markov_gauss": MarkovGaussian(
+        Xmu_markov, np.zeros((2, num_data + 1, D_in, D_in))
+    ),
+    "markov_gauss": markov_gauss(),
 }
 
 _kerns = {
-    'rbf':
-    kernels.SquaredExponential(variance=rng.rand(), lengthscale=rng.rand() + 1.),
-    'lin':
-    kernels.Linear(variance=rng.rand()),
-    'matern':
-    kernels.Matern32(variance=rng.rand()),
-    'rbf_act_dim_0':
-    kernels.SquaredExponential(variance=rng.rand(),
-                               lengthscale=rng.rand() + 1.,
-                               active_dims=[0]),
-    'rbf_act_dim_1':
-    kernels.SquaredExponential(variance=rng.rand(),
-                               lengthscale=rng.rand() + 1.,
-                               active_dims=[1]),
-    'lin_act_dim_0':
-    kernels.Linear(variance=rng.rand(), active_dims=[0]),
-    'lin_act_dim_1':
-    kernels.Linear(variance=rng.rand(), active_dims=[1]),
-    'rbf_lin_sum':
-    kernels.Sum([
-        kernels.SquaredExponential(variance=rng.rand(), lengthscale=rng.rand() + 1.),
-        kernels.Linear(variance=rng.rand())
-    ]),
-    'rbf_lin_sum2':
-    kernels.Sum([
-        kernels.Linear(variance=rng.rand()),
-        kernels.SquaredExponential(variance=rng.rand(), lengthscale=rng.rand() + 1.),
-        kernels.Linear(variance=rng.rand()),
-        kernels.SquaredExponential(variance=rng.rand(), lengthscale=rng.rand() + 1.),
-    ]),
-    'rbf_lin_prod':
-    kernels.Product([
-        kernels.SquaredExponential(variance=rng.rand(),
-                                   lengthscale=rng.rand() + 1.,
-                                   active_dims=[0]),
-        kernels.Linear(variance=rng.rand(), active_dims=[1])
-    ])
+    "rbf": kernels.SquaredExponential(
+        variance=rng.rand(), lengthscale=rng.rand() + 1.0
+    ),
+    "lin": kernels.Linear(variance=rng.rand()),
+    "matern": kernels.Matern32(variance=rng.rand()),
+    "rbf_act_dim_0": kernels.SquaredExponential(
+        variance=rng.rand(), lengthscale=rng.rand() + 1.0, active_dims=[0]
+    ),
+    "rbf_act_dim_1": kernels.SquaredExponential(
+        variance=rng.rand(), lengthscale=rng.rand() + 1.0, active_dims=[1]
+    ),
+    "lin_act_dim_0": kernels.Linear(variance=rng.rand(), active_dims=[0]),
+    "lin_act_dim_1": kernels.Linear(variance=rng.rand(), active_dims=[1]),
+    "rbf_lin_sum": kernels.Sum(
+        [
+            kernels.SquaredExponential(
+                variance=rng.rand(), lengthscale=rng.rand() + 1.0
+            ),
+            kernels.Linear(variance=rng.rand()),
+        ]
+    ),
+    "rbf_lin_sum2": kernels.Sum(
+        [
+            kernels.Linear(variance=rng.rand()),
+            kernels.SquaredExponential(
+                variance=rng.rand(), lengthscale=rng.rand() + 1.0
+            ),
+            kernels.Linear(variance=rng.rand()),
+            kernels.SquaredExponential(
+                variance=rng.rand(), lengthscale=rng.rand() + 1.0
+            ),
+        ]
+    ),
+    "rbf_lin_prod": kernels.Product(
+        [
+            kernels.SquaredExponential(
+                variance=rng.rand(), lengthscale=rng.rand() + 1.0, active_dims=[0]
+            ),
+            kernels.Linear(variance=rng.rand(), active_dims=[1]),
+        ]
+    ),
 }
 
 
@@ -149,47 +147,51 @@ kern_args2 = kerns("lin", "rbf", "rbf_lin_sum")
 @pytest.mark.parametrize("mean1", mean_args)
 @pytest.mark.parametrize("mean2", mean_args)
 @pytest.mark.parametrize(
-    "arg_filter", [lambda p, m1, m2: (p, m1), lambda p, m1, m2: (p, m1, m2)])
-def test_mean_function_only_expectations(distribution, mean1, mean2,
-                                         arg_filter):
+    "arg_filter", [lambda p, m1, m2: (p, m1), lambda p, m1, m2: (p, m1, m2)]
+)
+def test_mean_function_only_expectations(distribution, mean1, mean2, arg_filter):
     params = arg_filter(distribution, mean1, mean2)
     _check(params)
 
 
 @pytest.mark.parametrize("distribution", distrs("gauss", "gauss_diag"))
 @pytest.mark.parametrize("kernel", kern_args1)
-@pytest.mark.parametrize("arg_filter", [
-    lambda p, k, f: (p, k), lambda p, k, f: (p, (k, f)), lambda p, k, f:
-    (p, (k, f), (k, f))
-])
+@pytest.mark.parametrize(
+    "arg_filter",
+    [
+        lambda p, k, f: (p, k),
+        lambda p, k, f: (p, (k, f)),
+        lambda p, k, f: (p, (k, f), (k, f)),
+    ],
+)
 def test_kernel_only_expectations(distribution, kernel, inducing_variable, arg_filter):
     params = arg_filter(distribution, kernel, inducing_variable)
     _check(params)
 
 
 @pytest.mark.parametrize("distribution", distr_args1)
-@pytest.mark.parametrize("kernel", kerns("rbf", "lin", "matern",
-                                         "rbf_lin_sum"))
+@pytest.mark.parametrize("kernel", kerns("rbf", "lin", "matern", "rbf_lin_sum"))
 @pytest.mark.parametrize("mean", mean_args)
 @pytest.mark.parametrize(
-    "arg_filter",
-    [lambda p, k, f, m: (p, (k, f), m), lambda p, k, f, m: (p, m, (k, f))])
-def test_kernel_mean_function_expectations(distribution, kernel, inducing_variable, mean,
-                                           arg_filter):
+    "arg_filter", [lambda p, k, f, m: (p, (k, f), m), lambda p, k, f, m: (p, m, (k, f))]
+)
+def test_kernel_mean_function_expectations(
+    distribution, kernel, inducing_variable, mean, arg_filter
+):
     params = arg_filter(distribution, kernel, inducing_variable, mean)
     _check(params)
 
 
 @pytest.mark.parametrize("kernel", kern_args1)
 def test_eKdiag_no_uncertainty(kernel):
-    eKdiag = expectation(_distrs['dirac_diag'], kernel)
+    eKdiag = expectation(_distrs["dirac_diag"], kernel)
     Kdiag = kernel(Xmu, full=False)
     assert_allclose(eKdiag, Kdiag, rtol=RTOL)
 
 
 @pytest.mark.parametrize("kernel", kern_args1)
 def test_eKxz_no_uncertainty(kernel, inducing_variable):
-    eKxz = expectation(_distrs['dirac_diag'], (kernel, inducing_variable))
+    eKxz = expectation(_distrs["dirac_diag"], (kernel, inducing_variable))
     Kxz = kernel(Xmu, Z)
     assert_allclose(eKxz, Kxz, rtol=RTOL)
 
@@ -197,17 +199,17 @@ def test_eKxz_no_uncertainty(kernel, inducing_variable):
 @pytest.mark.parametrize("kernel", kern_args2)
 @pytest.mark.parametrize("mean", mean_args)
 def test_eMxKxz_no_uncertainty(kernel, inducing_variable, mean):
-    exKxz = expectation(_distrs['dirac_diag'], mean, (kernel, inducing_variable))
+    exKxz = expectation(_distrs["dirac_diag"], mean, (kernel, inducing_variable))
     Kxz = kernel(Xmu, Z)
-    xKxz = expectation(_distrs['dirac_gauss'],
-                       mean)[:, :, None] * Kxz[:, None, :]
+    xKxz = expectation(_distrs["dirac_gauss"], mean)[:, :, None] * Kxz[:, None, :]
     assert_allclose(exKxz, xKxz, rtol=RTOL)
 
 
 @pytest.mark.parametrize("kernel", kern_args1)
 def test_eKzxKxz_no_uncertainty(kernel, inducing_variable):
-    eKzxKxz = expectation(_distrs['dirac_diag'], (kernel, inducing_variable),
-                          (kernel, inducing_variable))
+    eKzxKxz = expectation(
+        _distrs["dirac_diag"], (kernel, inducing_variable), (kernel, inducing_variable)
+    )
     Kxz = kernel(Xmu, Z)
     KzxKxz = Kxz[:, :, None] * Kxz[:, None, :]
     assert_allclose(eKzxKxz, KzxKxz, rtol=RTOL)
@@ -223,8 +225,9 @@ def test_RBF_eKzxKxz_gradient_notNaN():
 
     p = gpflow.probability_distributions.Gaussian(
         tf.constant([[10]], dtype=default_float()),
-        tf.constant([[[0.1]]], dtype=default_float()))
-    z = gpflow.inducing_variables.InducingPoints([[-10.], [10.]])
+        tf.constant([[[0.1]]], dtype=default_float()),
+    )
+    z = gpflow.inducing_variables.InducingPoints([[-10.0], [10.0]])
 
     with tf.GradientTape() as tape:
         ekz = expectation(p, (kernel, z), (kernel, z))
@@ -235,8 +238,9 @@ def test_RBF_eKzxKxz_gradient_notNaN():
 @pytest.mark.parametrize("distribution", distrs("gauss_diag"))
 @pytest.mark.parametrize("kern1", kerns("rbf_act_dim_0", "lin_act_dim_0"))
 @pytest.mark.parametrize("kern2", kerns("rbf_act_dim_1", "lin_act_dim_1"))
-def test_eKzxKxz_separate_dims_simplification(distribution, kern1, kern2,
-                                              inducing_variable):
+def test_eKzxKxz_separate_dims_simplification(
+    distribution, kern1, kern2, inducing_variable
+):
     _check((distribution, (kern1, inducing_variable), (kern2, inducing_variable)))
 
 
@@ -250,12 +254,16 @@ def test_eKzxKxz_different_sum_kernels(distribution, kern1, kern2, inducing_vari
 @pytest.mark.parametrize("distribution", distr_args1)
 @pytest.mark.parametrize("kern1", kerns("rbf_lin_sum2"))
 @pytest.mark.parametrize("kern2", kerns("rbf_lin_sum2"))
-def test_eKzxKxz_same_vs_different_sum_kernels(distribution, kern1, kern2,
-                                               inducing_variable):
+def test_eKzxKxz_same_vs_different_sum_kernels(
+    distribution, kern1, kern2, inducing_variable
+):
     # check the result is the same if we pass different objects with the same value
-    same = expectation(*(distribution, (kern1, inducing_variable), (kern1, inducing_variable)))
-    different = expectation(*(distribution, (kern1, inducing_variable),
-                              (kern2, inducing_variable)))
+    same = expectation(
+        *(distribution, (kern1, inducing_variable), (kern1, inducing_variable))
+    )
+    different = expectation(
+        *(distribution, (kern1, inducing_variable), (kern2, inducing_variable))
+    )
     assert_allclose(same, different, rtol=RTOL)
 
 
@@ -277,8 +285,7 @@ def test_exKxz_markov_no_uncertainty(distribution, kernel, mean, inducing_variab
 
 
 @pytest.mark.parametrize("kernel", kerns("rbf"))
-@pytest.mark.parametrize("distribution",
-                         distrs("gauss", "gauss_diag", "markov_gauss"))
+@pytest.mark.parametrize("distribution", distrs("gauss", "gauss_diag", "markov_gauss"))
 def test_cov_shape_inference(distribution, kernel, inducing_variable):
     gauss_tuple = (distribution.mu, distribution.cov)
     _check((gauss_tuple, (kernel, inducing_variable)))

--- a/tests/gpflow/kernels/reference.py
+++ b/tests/gpflow/kernels/reference.py
@@ -10,8 +10,9 @@ def ref_rbf_kernel(X, lengthscale, signal_variance):
             vecB = X[column_index, :]
             delta = vecA - vecB
             distance_squared = np.dot(delta.T, delta)
-            kernel[row_index, column_index] = \
-                signal_variance * np.exp(-0.5 * distance_squared / lengthscale ** 2)
+            kernel[row_index, column_index] = signal_variance * np.exp(
+                -0.5 * distance_squared / lengthscale ** 2
+            )
     return kernel
 
 
@@ -25,24 +26,26 @@ def ref_arccosine_kernel(X, order, weight_variances, bias_variance, signal_varia
 
             numerator = (weight_variances * x).dot(y) + bias_variance
 
-            x_denominator = np.sqrt((weight_variances * x).dot(x) +
-                                    bias_variance)
-            y_denominator = np.sqrt((weight_variances * y).dot(y) +
-                                    bias_variance)
+            x_denominator = np.sqrt((weight_variances * x).dot(x) + bias_variance)
+            y_denominator = np.sqrt((weight_variances * y).dot(y) + bias_variance)
             denominator = x_denominator * y_denominator
 
-            theta = np.arccos(np.clip(numerator / denominator, -1., 1.))
+            theta = np.arccos(np.clip(numerator / denominator, -1.0, 1.0))
             if order == 0:
                 J = np.pi - theta
             elif order == 1:
                 J = np.sin(theta) + (np.pi - theta) * np.cos(theta)
             elif order == 2:
-                J = 3. * np.sin(theta) * np.cos(theta)
-                J += (np.pi - theta) * (1. + 2. * np.cos(theta) ** 2)
+                J = 3.0 * np.sin(theta) * np.cos(theta)
+                J += (np.pi - theta) * (1.0 + 2.0 * np.cos(theta) ** 2)
 
-            kernel[row, col] = signal_variance * (1. / np.pi) * J * \
-                               x_denominator ** order * \
-                               y_denominator ** order
+            kernel[row, col] = (
+                signal_variance
+                * (1.0 / np.pi)
+                * J
+                * x_denominator ** order
+                * y_denominator ** order
+            )
     return kernel
 
 

--- a/tests/gpflow/kernels/test_kernels.py
+++ b/tests/gpflow/kernels/test_kernels.py
@@ -20,7 +20,11 @@ from numpy.testing import assert_allclose
 import gpflow
 from gpflow.config import default_float
 from gpflow.kernels import SquaredExponential, ArcCosine, Linear
-from tests.gpflow.kernels.reference import ref_rbf_kernel, ref_arccosine_kernel, ref_periodic_kernel
+from tests.gpflow.kernels.reference import (
+    ref_rbf_kernel,
+    ref_arccosine_kernel,
+    ref_periodic_kernel,
+)
 
 
 rng = np.random.RandomState(1)
@@ -33,11 +37,13 @@ def _ref_changepoints(X, kernels, locations, steepness):
     by a location and a steepness parameter.
     """
     locations = sorted(locations)
-    steepness = steepness if isinstance(steepness, list) else [steepness] * len(locations)
+    steepness = (
+        steepness if isinstance(steepness, list) else [steepness] * len(locations)
+    )
     locations = np.array(locations).reshape((1, 1, -1))
     steepness = np.array(steepness).reshape((1, 1, -1))
 
-    sig_X = 1. / (1. + np.exp(-steepness * (X[:, :, None] - locations)))
+    sig_X = 1.0 / (1.0 + np.exp(-steepness * (X[:, :, None] - locations)))
 
     starters = sig_X * np.transpose(sig_X, axes=(1, 0, 2))
     stoppers = (1 - sig_X) * np.transpose((1 - sig_X), axes=(1, 0, 2))
@@ -50,10 +56,12 @@ def _ref_changepoints(X, kernels, locations, steepness):
     return (kernel_stack * starters * stoppers).sum(axis=2)
 
 
-@pytest.mark.parametrize('variance, lengthscale', [[2.3, 1.4]])
+@pytest.mark.parametrize("variance, lengthscale", [[2.3, 1.4]])
 def test_rbf_1d(variance, lengthscale):
     X = rng.randn(3, 1)
-    kernel = gpflow.kernels.SquaredExponential(lengthscale=lengthscale, variance=variance)
+    kernel = gpflow.kernels.SquaredExponential(
+        lengthscale=lengthscale, variance=variance
+    )
 
     gram_matrix = kernel(X)
     reference_gram_matrix = ref_rbf_kernel(X, lengthscale, variance)
@@ -61,12 +69,12 @@ def test_rbf_1d(variance, lengthscale):
     assert_allclose(gram_matrix, reference_gram_matrix)
 
 
-@pytest.mark.parametrize('variance, lengthscale', [[2.3, 1.4]])
+@pytest.mark.parametrize("variance, lengthscale", [[2.3, 1.4]])
 def test_rq_1d(variance, lengthscale):
     kSE = gpflow.kernels.SquaredExponential(lengthscale=lengthscale, variance=variance)
-    kRQ = gpflow.kernels.RationalQuadratic(lengthscale=lengthscale,
-                                           variance=variance,
-                                           alpha=1e8)
+    kRQ = gpflow.kernels.RationalQuadratic(
+        lengthscale=lengthscale, variance=variance, alpha=1e8
+    )
     rng = np.random.RandomState(1)
     X = rng.randn(6, 1).astype(default_float())
 
@@ -75,37 +83,37 @@ def test_rq_1d(variance, lengthscale):
     assert_allclose(gram_matrix_SE, gram_matrix_RQ)
 
 
-def _assert_arccosine_kern_err(variance, weight_variances, bias_variance,
-                               order, X):
-    kernel = gpflow.kernels.ArcCosine(order=order,
-                                      variance=variance,
-                                      weight_variances=weight_variances,
-                                      bias_variance=bias_variance)
+def _assert_arccosine_kern_err(variance, weight_variances, bias_variance, order, X):
+    kernel = gpflow.kernels.ArcCosine(
+        order=order,
+        variance=variance,
+        weight_variances=weight_variances,
+        bias_variance=bias_variance,
+    )
     gram_matrix = kernel(X)
-    reference_gram_matrix = ref_arccosine_kernel(X, order, weight_variances,
-                                           bias_variance, variance)
+    reference_gram_matrix = ref_arccosine_kernel(
+        X, order, weight_variances, bias_variance, variance
+    )
     assert_allclose(gram_matrix, reference_gram_matrix)
 
 
-@pytest.mark.parametrize('order', gpflow.kernels.ArcCosine.implemented_orders)
-@pytest.mark.parametrize('D, weight_variances',
-                         [[1, 1.7], [3, 1.7], [3, (1.1, 1.7, 1.9)]])
-@pytest.mark.parametrize('N, bias_variance, variance',
-                         [[3, 0.6, 2.3]])
-def test_arccosine_1d_and_3d(order, D, N, weight_variances, bias_variance,
-                             variance):
+@pytest.mark.parametrize("order", gpflow.kernels.ArcCosine.implemented_orders)
+@pytest.mark.parametrize(
+    "D, weight_variances", [[1, 1.7], [3, 1.7], [3, (1.1, 1.7, 1.9)]]
+)
+@pytest.mark.parametrize("N, bias_variance, variance", [[3, 0.6, 2.3]])
+def test_arccosine_1d_and_3d(order, D, N, weight_variances, bias_variance, variance):
     X_data = rng.randn(N, D)
-    _assert_arccosine_kern_err(variance, weight_variances, bias_variance,
-                               order, X_data)
+    _assert_arccosine_kern_err(variance, weight_variances, bias_variance, order, X_data)
 
 
-@pytest.mark.parametrize('order', [42])
+@pytest.mark.parametrize("order", [42])
 def test_arccosine_non_implemented_order(order):
     with pytest.raises(ValueError):
         gpflow.kernels.ArcCosine(order=order)
 
 
-@pytest.mark.parametrize('D, N', [[1, 4]])
+@pytest.mark.parametrize("D, N", [[1, 4]])
 def test_arccosine_nan_gradient(D, N):
     X = rng.rand(N, D)
     kernel = gpflow.kernels.ArcCosine()
@@ -119,43 +127,50 @@ def _assert_periodic_kern_err(base_class, lengthscale, variance, period, X):
     base = base_class(lengthscale=lengthscale, variance=variance)
     kernel = gpflow.kernels.Periodic(base, period=period)
     gram_matrix = kernel(X)
-    reference_gram_matrix = ref_periodic_kernel(X, base_class.__name__, lengthscale, variance, period)
+    reference_gram_matrix = ref_periodic_kernel(
+        X, base_class.__name__, lengthscale, variance, period
+    )
 
     assert_allclose(gram_matrix, reference_gram_matrix)
 
 
-@pytest.mark.parametrize('base_class', [
-    gpflow.kernels.SquaredExponential,
-    gpflow.kernels.Matern12,
-    gpflow.kernels.Matern32,
-    gpflow.kernels.Matern52,
-])
-@pytest.mark.parametrize('D, lengthscale, period', [
-    [1, 2., 3.],                  # 1d, single lengthscale, single period
-    [2, 11.5, 3.],                # 2d, single lengthscale, single period
-    [2, 11.5, (3., 6.)],          # 2d, single lengthscale, ard period
-    [2, (11.5, 12.5), 3.],        # 2d, ard lengthscale, single period
-    [2, (11.5, 12.5), (3., 6.)],  # 2d, ard lengthscale, ard period
-])
-@pytest.mark.parametrize('N, variance', [
-    [3, 2.3],
-    [5, 1.3],
-])
+@pytest.mark.parametrize(
+    "base_class",
+    [
+        gpflow.kernels.SquaredExponential,
+        gpflow.kernels.Matern12,
+        gpflow.kernels.Matern32,
+        gpflow.kernels.Matern52,
+    ],
+)
+@pytest.mark.parametrize(
+    "D, lengthscale, period",
+    [
+        [1, 2.0, 3.0],  # 1d, single lengthscale, single period
+        [2, 11.5, 3.0],  # 2d, single lengthscale, single period
+        [2, 11.5, (3.0, 6.0)],  # 2d, single lengthscale, ard period
+        [2, (11.5, 12.5), 3.0],  # 2d, ard lengthscale, single period
+        [2, (11.5, 12.5), (3.0, 6.0)],  # 2d, ard lengthscale, ard period
+    ],
+)
+@pytest.mark.parametrize("N, variance", [[3, 2.3], [5, 1.3],])
 def test_periodic(base_class, D, N, lengthscale, variance, period):
-    X = rng.randn(N, D) if D == 1 else rng.multivariate_normal(
-        np.zeros(D), np.eye(D), N)
+    X = (
+        rng.randn(N, D)
+        if D == 1
+        else rng.multivariate_normal(np.zeros(D), np.eye(D), N)
+    )
     _assert_periodic_kern_err(base_class, lengthscale, variance, period, X)
 
 
-@pytest.mark.parametrize('base_class', [
-    gpflow.kernels.SquaredExponential,
-    gpflow.kernels.Matern12,
-])
+@pytest.mark.parametrize(
+    "base_class", [gpflow.kernels.SquaredExponential, gpflow.kernels.Matern12,]
+)
 def test_periodic_diag(base_class):
     N, D = 5, 3
     X = rng.multivariate_normal(np.zeros(D), np.eye(D), N)
-    base = base_class(lengthscale=2., variance=1.)
-    kernel = gpflow.kernels.Periodic(base, period=6.)
+    base = base_class(lengthscale=2.0, variance=1.0)
+    kernel = gpflow.kernels.Periodic(base, period=6.0)
     assert_allclose(base(X, full=False), kernel(X, full=False))
 
 
@@ -166,39 +181,38 @@ def test_periodic_non_stationary_base():
 
 
 def test_periodic_bad_ard_period():
-    error_msg = r"Size of `active_dims` \[1 2\] does not match size of ard parameter \(3\)"
+    error_msg = (
+        r"Size of `active_dims` \[1 2\] does not match size of ard parameter \(3\)"
+    )
     base = gpflow.kernels.RBF(active_dims=[1, 2])
     with pytest.raises(ValueError, match=error_msg):
-        gpflow.kernels.Periodic(base, period=[1., 1., 1.])
+        gpflow.kernels.Periodic(base, period=[1.0, 1.0, 1.0])
 
 
-kernel_setups = [
-    kernel() for kernel in gpflow.kernels.Stationary.__subclasses__()
-] + [
+kernel_setups = [kernel() for kernel in gpflow.kernels.Stationary.__subclasses__()] + [
     gpflow.kernels.Constant(),
     gpflow.kernels.Linear(),
     gpflow.kernels.Polynomial(),
-    gpflow.kernels.ArcCosine()
+    gpflow.kernels.ArcCosine(),
 ]
 
 
-@pytest.mark.parametrize('D', [1, 5])
-@pytest.mark.parametrize('kernel', kernel_setups)
-@pytest.mark.parametrize('N', [10])
+@pytest.mark.parametrize("D", [1, 5])
+@pytest.mark.parametrize("kernel", kernel_setups)
+@pytest.mark.parametrize("N", [10])
 def test_kernel_symmetry_1d_and_5d(D, kernel, N):
     X = rng.randn(N, D)
     errors = kernel(X) - kernel(X, X)
     assert np.allclose(errors, 0)
 
 
-@pytest.mark.parametrize('N, N2, input_dim, output_dim, rank',
-                         [[10, 12, 1, 3, 2]])
+@pytest.mark.parametrize("N, N2, input_dim, output_dim, rank", [[10, 12, 1, 3, 2]])
 def test_coregion_shape(N, N2, input_dim, output_dim, rank):
     X = np.random.randint(0, output_dim, (N, input_dim))
     X2 = np.random.randint(0, output_dim, (N2, input_dim))
     kernel = gpflow.kernels.Coregion(output_dim=output_dim, rank=rank)
     kernel.W = rng.randn(output_dim, rank)
-    kernel.kappa = rng.randn(output_dim, 1).reshape(-1) + 1.
+    kernel.kappa = rng.randn(output_dim, 1).reshape(-1) + 1.0
 
     Kff2 = kernel(X, X2)
     assert Kff2.shape == (10, 12)
@@ -206,25 +220,23 @@ def test_coregion_shape(N, N2, input_dim, output_dim, rank):
     assert Kff.shape == (10, 10)
 
 
-@pytest.mark.parametrize('N, input_dim, output_dim, rank', [[10, 1, 3, 2]])
+@pytest.mark.parametrize("N, input_dim, output_dim, rank", [[10, 1, 3, 2]])
 def test_coregion_diag(N, input_dim, output_dim, rank):
     X = np.random.randint(0, output_dim, (N, input_dim))
     kernel = gpflow.kernels.Coregion(output_dim=output_dim, rank=rank)
     kernel.W = rng.randn(output_dim, rank)
-    kernel.kappa = rng.randn(output_dim, 1).reshape(-1) + 1.
+    kernel.kappa = rng.randn(output_dim, 1).reshape(-1) + 1.0
 
     K = kernel(X)
     Kdiag = kernel.K_diag(X)
     assert np.allclose(np.diag(K), Kdiag)
 
 
-@pytest.mark.parametrize('N, input_dim, output_dim, rank', [[10, 1, 3, 2]])
+@pytest.mark.parametrize("N, input_dim, output_dim, rank", [[10, 1, 3, 2]])
 def test_coregion_slice(N, input_dim, output_dim, rank):
     X = np.random.randint(0, output_dim, (N, input_dim))
     X = np.hstack((X, rng.randn(10, 1)))
-    kernel1 = gpflow.kernels.Coregion(output_dim=output_dim,
-                                      rank=rank,
-                                      active_dims=[0])
+    kernel1 = gpflow.kernels.Coregion(output_dim=output_dim, rank=rank, active_dims=[0])
     # compute another kernel with additinoal inputs,
     # make sure out kernel is still okay.
     kernel2 = gpflow.kernels.SquaredExponential(active_dims=[1])
@@ -235,15 +247,19 @@ def test_coregion_slice(N, input_dim, output_dim, rank):
 
 
 _dim = 3
-kernel_setups_extended = kernel_setups + [
-    SquaredExponential() + Linear(),
-    SquaredExponential() * Linear(),
-    SquaredExponential() + Linear(variance=rng.rand(_dim))
-] + [ArcCosine(order=order) for order in ArcCosine.implemented_orders]
+kernel_setups_extended = (
+    kernel_setups
+    + [
+        SquaredExponential() + Linear(),
+        SquaredExponential() * Linear(),
+        SquaredExponential() + Linear(variance=rng.rand(_dim)),
+    ]
+    + [ArcCosine(order=order) for order in ArcCosine.implemented_orders]
+)
 
 
-@pytest.mark.parametrize('kernel', kernel_setups_extended)
-@pytest.mark.parametrize('N, dim', [[30, _dim]])
+@pytest.mark.parametrize("kernel", kernel_setups_extended)
+@pytest.mark.parametrize("N, dim", [[30, _dim]])
 def test_diags(kernel, N, dim):
     X = np.random.randn(N, dim)
     kernel1 = tf.linalg.diag_part(kernel(X, full=True))
@@ -252,7 +268,9 @@ def test_diags(kernel, N, dim):
 
 
 def test_conv_diag():
-    kernel = gpflow.kernels.Convolutional(gpflow.kernels.SquaredExponential(), [3, 3], [2, 2])
+    kernel = gpflow.kernels.Convolutional(
+        gpflow.kernels.SquaredExponential(), [3, 3], [2, 2]
+    )
     X = np.random.randn(3, 9)
     kernel_full = np.diagonal(kernel(X, full=True))
     kernel_diag = kernel(X, full=False)
@@ -268,7 +286,7 @@ _kernel_setups_add = [
 ]
 
 
-@pytest.mark.parametrize('N, D', [[10, 1]])
+@pytest.mark.parametrize("N, D", [[10, 1]])
 def test_add_symmetric(N, D):
     X = rng.randn(N, D)
     Kffs = [kernel(X) for kernel in _kernel_setups_add]
@@ -276,7 +294,7 @@ def test_add_symmetric(N, D):
     assert np.allclose(Kffs[0] + Kffs[1], Kffs[2])
 
 
-@pytest.mark.parametrize('N, M, D', [[10, 12, 1]])
+@pytest.mark.parametrize("N, M, D", [[10, 12, 1]])
 def test_add_asymmetric(N, M, D):
     X, Z = rng.randn(N, D), rng.randn(M, D)
     Kfus = [kernel(X, Z) for kernel in _kernel_setups_add]
@@ -284,7 +302,7 @@ def test_add_asymmetric(N, M, D):
     assert np.allclose(Kfus[0] + Kfus[1], Kfus[2])
 
 
-@pytest.mark.parametrize('N, D', [[10, 1]])
+@pytest.mark.parametrize("N, D", [[10, 1]])
 def test_white(N, D):
     """
     The white kernel should not give the same result when called with k(X) and
@@ -298,20 +316,20 @@ def test_white(N, D):
     assert not np.allclose(Kff_sym, Kff_asym)
 
 
-_kernel_classes_slice = [kernel for kernel in gpflow.kernels.Stationary.__subclasses__()] + \
-                        [gpflow.kernels.Constant,
-                         gpflow.kernels.Linear,
-                         gpflow.kernels.Polynomial]
+_kernel_classes_slice = [
+    kernel for kernel in gpflow.kernels.Stationary.__subclasses__()
+] + [gpflow.kernels.Constant, gpflow.kernels.Linear, gpflow.kernels.Polynomial]
 
 _kernel_triples_slice = [
     (k1(active_dims=[0]), k2(active_dims=[1]), k3(active_dims=slice(0, 1)))
-    for k1, k2, k3 in zip(_kernel_classes_slice, _kernel_classes_slice,
-                          _kernel_classes_slice)
+    for k1, k2, k3 in zip(
+        _kernel_classes_slice, _kernel_classes_slice, _kernel_classes_slice
+    )
 ]
 
 
-@pytest.mark.parametrize('kernel_triple', _kernel_triples_slice)
-@pytest.mark.parametrize('N, D', [[20, 2]])
+@pytest.mark.parametrize("kernel_triple", _kernel_triples_slice)
+@pytest.mark.parametrize("N, D", [[20, 2]])
 def test_slice_symmetric(kernel_triple, N, D):
     X = rng.randn(N, D)
     K1, K3 = kernel_triple[0](X), kernel_triple[2](X[:, :1])
@@ -320,8 +338,8 @@ def test_slice_symmetric(kernel_triple, N, D):
     assert np.allclose(K2, K4)
 
 
-@pytest.mark.parametrize('kernel_triple', _kernel_triples_slice)
-@pytest.mark.parametrize('N, M, D', [[10, 12, 2]])
+@pytest.mark.parametrize("kernel_triple", _kernel_triples_slice)
+@pytest.mark.parametrize("N, M, D", [[10, 12, 2]])
 def test_slice_asymmetric(kernel_triple, N, M, D):
     X = rng.randn(N, D)
     Z = rng.randn(M, D)
@@ -338,7 +356,7 @@ _kernel_setups_prod = [
 ]
 
 
-@pytest.mark.parametrize('N, D', [[30, 2]])
+@pytest.mark.parametrize("N, D", [[30, 2]])
 def test_product(N, D):
     X = rng.randn(N, D)
     Kffs = [kernel(X) for kernel in _kernel_setups_prod]
@@ -346,16 +364,19 @@ def test_product(N, D):
     assert np.allclose(Kffs[0] * Kffs[1], Kffs[2])
 
 
-@pytest.mark.parametrize('N, D', [[30, 4], [10, 7]])
+@pytest.mark.parametrize("N, D", [[30, 4], [10, 7]])
 def test_active_product(N, D):
     X = rng.randn(N, D)
-    dims, rand_idx, ls = list(range(D)), int(rng.randint(0, D)), rng.uniform(
-        1., 7., D)
-    active_dims_list = [
-        dims[:rand_idx] + dims[rand_idx + 1:], [rand_idx], dims
-    ]
+    dims, rand_idx, ls = (
+        list(range(D)),
+        int(rng.randint(0, D)),
+        rng.uniform(1.0, 7.0, D),
+    )
+    active_dims_list = [dims[:rand_idx] + dims[rand_idx + 1 :], [rand_idx], dims]
     lengthscale_list = [
-        np.hstack([ls[:rand_idx], ls[rand_idx + 1:]]), ls[rand_idx], ls
+        np.hstack([ls[:rand_idx], ls[rand_idx + 1 :]]),
+        ls[rand_idx],
+        ls,
     ]
     kernels = [
         gpflow.kernels.SquaredExponential(lengthscale=lengthscale, active_dims=dims)
@@ -369,7 +390,7 @@ def test_active_product(N, D):
     assert np.allclose(Kff, Kff_prod)
 
 
-@pytest.mark.parametrize('D', [4, 7])
+@pytest.mark.parametrize("D", [4, 7])
 def test_ard_init_scalar(D):
     """
     For ard kernels, make sure that kernels can be instantiated with a single
@@ -388,30 +409,39 @@ def test_ard_invalid_active_dims():
         gpflow.kernels.SquaredExponential(lengthscale=np.ones(2), active_dims=[1])
 
 
-@pytest.mark.parametrize('kernel_class, param_name', [
-    [gpflow.kernels.SquaredExponential, "lengthscale"],
-    [gpflow.kernels.Linear, "variance"],
-    [gpflow.kernels.ArcCosine, "weight_variances"],
-])
-@pytest.mark.parametrize('param_value, ard', [
-    [1., False],
-    [[1.], True],
-    [[1., 1.], True],
-])
+@pytest.mark.parametrize(
+    "kernel_class, param_name",
+    [
+        [gpflow.kernels.SquaredExponential, "lengthscale"],
+        [gpflow.kernels.Linear, "variance"],
+        [gpflow.kernels.ArcCosine, "weight_variances"],
+    ],
+)
+@pytest.mark.parametrize(
+    "param_value, ard", [[1.0, False], [[1.0], True], [[1.0, 1.0], True],]
+)
 def test_ard_property(kernel_class, param_name, param_value, ard):
     kernel = kernel_class(**{param_name: param_value})
     assert kernel.ard is ard
 
 
-@pytest.mark.parametrize('locations, steepness, error_msg', [
-    # 1. Kernels locations dimension mismatch
-    [[1.], 1.,
-     r"Number of kernels \(3\) must be one more than the number of changepoint locations \(1\)"],
-
-     # 2. Locations steepness dimension mismatch
-    [[1., 2.], [1.],
-     r"Dimension of steepness \(1\) does not match number of changepoint locations \(2\)"],
-])
+@pytest.mark.parametrize(
+    "locations, steepness, error_msg",
+    [
+        # 1. Kernels locations dimension mismatch
+        [
+            [1.0],
+            1.0,
+            r"Number of kernels \(3\) must be one more than the number of changepoint locations \(1\)",
+        ],
+        # 2. Locations steepness dimension mismatch
+        [
+            [1.0, 2.0],
+            [1.0],
+            r"Dimension of steepness \(1\) does not match number of changepoint locations \(2\)",
+        ],
+    ],
+)
 def test_changepoints_init_fail(locations, steepness, error_msg):
     kernels = [
         gpflow.kernels.Matern12(),
@@ -430,37 +460,60 @@ def _assert_changepoints_kern_err(X, kernels, locations, steepness):
     assert_allclose(kernel.K_diag(X), np.diag(reference_gram_matrix))
 
 
-@pytest.mark.parametrize('N', [2, 10])
-@pytest.mark.parametrize('kernels, locations, steepness', [
-    # 1. Single changepoint
-    [[gpflow.kernels.Constant(),
-      gpflow.kernels.Constant()], [2.], 5.],
-    # 2. Two changepoints
-    [[gpflow.kernels.Constant(),
-      gpflow.kernels.Constant(),
-      gpflow.kernels.Constant()], [1., 2.], 5.],
-    # 3. Multiple steepness
-    [[gpflow.kernels.Constant(),
-      gpflow.kernels.Constant(),
-      gpflow.kernels.Constant()], [1., 2.], [5., 10.]],
-    # 4. Variety of kernels
-    [[gpflow.kernels.Matern12(),
-      gpflow.kernels.Linear(),
-      gpflow.kernels.SquaredExponential(),
-      gpflow.kernels.Constant()], [1., 2., 3.], 5.],
-])
+@pytest.mark.parametrize("N", [2, 10])
+@pytest.mark.parametrize(
+    "kernels, locations, steepness",
+    [
+        # 1. Single changepoint
+        [[gpflow.kernels.Constant(), gpflow.kernels.Constant()], [2.0], 5.0],
+        # 2. Two changepoints
+        [
+            [
+                gpflow.kernels.Constant(),
+                gpflow.kernels.Constant(),
+                gpflow.kernels.Constant(),
+            ],
+            [1.0, 2.0],
+            5.0,
+        ],
+        # 3. Multiple steepness
+        [
+            [
+                gpflow.kernels.Constant(),
+                gpflow.kernels.Constant(),
+                gpflow.kernels.Constant(),
+            ],
+            [1.0, 2.0],
+            [5.0, 10.0],
+        ],
+        # 4. Variety of kernels
+        [
+            [
+                gpflow.kernels.Matern12(),
+                gpflow.kernels.Linear(),
+                gpflow.kernels.SquaredExponential(),
+                gpflow.kernels.Constant(),
+            ],
+            [1.0, 2.0, 3.0],
+            5.0,
+        ],
+    ],
+)
 def test_changepoints(N, kernels, locations, steepness):
     X_data = rng.randn(N, 1)
     _assert_changepoints_kern_err(X_data, kernels, locations, steepness)
 
 
-@pytest.mark.parametrize('active_dims_1, active_dims_2, is_separate', [
-    [[1, 2, 3], None, False],
-    [None, [1, 2, 3], False],
-    [None, None, False],
-    [[1, 2, 3], [3, 4, 5], False],
-    [[1, 2, 3], [4, 5, 6], True],
-    ])
+@pytest.mark.parametrize(
+    "active_dims_1, active_dims_2, is_separate",
+    [
+        [[1, 2, 3], None, False],
+        [None, [1, 2, 3], False],
+        [None, None, False],
+        [[1, 2, 3], [3, 4, 5], False],
+        [[1, 2, 3], [4, 5, 6], True],
+    ],
+)
 def test_on_separate_dims(active_dims_1, active_dims_2, is_separate):
     kernel_1 = gpflow.kernels.Linear(active_dims=active_dims_1)
     kernel_2 = gpflow.kernels.SquaredExponential(active_dims=active_dims_2)
@@ -470,7 +523,7 @@ def test_on_separate_dims(active_dims_1, active_dims_2, is_separate):
     assert kernel_2.on_separate_dims(kernel_2) is False
 
 
-@pytest.mark.parametrize('kernel', kernel_setups_extended)
+@pytest.mark.parametrize("kernel", kernel_setups_extended)
 def test_kernel_call_diag_and_X2_errors(kernel):
     X = rng.randn(4, 1)
     X2 = rng.randn(5, 1)

--- a/tests/gpflow/kernels/test_scaled_euclid_dist.py
+++ b/tests/gpflow/kernels/test_scaled_euclid_dist.py
@@ -32,29 +32,33 @@ kernel_list = [
     kernels.Matern32(),
     kernels.Matern52(),
     kernels.Exponential(),
-    kernels.Cosine()
+    kernels.Cosine(),
 ]
 
 
-@pytest.mark.parametrize('kernel', kernel_list)
+@pytest.mark.parametrize("kernel", kernel_list)
 def test_kernel_euclidean_distance(kernel):
-    '''
+    """
     Tests output & gradients of kernels that are a function of the (scaled) euclidean distance
     of the points. We test on a high dimensional space, which can generate very small distances
     causing the scaled_square_dist to generate some negative values.
-    '''
+    """
     K = kernel(Datum.X)
-    assert not np.isnan(
-        K).any(), 'NaNs in the output of the ' + kernel.__name__ + 'kernel.'
-    assert np.isfinite(
-        K).all(), 'Infs in the output of the ' + kernel.__name__ + ' kernel.'
+    assert not np.isnan(K).any(), (
+        "NaNs in the output of the " + kernel.__name__ + "kernel."
+    )
+    assert np.isfinite(K).all(), (
+        "Infs in the output of the " + kernel.__name__ + " kernel."
+    )
 
     X_as_param = tf.Variable(Datum.X)
     with tf.GradientTape() as tape:
         K_value = kernel(X_as_param, X_as_param)
         dK = tape.gradient(K_value, X_as_param)[0]
 
-    assert not np.isnan(dK).any(
-    ), 'NaNs in the gradient of the ' + kernel.__name__ + ' kernel.'
-    assert np.isfinite(
-        dK).all(), 'Infs in the output of the ' + kernel.__name__ + ' kernel.'
+    assert not np.isnan(dK).any(), (
+        "NaNs in the gradient of the " + kernel.__name__ + " kernel."
+    )
+    assert np.isfinite(dK).all(), (
+        "Infs in the output of the " + kernel.__name__ + " kernel."
+    )

--- a/tests/gpflow/models/test_gplvm.py
+++ b/tests/gpflow/models/test_gplvm.py
@@ -32,10 +32,13 @@ class Data:
     X = rng.randn(N, Q)
 
 
-@pytest.mark.parametrize("kernel", [
-    None,  # default kernel: SquaredExponential
-    gpflow.kernels.Periodic(base=gpflow.kernels.SquaredExponential()),
-])
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        None,  # default kernel: SquaredExponential
+        gpflow.kernels.Periodic(base=gpflow.kernels.SquaredExponential()),
+    ],
+)
 def test_gplvm_with_kernels(kernel):
     m = gpflow.models.GPLVM(Data.Y, Data.Q, kernel=kernel)
     log_likelihood_initial = m.log_likelihood()
@@ -43,7 +46,7 @@ def test_gplvm_with_kernels(kernel):
 
     @tf.function
     def objective_closure():
-        return - m.log_marginal_likelihood()
+        return -m.log_marginal_likelihood()
 
     opt.minimize(objective_closure, m.trainable_variables, options=dict(maxiter=2))
     assert m.log_likelihood() > log_likelihood_initial
@@ -53,18 +56,20 @@ def test_bayesian_gplvm_1d():
     Q = 1
     kernel = gpflow.kernels.SquaredExponential()
     inducing_variable = np.linspace(0, 1, Data.M)[:, None]
-    m = gpflow.models.BayesianGPLVM(Data.Y,
-                                    np.zeros((Data.N, Q)),
-                                    np.ones((Data.N, Q)),
-                                    kernel,
-                                    inducing_variable=inducing_variable)
+    m = gpflow.models.BayesianGPLVM(
+        Data.Y,
+        np.zeros((Data.N, Q)),
+        np.ones((Data.N, Q)),
+        kernel,
+        inducing_variable=inducing_variable,
+    )
     assert len(m.inducing_variable) == Data.M
     log_likelihood_initial = m.log_likelihood()
     opt = gpflow.optimizers.Scipy()
 
     @tf.function
     def objective_closure():
-        return - m.log_marginal_likelihood()
+        return -m.log_marginal_likelihood()
 
     opt.minimize(objective_closure, m.trainable_variables, options=dict(maxiter=2))
     assert m.log_likelihood() > log_likelihood_initial
@@ -75,14 +80,16 @@ def test_bayesian_gplvm_2d():
     x_data_mean = pca_reduce(Data.Y, Q)
     kernel = gpflow.kernels.SquaredExponential()
 
-    m = gpflow.models.BayesianGPLVM(Data.Y, x_data_mean, np.ones((Data.N, Q)), kernel, num_inducing_variables=Data.M)
+    m = gpflow.models.BayesianGPLVM(
+        Data.Y, x_data_mean, np.ones((Data.N, Q)), kernel, num_inducing_variables=Data.M
+    )
 
     log_likelihood_initial = m.log_likelihood()
     opt = gpflow.optimizers.Scipy()
 
     @tf.function
     def objective_closure():
-        return - m.log_marginal_likelihood()
+        return -m.log_marginal_likelihood()
 
     opt.minimize(objective_closure, m.trainable_variables, options=dict(maxiter=2))
     assert m.log_likelihood() > log_likelihood_initial
@@ -100,23 +107,26 @@ def test_bayesian_gplvm_2d():
 def test_gplvm_constructor_checks():
     with pytest.raises(ValueError):
         assert Data.X.shape[1] == Data.Q
-        latents_wrong_shape = Data.X[:, :Data.Q - 1]
+        latents_wrong_shape = Data.X[:, : Data.Q - 1]
         gpflow.models.GPLVM(Data.Y, Data.Q, x_data_mean=latents_wrong_shape)
     with pytest.raises(ValueError):
-        observations_wrong_shape = Data.Y[:, :Data.Q - 1]
+        observations_wrong_shape = Data.Y[:, : Data.Q - 1]
         gpflow.models.GPLVM(observations_wrong_shape, Data.Q)
     with pytest.raises(ValueError):
-        observations_wrong_shape = Data.Y[:, :Data.Q - 1]
+        observations_wrong_shape = Data.Y[:, : Data.Q - 1]
         gpflow.models.GPLVM(observations_wrong_shape, Data.Q, x_data_mean=Data.X)
+
 
 def test_bayesian_gplvm_constructor_check():
     Q = 1
     kernel = gpflow.kernels.SquaredExponential()
     inducing_variable = np.linspace(0, 1, Data.M)[:, None]
     with pytest.raises(ValueError):
-        gpflow.models.BayesianGPLVM(Data.Y,
-                                    np.zeros((Data.N, Q)),
-                                    np.ones((Data.N, Q)),
-                                    kernel,
-                                    inducing_variable=inducing_variable,
-                                    num_inducing_variables=len(inducing_variable))
+        gpflow.models.BayesianGPLVM(
+            Data.Y,
+            np.zeros((Data.N, Q)),
+            np.ones((Data.N, Q)),
+            kernel,
+            inducing_variable=inducing_variable,
+            num_inducing_variables=len(inducing_variable),
+        )

--- a/tests/gpflow/models/test_gpr.py
+++ b/tests/gpflow/models/test_gpr.py
@@ -38,7 +38,9 @@ def test_non_trainable_model_objective():
     """
     model = gpflow.models.GPR(
         (Data.X, Data.Y),
-        kernel=gpflow.kernels.SquaredExponential(lengthscale=Data.ls, variance=Data.var),
+        kernel=gpflow.kernels.SquaredExponential(
+            lengthscale=Data.ls, variance=Data.var
+        ),
     )
 
     set_trainable(model, False)

--- a/tests/gpflow/models/test_mcmc.py
+++ b/tests/gpflow/models/test_mcmc.py
@@ -30,11 +30,15 @@ def test_sparse_mcmc_likelihoods_and_gradients():
     v_vals = rng.randn(10, 1)
 
     likelihood = gpflow.likelihoods.StudentT()
-    model_1 = gpflow.models.GPMC(data=(X, Y), kernel=gpflow.kernels.Exponential(), likelihood=likelihood)
-    model_2 = gpflow.models.SGPMC(data=(X, Y),
-                                  kernel=gpflow.kernels.Exponential(),
-                                  inducing_variable=X.copy(),
-                                  likelihood=likelihood)
+    model_1 = gpflow.models.GPMC(
+        data=(X, Y), kernel=gpflow.kernels.Exponential(), likelihood=likelihood
+    )
+    model_2 = gpflow.models.SGPMC(
+        data=(X, Y),
+        kernel=gpflow.kernels.Exponential(),
+        inducing_variable=X.copy(),
+        likelihood=likelihood,
+    )
     model_1.V = tf.convert_to_tensor(v_vals, dtype=default_float())
     model_2.V = tf.convert_to_tensor(v_vals, dtype=default_float())
     model_1.kernel.lengthscale.assign(0.8)
@@ -42,4 +46,6 @@ def test_sparse_mcmc_likelihoods_and_gradients():
     model_1.kernel.variance.assign(4.2)
     model_2.kernel.variance.assign(4.2)
 
-    assert_allclose(model_1.log_likelihood(), model_2.log_likelihood(), rtol=1e-5, atol=1e-5)
+    assert_allclose(
+        model_1.log_likelihood(), model_2.log_likelihood(), rtol=1e-5, atol=1e-5
+    )

--- a/tests/gpflow/models/test_methods.py
+++ b/tests/gpflow/models/test_methods.py
@@ -43,21 +43,39 @@ default_datum = Datum()
 
 
 _gp_models = [
-    gpflow.models.VGP((default_datum.X, default_datum.Y), default_datum.kernel, default_datum.lik),
-    gpflow.models.GPMC((default_datum.X, default_datum.Y), default_datum.kernel, default_datum.lik),
-    gpflow.models.SGPMC((default_datum.X, default_datum.Y),
-                        default_datum.kernel,
-                        default_datum.lik,
-                        inducing_variable=default_datum.Z),
-    gpflow.models.SGPR((default_datum.X, default_datum.Y), default_datum.kernel, inducing_variable=default_datum.Z),
+    gpflow.models.VGP(
+        (default_datum.X, default_datum.Y), default_datum.kernel, default_datum.lik
+    ),
+    gpflow.models.GPMC(
+        (default_datum.X, default_datum.Y), default_datum.kernel, default_datum.lik
+    ),
+    gpflow.models.SGPMC(
+        (default_datum.X, default_datum.Y),
+        default_datum.kernel,
+        default_datum.lik,
+        inducing_variable=default_datum.Z,
+    ),
+    gpflow.models.SGPR(
+        (default_datum.X, default_datum.Y),
+        default_datum.kernel,
+        inducing_variable=default_datum.Z,
+    ),
     gpflow.models.GPR((default_datum.X, default_datum.Y), default_datum.kernel),
-    gpflow.models.GPRFITC((default_datum.X, default_datum.Y), default_datum.kernel, inducing_variable=default_datum.Z)
+    gpflow.models.GPRFITC(
+        (default_datum.X, default_datum.Y),
+        default_datum.kernel,
+        inducing_variable=default_datum.Z,
+    ),
 ]
 
-_state_less_gp_models = [gpflow.models.SVGP(default_datum.kernel, default_datum.lik, inducing_variable=default_datum.Z)]
+_state_less_gp_models = [
+    gpflow.models.SVGP(
+        default_datum.kernel, default_datum.lik, inducing_variable=default_datum.Z
+    )
+]
 
 
-@pytest.mark.parametrize('model', _state_less_gp_models + _gp_models)
+@pytest.mark.parametrize("model", _state_less_gp_models + _gp_models)
 def test_methods_predict_f(model):
     mf, vf = model.predict_f(default_datum.Xs)
     assert_array_equal(mf.shape, vf.shape)
@@ -65,7 +83,7 @@ def test_methods_predict_f(model):
     assert_array_less(np.full_like(vf, -1e-6), vf)
 
 
-@pytest.mark.parametrize('model', _state_less_gp_models + _gp_models)
+@pytest.mark.parametrize("model", _state_less_gp_models + _gp_models)
 def test_methods_predict_y(model):
     mf, vf = model.predict_y(default_datum.Xs)
     assert_array_equal(mf.shape, vf.shape)
@@ -73,7 +91,7 @@ def test_methods_predict_y(model):
     assert_array_less(np.full_like(vf, -1e-6), vf)
 
 
-@pytest.mark.parametrize('model', _state_less_gp_models + _gp_models)
+@pytest.mark.parametrize("model", _state_less_gp_models + _gp_models)
 def test_methods_predict_log_density(model):
     rng = Datum().rng
     Ys = rng.randn(10, 1)

--- a/tests/gpflow/models/test_model_predict.py
+++ b/tests/gpflow/models/test_model_predict.py
@@ -23,15 +23,17 @@ rng = np.random.RandomState(0)
 
 
 class ModelSetup:
-    def __init__(self,
-                 model_class,
-                 kernel=Matern32(),
-                 likelihood=gpflow.likelihoods.Gaussian(),
-                 whiten=None,
-                 q_diag=None,
-                 requires_inducing_variables=True,
-                 requires_data=False,
-                 requires_likelihood=True):
+    def __init__(
+        self,
+        model_class,
+        kernel=Matern32(),
+        likelihood=gpflow.likelihoods.Gaussian(),
+        whiten=None,
+        q_diag=None,
+        requires_inducing_variables=True,
+        requires_data=False,
+        requires_likelihood=True,
+    ):
         self.model_class = model_class
         self.kernel = kernel
         self.likelihood = likelihood
@@ -67,15 +69,29 @@ model_setups = [
     ModelSetup(model_class=gpflow.models.SVGP, whiten=True, q_diag=False),
     ModelSetup(model_class=gpflow.models.SVGP, whiten=True, q_diag=True),
     ModelSetup(model_class=gpflow.models.SVGP, whiten=False, q_diag=False),
-    ModelSetup(model_class=gpflow.models.SGPR, requires_data=True, requires_likelihood=False),
-    ModelSetup(model_class=gpflow.models.VGP, requires_inducing_variables=False, requires_data=True),
+    ModelSetup(
+        model_class=gpflow.models.SGPR, requires_data=True, requires_likelihood=False
+    ),
+    ModelSetup(
+        model_class=gpflow.models.VGP,
+        requires_inducing_variables=False,
+        requires_data=True,
+    ),
     #     ModelSetup(model_class=gpflow.models.GPRF),
-    ModelSetup(model_class=gpflow.models.GPMC, requires_data=True, requires_inducing_variables=False),
-    ModelSetup(model_class=gpflow.models.SGPMC, requires_data=True, requires_inducing_variables=True)
+    ModelSetup(
+        model_class=gpflow.models.GPMC,
+        requires_data=True,
+        requires_inducing_variables=False,
+    ),
+    ModelSetup(
+        model_class=gpflow.models.SGPMC,
+        requires_data=True,
+        requires_inducing_variables=True,
+    ),
 ]
 
 
-@pytest.mark.parametrize('Ntrain, Ntest, D', [[100, 10, 2]])
+@pytest.mark.parametrize("Ntrain, Ntest, D", [[100, 10, 2]])
 def test_gaussian_mean_and_variance(Ntrain, Ntest, D):
     data = rng.randn(Ntrain, D), rng.randn(Ntrain, 1)
     Xtest, _ = rng.randn(Ntest, D), rng.randn(Ntest, 1)
@@ -86,10 +102,10 @@ def test_gaussian_mean_and_variance(Ntrain, Ntest, D):
     mu_y, var_y = model_gp.predict_y(Xtest)
 
     assert np.allclose(mu_f, mu_y)
-    assert np.allclose(var_f, var_y - 1.)
+    assert np.allclose(var_f, var_y - 1.0)
 
 
-@pytest.mark.parametrize('Ntrain, Ntest, D', [[100, 10, 2]])
+@pytest.mark.parametrize("Ntrain, Ntest, D", [[100, 10, 2]])
 def test_gaussian_log_density(Ntrain, Ntest, D):
     data = rng.randn(Ntrain, D), rng.randn(Ntrain, 1)
     Xtest, Ytest = rng.randn(Ntest, D), rng.randn(Ntest, 1)
@@ -99,12 +115,16 @@ def test_gaussian_log_density(Ntrain, Ntest, D):
     mu_y, var_y = model_gp.predict_y(Xtest)
     data = Xtest, Ytest
     log_density = model_gp.predict_log_density(data)
-    log_density_hand = (-0.5 * np.log(2 * np.pi) - 0.5 * np.log(var_y) - 0.5 * np.square(mu_y - Ytest) / var_y)
+    log_density_hand = (
+        -0.5 * np.log(2 * np.pi)
+        - 0.5 * np.log(var_y)
+        - 0.5 * np.square(mu_y - Ytest) / var_y
+    )
 
     assert np.allclose(log_density_hand, log_density)
 
 
-@pytest.mark.parametrize('input_dim, output_dim, N, Ntest, M', [[3, 2, 20, 30, 5]])
+@pytest.mark.parametrize("input_dim, output_dim, N, Ntest, M", [[3, 2, 20, 30, 5]])
 def test_gaussian_full_cov(input_dim, output_dim, N, Ntest, M):
     covar_shape = (output_dim, Ntest, Ntest)
     X, Y, Z = rng.randn(N, input_dim), rng.randn(N, output_dim), rng.randn(M, input_dim)
@@ -115,15 +135,17 @@ def test_gaussian_full_cov(input_dim, output_dim, N, Ntest, M):
     mu1, var = model_gp.predict_f(Xtest, full_cov=False)
     mu2, covar = model_gp.predict_f(Xtest, full_cov=True)
 
-    assert np.allclose(mu1, mu2, atol=1.e-10)
+    assert np.allclose(mu1, mu2, atol=1.0e-10)
     assert covar.shape == covar_shape
     assert var.shape == (Ntest, output_dim)
     for i in range(output_dim):
         assert np.allclose(var[:, i], np.diag(covar[i, :, :]))
 
 
-@pytest.mark.skip(reason='GPR model is not ready')
-@pytest.mark.parametrize('input_dim, output_dim, N, Ntest, M, num_samples', [[3, 2, 20, 30, 5, 5]])
+@pytest.mark.skip(reason="GPR model is not ready")
+@pytest.mark.parametrize(
+    "input_dim, output_dim, N, Ntest, M, num_samples", [[3, 2, 20, 30, 5, 5]]
+)
 def test_gaussian_full_cov_samples(input_dim, output_dim, N, Ntest, M, num_samples):
     samples_shape = (num_samples, Ntest, output_dim)
     X, Y, _ = rng.randn(N, input_dim), rng.randn(N, output_dim), rng.randn(M, input_dim)
@@ -135,12 +157,12 @@ def test_gaussian_full_cov_samples(input_dim, output_dim, N, Ntest, M, num_sampl
     assert samples.shape == samples_shape
 
 
-@pytest.mark.parametrize('model_setup', model_setups)
-@pytest.mark.parametrize('input_dim', [3])
-@pytest.mark.parametrize('output_dim', [2])
-@pytest.mark.parametrize('N', [20])
-@pytest.mark.parametrize('Ntest', [30])
-@pytest.mark.parametrize('M', [5])
+@pytest.mark.parametrize("model_setup", model_setups)
+@pytest.mark.parametrize("input_dim", [3])
+@pytest.mark.parametrize("output_dim", [2])
+@pytest.mark.parametrize("N", [20])
+@pytest.mark.parametrize("Ntest", [30])
+@pytest.mark.parametrize("M", [5])
 def test_other_models_full_cov(model_setup, input_dim, output_dim, N, Ntest, M):
     covar_shape = (output_dim, Ntest, Ntest)
     X, Y = rng.randn(N, input_dim), rng.randn(N, output_dim)
@@ -151,21 +173,23 @@ def test_other_models_full_cov(model_setup, input_dim, output_dim, N, Ntest, M):
     mu1, var = model_gp.predict_f(Xtest, full_cov=False)
     mu2, covar = model_gp.predict_f(Xtest, full_cov=True)
 
-    assert np.allclose(mu1, mu2, atol=1.e-10)
+    assert np.allclose(mu1, mu2, atol=1.0e-10)
     assert covar.shape == covar_shape
     assert var.shape == (Ntest, output_dim)
     for i in range(output_dim):
         assert np.allclose(var[:, i], np.diag(covar[i, :, :]))
 
 
-@pytest.mark.parametrize('model_setup', model_setups)
-@pytest.mark.parametrize('input_dim', [3])
-@pytest.mark.parametrize('output_dim', [2])
-@pytest.mark.parametrize('N', [20])
-@pytest.mark.parametrize('Ntest', [30])
-@pytest.mark.parametrize('M', [5])
-@pytest.mark.parametrize('num_samples', [5])
-def test_other_models_full_cov_samples(model_setup, input_dim, output_dim, N, Ntest, M, num_samples):
+@pytest.mark.parametrize("model_setup", model_setups)
+@pytest.mark.parametrize("input_dim", [3])
+@pytest.mark.parametrize("output_dim", [2])
+@pytest.mark.parametrize("N", [20])
+@pytest.mark.parametrize("Ntest", [30])
+@pytest.mark.parametrize("M", [5])
+@pytest.mark.parametrize("num_samples", [5])
+def test_other_models_full_cov_samples(
+    model_setup, input_dim, output_dim, N, Ntest, M, num_samples
+):
     samples_shape = (num_samples, Ntest, output_dim)
     X, Y, Z = rng.randn(N, input_dim), rng.randn(N, output_dim), rng.randn(M, input_dim)
     Xtest = rng.randn(Ntest, input_dim)

--- a/tests/gpflow/models/test_sgpr.py
+++ b/tests/gpflow/models/test_sgpr.py
@@ -35,13 +35,21 @@ class Datum:
 
 def test_sgpr_qu():
     rng = Datum().rng
-    X, Z = tf.cast(rng.randn(100, 2), default_float()), tf.cast(rng.randn(20, 2), default_float())
-    Y = tf.cast(np.sin(X @ np.array([[-1.4], [0.5]])) + 0.5 * np.random.randn(len(X), 1), default_float())
-    model = gpflow.models.SGPR((X, Y), kernel=gpflow.kernels.SquaredExponential(), inducing_variable=Z)
+    X, Z = (
+        tf.cast(rng.randn(100, 2), default_float()),
+        tf.cast(rng.randn(20, 2), default_float()),
+    )
+    Y = tf.cast(
+        np.sin(X @ np.array([[-1.4], [0.5]])) + 0.5 * np.random.randn(len(X), 1),
+        default_float(),
+    )
+    model = gpflow.models.SGPR(
+        (X, Y), kernel=gpflow.kernels.SquaredExponential(), inducing_variable=Z
+    )
 
     @tf.function
     def closure():
-        return - model.log_marginal_likelihood()
+        return -model.log_marginal_likelihood()
 
     gpflow.optimizers.Scipy().minimize(closure, variables=model.trainable_variables)
 
@@ -49,4 +57,6 @@ def test_sgpr_qu():
     f_at_Z_mean, f_at_Z_cov = model.predict_f(model.inducing_variable.Z, full_cov=True)
 
     np.testing.assert_allclose(qu_mean, f_at_Z_mean, rtol=1e-5, atol=1e-5)
-    np.testing.assert_allclose(tf.reshape(qu_cov, (1, 20, 20)), f_at_Z_cov, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(
+        tf.reshape(qu_cov, (1, 20, 20)), f_at_Z_cov, rtol=1e-5, atol=1e-5
+    )

--- a/tests/gpflow/models/test_svgp.py
+++ b/tests/gpflow/models/test_svgp.py
@@ -26,9 +26,9 @@ from gpflow.config import default_float
 class DatumSVGP:
     rng: np.random.RandomState = np.random.RandomState(0)
     X = rng.randn(20, 1)
-    Y = rng.randn(20, 2)**2
+    Y = rng.randn(20, 2) ** 2
     Z = rng.randn(3, 1)
-    qsqrt = (rng.randn(3, 2)**2) * 0.01
+    qsqrt = (rng.randn(3, 2) ** 2) * 0.01
     qmean = rng.randn(3, 2)
     lik = gpflow.likelihoods.Exponential()
     data = (X, Y)
@@ -42,12 +42,14 @@ def test_svgp_fixing_q_sqrt():
     In response to bug #46, we need to make sure that the q_sqrt matrix can be fixed
     """
     num_latent = default_datum_svgp.Y.shape[1]
-    model = gpflow.models.SVGP(kernel=gpflow.kernels.SquaredExponential(),
-                               likelihood=default_datum_svgp.lik,
-                               q_diag=True,
-                               num_latent=num_latent,
-                               inducing_variable=default_datum_svgp.Z,
-                               whiten=False)
+    model = gpflow.models.SVGP(
+        kernel=gpflow.kernels.SquaredExponential(),
+        likelihood=default_datum_svgp.lik,
+        q_diag=True,
+        num_latent=num_latent,
+        inducing_variable=default_datum_svgp.Z,
+        whiten=False,
+    )
     default_num_trainable_variables = len(model.trainable_variables)
     model.q_sqrt.trainable = False
     assert len(model.trainable_variables) == default_num_trainable_variables - 1
@@ -59,23 +61,37 @@ def test_svgp_white():
     with and without diagonals when whitening.
     """
     num_latent = default_datum_svgp.Y.shape[1]
-    model_1 = gpflow.models.SVGP(kernel=gpflow.kernels.SquaredExponential(),
-                                 likelihood=default_datum_svgp.lik,
-                                 q_diag=True,
-                                 num_latent=num_latent,
-                                 inducing_variable=default_datum_svgp.Z,
-                                 whiten=True)
-    model_2 = gpflow.models.SVGP(kernel=gpflow.kernels.SquaredExponential(),
-                                 likelihood=default_datum_svgp.lik,
-                                 q_diag=False,
-                                 num_latent=num_latent,
-                                 inducing_variable=default_datum_svgp.Z,
-                                 whiten=True)
+    model_1 = gpflow.models.SVGP(
+        kernel=gpflow.kernels.SquaredExponential(),
+        likelihood=default_datum_svgp.lik,
+        q_diag=True,
+        num_latent=num_latent,
+        inducing_variable=default_datum_svgp.Z,
+        whiten=True,
+    )
+    model_2 = gpflow.models.SVGP(
+        kernel=gpflow.kernels.SquaredExponential(),
+        likelihood=default_datum_svgp.lik,
+        q_diag=False,
+        num_latent=num_latent,
+        inducing_variable=default_datum_svgp.Z,
+        whiten=True,
+    )
     model_1.q_sqrt.assign(default_datum_svgp.qsqrt)
     model_1.q_mu.assign(default_datum_svgp.qmean)
-    model_2.q_sqrt.assign(np.array([np.diag(default_datum_svgp.qsqrt[:, 0]), np.diag(default_datum_svgp.qsqrt[:, 1])]))
+    model_2.q_sqrt.assign(
+        np.array(
+            [
+                np.diag(default_datum_svgp.qsqrt[:, 0]),
+                np.diag(default_datum_svgp.qsqrt[:, 1]),
+            ]
+        )
+    )
     model_2.q_mu.assign(default_datum_svgp.qmean)
-    assert_allclose(model_1.log_likelihood(default_datum_svgp.data), model_2.log_likelihood(default_datum_svgp.data))
+    assert_allclose(
+        model_1.log_likelihood(default_datum_svgp.data),
+        model_2.log_likelihood(default_datum_svgp.data),
+    )
 
 
 def test_svgp_non_white():
@@ -84,23 +100,37 @@ def test_svgp_non_white():
     with and without diagonals when whitening is not used.
     """
     num_latent = default_datum_svgp.Y.shape[1]
-    model_1 = gpflow.models.SVGP(kernel=gpflow.kernels.SquaredExponential(),
-                                 likelihood=default_datum_svgp.lik,
-                                 q_diag=True,
-                                 num_latent=num_latent,
-                                 inducing_variable=default_datum_svgp.Z,
-                                 whiten=False)
-    model_2 = gpflow.models.SVGP(kernel=gpflow.kernels.SquaredExponential(),
-                                 likelihood=default_datum_svgp.lik,
-                                 q_diag=False,
-                                 num_latent=num_latent,
-                                 inducing_variable=default_datum_svgp.Z,
-                                 whiten=False)
+    model_1 = gpflow.models.SVGP(
+        kernel=gpflow.kernels.SquaredExponential(),
+        likelihood=default_datum_svgp.lik,
+        q_diag=True,
+        num_latent=num_latent,
+        inducing_variable=default_datum_svgp.Z,
+        whiten=False,
+    )
+    model_2 = gpflow.models.SVGP(
+        kernel=gpflow.kernels.SquaredExponential(),
+        likelihood=default_datum_svgp.lik,
+        q_diag=False,
+        num_latent=num_latent,
+        inducing_variable=default_datum_svgp.Z,
+        whiten=False,
+    )
     model_1.q_sqrt.assign(default_datum_svgp.qsqrt)
     model_1.q_mu.assign(default_datum_svgp.qmean)
-    model_2.q_sqrt.assign(np.array([np.diag(default_datum_svgp.qsqrt[:, 0]), np.diag(default_datum_svgp.qsqrt[:, 1])]))
+    model_2.q_sqrt.assign(
+        np.array(
+            [
+                np.diag(default_datum_svgp.qsqrt[:, 0]),
+                np.diag(default_datum_svgp.qsqrt[:, 1]),
+            ]
+        )
+    )
     model_2.q_mu.assign(default_datum_svgp.qmean)
-    assert_allclose(model_1.log_likelihood(default_datum_svgp.data), model_2.log_likelihood(default_datum_svgp.data))
+    assert_allclose(
+        model_1.log_likelihood(default_datum_svgp.data),
+        model_2.log_likelihood(default_datum_svgp.data),
+    )
 
 
 def _check_models_close(m1, m2, tolerance=1e-2):
@@ -111,16 +141,17 @@ def _check_models_close(m1, m2, tolerance=1e-2):
     for key in m1_params:
         p1 = m1_params[key]
         p2 = m2_params[key]
-        if not np.allclose(p1.read_value(), p2.read_value(), rtol=tolerance, atol=tolerance):
+        if not np.allclose(
+            p1.read_value(), p2.read_value(), rtol=tolerance, atol=tolerance
+        ):
             return False
     return True
 
 
-@pytest.mark.parametrize('indices_1, indices_2, num_data1, num_data2, max_iter', [
-    [[0, 1], [1, 0], 2, 2, 3],
-    [[0, 1], [0, 0], 1, 2, 1],
-    [[0, 0], [0, 1], 1, 1, 2],
-])
+@pytest.mark.parametrize(
+    "indices_1, indices_2, num_data1, num_data2, max_iter",
+    [[[0, 1], [1, 0], 2, 2, 3], [[0, 1], [0, 0], 1, 2, 1], [[0, 0], [0, 1], 1, 1, 2],],
+)
 def test_stochastic_gradients(indices_1, indices_2, num_data1, num_data2, max_iter):
     """
     In response to bug #281, we need to make sure stochastic update
@@ -135,18 +166,20 @@ def test_stochastic_gradients(indices_1, indices_2, num_data1, num_data2, max_it
     In this test we substitute a deterministic analogue of the batchs
     sampler for which we can predict the effects of different updates.
     """
-    X, Y = np.atleast_2d(np.array([0., 1.])).T, np.atleast_2d(np.array([-1., 3.])).T
+    X, Y = np.atleast_2d(np.array([0.0, 1.0])).T, np.atleast_2d(np.array([-1.0, 3.0])).T
     Z = np.atleast_2d(np.array([0.5]))
 
     def get_model(num_data):
-        return gpflow.models.SVGP(kernel=gpflow.kernels.SquaredExponential(),
-                                  num_data=num_data,
-                                  likelihood=gpflow.likelihoods.Gaussian(),
-                                  inducing_variable=Z)
+        return gpflow.models.SVGP(
+            kernel=gpflow.kernels.SquaredExponential(),
+            num_data=num_data,
+            likelihood=gpflow.likelihoods.Gaussian(),
+            inducing_variable=Z,
+        )
 
     def training_loop(indices, num_data, max_iter):
         model = get_model(num_data)
-        opt = tf.optimizers.SGD(learning_rate=.001)
+        opt = tf.optimizers.SGD(learning_rate=0.001)
         data = X[indices], Y[indices]
         for _ in range(max_iter):
             with tf.GradientTape() as tape:

--- a/tests/gpflow/models/test_variational.py
+++ b/tests/gpflow/models/test_variational.py
@@ -29,8 +29,11 @@ rng = np.random.RandomState(1)
 
 
 def univariate_log_marginal_likelihood(y, K, noise_var):
-    return (-0.5 * y * y / (K + noise_var) - 0.5 * np.log(K + noise_var) -
-            0.5 * np.log(np.pi * 2.))
+    return (
+        -0.5 * y * y / (K + noise_var)
+        - 0.5 * np.log(K + noise_var)
+        - 0.5 * np.log(np.pi * 2.0)
+    )
 
 
 def univariate_posterior(y, K, noise_var):
@@ -41,8 +44,13 @@ def univariate_posterior(y, K, noise_var):
 
 def univariate_prior_KL(meanA, meanB, varA, varB):
     # KL[ qA | qB ] = E_{qA} \log [qA / qB] where qA and qB are univariate normal distributions.
-    return (0.5 * (np.log(varB) - np.log(varA) - 1. + varA / varB +
-                   (meanB - meanA) * (meanB - meanA) / varB))
+    return 0.5 * (
+        np.log(varB)
+        - np.log(varA)
+        - 1.0
+        + varA / varB
+        + (meanB - meanA) * (meanB - meanA) / varB
+    )
 
 
 def multivariate_prior_KL(meanA, covA, meanB, covB):
@@ -58,8 +66,13 @@ def multivariate_prior_KL(meanA, covA, meanB, covB):
     constantTerm = -0.5 * K
     priorLogDeterminantTerm = 0.5 * np.linalg.slogdet(covB)[1]
     variationalLogDeterminantTerm = -0.5 * np.linalg.slogdet(covA)[1]
-    return (traceTerm + mahalanobisTerm + constantTerm +
-            priorLogDeterminantTerm + variationalLogDeterminantTerm)
+    return (
+        traceTerm
+        + mahalanobisTerm
+        + constantTerm
+        + priorLogDeterminantTerm
+        + variationalLogDeterminantTerm
+    )
 
 
 # ------------------------------------------
@@ -69,16 +82,16 @@ def multivariate_prior_KL(meanA, covA, meanB, covB):
 
 class Datum:
     num_latent = 1
-    y_data = 2.
-    X = np.atleast_2d(np.array([0.]))
+    y_data = 2.0
+    X = np.atleast_2d(np.array([0.0]))
     Y = np.atleast_2d(np.array([y_data]))
     Z = X.copy()
-    zero_mean = 0.
-    K = 1.
+    zero_mean = 0.0
+    K = 1.0
     noise_var = 0.5
-    posterior_mean, posterior_var = univariate_posterior(y=y_data,
-                                                         K=K,
-                                                         noise_var=noise_var)
+    posterior_mean, posterior_var = univariate_posterior(
+        y=y_data, K=K, noise_var=noise_var
+    )
     posterior_std = np.sqrt(posterior_var)
     data = (X, Y)
 
@@ -104,105 +117,112 @@ def test_reference_implementation_consistency():
     p_cov = rng.rand(1, 1)
 
     multivariate_KL = multivariate_prior_KL(q_mean, p_mean, q_cov, p_cov)
-    univariate_KL = univariate_prior_KL(q_mean.reshape(-1), p_mean.reshape(-1),
-                                        q_cov.reshape(-1), p_cov.reshape(-1))
+    univariate_KL = univariate_prior_KL(
+        q_mean.reshape(-1), p_mean.reshape(-1), q_cov.reshape(-1), p_cov.reshape(-1)
+    )
 
     assert_allclose(univariate_KL - multivariate_KL, 0, atol=4)
 
 
-@pytest.mark.parametrize('diag', [True, False])
-@pytest.mark.parametrize('whiten', [True, False])
+@pytest.mark.parametrize("diag", [True, False])
+@pytest.mark.parametrize("whiten", [True, False])
 def test_variational_univariate_prior_KL(diag, whiten):
-    reference_kl = univariate_prior_KL(Datum.posterior_mean, Datum.zero_mean,
-                                       Datum.posterior_var, Datum.K)
+    reference_kl = univariate_prior_KL(
+        Datum.posterior_mean, Datum.zero_mean, Datum.posterior_var, Datum.K
+    )
     q_mu = np.ones((1, Datum.num_latent)) * Datum.posterior_mean
-    ones = np.ones((1, Datum.num_latent)) if diag else np.ones(
-        (1, 1, Datum.num_latent))
+    ones = np.ones((1, Datum.num_latent)) if diag else np.ones((1, 1, Datum.num_latent))
     q_sqrt = ones * Datum.posterior_std
-    model = gpflow.models.SVGP(kernel=SquaredExponential(variance=Datum.K),
-                               likelihood=Gaussian(),
-                               inducing_variable=Datum.Z,
-                               num_latent=Datum.num_latent,
-                               q_diag=diag,
-                               whiten=whiten,
-                               q_mu=q_mu,
-                               q_sqrt=q_sqrt)
+    model = gpflow.models.SVGP(
+        kernel=SquaredExponential(variance=Datum.K),
+        likelihood=Gaussian(),
+        inducing_variable=Datum.Z,
+        num_latent=Datum.num_latent,
+        q_diag=diag,
+        whiten=whiten,
+        q_mu=q_mu,
+        q_sqrt=q_sqrt,
+    )
     test_prior_KL = model.prior_kl()
     assert_allclose(reference_kl - test_prior_KL, 0, atol=4)
 
 
-@pytest.mark.parametrize('diag', [True, False])
-@pytest.mark.parametrize('whiten', [True, False])
+@pytest.mark.parametrize("diag", [True, False])
+@pytest.mark.parametrize("whiten", [True, False])
 def test_variational_univariate_log_likelihood(diag, whiten):
     # reference marginal likelihood estimate
     reference_log_marginal_likelihood = univariate_log_marginal_likelihood(
-        y=Datum.y_data, K=Datum.K, noise_var=Datum.noise_var)
+        y=Datum.y_data, K=Datum.K, noise_var=Datum.noise_var
+    )
     q_mu = np.ones((1, Datum.num_latent)) * Datum.posterior_mean
-    ones = np.ones((1, Datum.num_latent)) if diag else np.ones(
-        (1, 1, Datum.num_latent))
+    ones = np.ones((1, Datum.num_latent)) if diag else np.ones((1, 1, Datum.num_latent))
     q_sqrt = ones * Datum.posterior_std
-    model = gpflow.models.SVGP(kernel=SquaredExponential(variance=Datum.K),
-                               likelihood=Gaussian(),
-                               inducing_variable=Datum.Z,
-                               num_latent=Datum.num_latent,
-                               q_diag=diag,
-                               whiten=whiten,
-                               q_mu=q_mu,
-                               q_sqrt=q_sqrt)
+    model = gpflow.models.SVGP(
+        kernel=SquaredExponential(variance=Datum.K),
+        likelihood=Gaussian(),
+        inducing_variable=Datum.Z,
+        num_latent=Datum.num_latent,
+        q_diag=diag,
+        whiten=whiten,
+        q_mu=q_mu,
+        q_sqrt=q_sqrt,
+    )
     model_likelihood = model.log_likelihood(Datum.data).numpy()
-    assert_allclose(model_likelihood - reference_log_marginal_likelihood,
-                    0,
-                    atol=4)
+    assert_allclose(model_likelihood - reference_log_marginal_likelihood, 0, atol=4)
 
 
-@pytest.mark.parametrize('diag', [True, False])
-@pytest.mark.parametrize('whiten', [True, False])
+@pytest.mark.parametrize("diag", [True, False])
+@pytest.mark.parametrize("whiten", [True, False])
 def test_variational_univariate_conditionals(diag, whiten):
     q_mu = np.ones((1, Datum.num_latent)) * Datum.posterior_mean
-    ones = np.ones((1, Datum.num_latent)) if diag else np.ones(
-        (1, 1, Datum.num_latent))
+    ones = np.ones((1, Datum.num_latent)) if diag else np.ones((1, 1, Datum.num_latent))
     q_sqrt = ones * Datum.posterior_std
-    model = gpflow.models.SVGP(kernel=SquaredExponential(variance=Datum.K),
-                               likelihood=Gaussian(),
-                               inducing_variable=Datum.Z,
-                               num_latent=Datum.num_latent,
-                               q_diag=diag,
-                               whiten=whiten,
-                               q_mu=q_mu,
-                               q_sqrt=q_sqrt)
+    model = gpflow.models.SVGP(
+        kernel=SquaredExponential(variance=Datum.K),
+        likelihood=Gaussian(),
+        inducing_variable=Datum.Z,
+        num_latent=Datum.num_latent,
+        q_diag=diag,
+        whiten=whiten,
+        q_mu=q_mu,
+        q_sqrt=q_sqrt,
+    )
 
     fmean_func, fvar_func = gpflow.conditionals.conditional(
-        Datum.X,
-        Datum.Z,
-        model.kernel,
-        model.q_mu,
-        q_sqrt=model.q_sqrt,
-        white=whiten)
+        Datum.X, Datum.Z, model.kernel, model.q_mu, q_sqrt=model.q_sqrt, white=whiten
+    )
     mean_value, var_value = fmean_func[0, 0], fvar_func[0, 0]
 
     assert_allclose(mean_value - Datum.posterior_mean, 0, atol=4)
     assert_allclose(var_value - Datum.posterior_var, 0, atol=4)
 
 
-@pytest.mark.parametrize('whiten', [True, False])
+@pytest.mark.parametrize("whiten", [True, False])
 def test_variational_multivariate_prior_KL_full_q(whiten):
     cov_q = MultiDatum.q_sqrt_full @ MultiDatum.q_sqrt_full.T
     mean_prior = np.zeros((MultiDatum.dim, 1))
-    cov_prior = np.eye(MultiDatum.dim) if whiten else ref_rbf_kernel(
-        MultiDatum.X, MultiDatum.ls, MultiDatum.signal_var)
-    reference_kl = multivariate_prior_KL(MultiDatum.q_mean, cov_q, mean_prior,
-                                         cov_prior)
+    cov_prior = (
+        np.eye(MultiDatum.dim)
+        if whiten
+        else ref_rbf_kernel(MultiDatum.X, MultiDatum.ls, MultiDatum.signal_var)
+    )
+    reference_kl = multivariate_prior_KL(
+        MultiDatum.q_mean, cov_q, mean_prior, cov_prior
+    )
 
     q_sqrt = MultiDatum.q_sqrt_full[None, :, :]
-    model = gpflow.models.SVGP(kernel=SquaredExponential(variance=MultiDatum.signal_var,
-                                                         lengthscale=MultiDatum.ls),
-                               likelihood=Gaussian(MultiDatum.noise_var),
-                               inducing_variable=MultiDatum.Z,
-                               num_latent=MultiDatum.num_latent,
-                               q_diag=False,
-                               whiten=whiten,
-                               q_mu=MultiDatum.q_mean,
-                               q_sqrt=q_sqrt)
+    model = gpflow.models.SVGP(
+        kernel=SquaredExponential(
+            variance=MultiDatum.signal_var, lengthscale=MultiDatum.ls
+        ),
+        likelihood=Gaussian(MultiDatum.noise_var),
+        inducing_variable=MultiDatum.Z,
+        num_latent=MultiDatum.num_latent,
+        q_diag=False,
+        whiten=whiten,
+        q_mu=MultiDatum.q_mean,
+        q_sqrt=q_sqrt,
+    )
 
     test_prior_kl = model.prior_kl()
     assert_allclose(reference_kl - test_prior_kl, 0, atol=4)

--- a/tests/gpflow/optimizers/test_mcmc.py
+++ b/tests/gpflow/optimizers/test_mcmc.py
@@ -17,7 +17,7 @@ np.random.seed(1)
 def build_data():
     N = 30
     X = np.random.rand(N, 1)
-    Y = np.sin(12*X) + 0.66*np.cos(25*X) + np.random.randn(N, 1)*0.1 + 3
+    Y = np.sin(12 * X) + 0.66 * np.cos(25 * X) + np.random.randn(N, 1) * 0.1 + 3
     return (X, Y)
 
 
@@ -43,7 +43,10 @@ def test_mcmc_helper_parameters():
         assert model.trainable_parameters[i].shape == hmc_helper.current_state[i].shape
         assert model.trainable_parameters[i] == hmc_helper._parameters[i]
         if isinstance(model.trainable_parameters[i], gpflow.Parameter):
-            assert model.trainable_parameters[i].unconstrained_variable == hmc_helper.current_state[i]
+            assert (
+                model.trainable_parameters[i].unconstrained_variable
+                == hmc_helper.current_state[i]
+            )
 
 
 def test_mcmc_helper_target_function_constrained():
@@ -60,7 +63,7 @@ def test_mcmc_helper_target_function_constrained():
     target_log_prob_fn = hmc_helper.target_log_prob_fn
 
     # Priors which are set on the constrained space
-    expected_log_prior = 0.
+    expected_log_prior = 0.0
     for param in model.trainable_parameters:
         if param.value() < 1e-3:
             # Avoid values which would be pathological for the Exp transform
@@ -92,7 +95,7 @@ def test_mcmc_helper_target_function_unconstrained():
     model = build_model(data)
 
     # Set up priors on the model parameters such that we can readily compute their expected values.
-    expected_log_prior = 0.
+    expected_log_prior = 0.0
     prior_width = 200.0
 
     hmc_helper = gpflow.optimizers.SamplingHelper(
@@ -103,7 +106,7 @@ def test_mcmc_helper_target_function_unconstrained():
         low_value = -100
         high_value = low_value + prior_width
         param.prior = Uniform(low=np.float64(low_value), high=np.float64(high_value))
-        param.prior_on = 'unconstrained'
+        param.prior_on = "unconstrained"
 
         prior_density = 1 / prior_width
         expected_log_prior += np.log(prior_density)
@@ -120,7 +123,7 @@ def test_mcmc_helper_target_function_no_transforms(prior_on):
     """
     data = build_data()
     model = build_model(data)
-    expected_log_prior = 0.
+    expected_log_prior = 0.0
     prior_width = 200.0
 
     hmc_helper = gpflow.optimizers.SamplingHelper(
@@ -161,14 +164,14 @@ def test_mcmc_sampler_integration():
     hmc = tfp.mcmc.HamiltonianMonteCarlo(
         target_log_prob_fn=hmc_helper.target_log_prob_fn,
         num_leapfrog_steps=2,
-        step_size=0.01
+        step_size=0.01,
     )
 
     adaptive_hmc = tfp.mcmc.SimpleStepSizeAdaptation(
         hmc,
         num_adaptation_steps=2,
         target_accept_prob=gpflow.utilities.to_default_float(0.75),
-        adaptation_rate=0.1
+        adaptation_rate=0.1,
     )
 
     num_samples = 5
@@ -180,8 +183,9 @@ def test_mcmc_sampler_integration():
             num_burnin_steps=2,
             current_state=hmc_helper.current_state,
             kernel=adaptive_hmc,
-            trace_fn=lambda _, pkr: pkr.inner_results.is_accepted
+            trace_fn=lambda _, pkr: pkr.inner_results.is_accepted,
         )
+
     samples, _ = run_chain_fn()
 
     assert len(samples) == len(model.trainable_parameters)

--- a/tests/gpflow/optimizers/test_natural_gradient.py
+++ b/tests/gpflow/optimizers/test_natural_gradient.py
@@ -59,11 +59,13 @@ def sgpr_and_svgp(data, inducing_variable, kernel, likelihood):
     return sgpr, svgp
 
 
-def assert_gpr_vs_vgp(m1: tf.Module,
-                      m2: tf.Module,
-                      gamma: float = 1.0,
-                      maxiter: int = 1,
-                      xi_transform: Optional[gpflow.optimizers.natgrad.XiTransform] = None):
+def assert_gpr_vs_vgp(
+    m1: tf.Module,
+    m2: tf.Module,
+    gamma: float = 1.0,
+    maxiter: int = 1,
+    xi_transform: Optional[gpflow.optimizers.natgrad.XiTransform] = None,
+):
     assert maxiter >= 1
 
     m2_ll_before = m2.log_likelihood()
@@ -73,11 +75,11 @@ def assert_gpr_vs_vgp(m1: tf.Module,
 
     @tf.function
     def loss_cb() -> tf.Tensor:
-        return - m2.log_marginal_likelihood()
+        return -m2.log_marginal_likelihood()
 
     params = (m2.q_mu, m2.q_sqrt)
     if xi_transform is not None:
-        params += (xi_transform, )
+        params += (xi_transform,)
 
     opt = NaturalGradient(gamma)
 
@@ -104,10 +106,10 @@ def assert_sgpr_vs_svgp(m1: tf.Module, m2: tf.Module):
 
     @tf.function
     def loss_cb() -> tf.Tensor:
-        return - m2.log_marginal_likelihood(data)
+        return -m2.log_marginal_likelihood(data)
 
     params = [(m2.q_mu, m2.q_sqrt)]
-    opt = NaturalGradient(1.)
+    opt = NaturalGradient(1.0)
     opt.minimize(loss_cb, var_list=params)
 
     m1_ll_after = m1.log_likelihood()

--- a/tests/gpflow/optimizers/test_scipy.py
+++ b/tests/gpflow/optimizers/test_scipy.py
@@ -42,6 +42,7 @@ def _create_full_gp_model():
         mean_function=gpflow.mean_functions.Constant(),
     )
 
+
 def test_scipy_jit():
     m1 = _create_full_gp_model()
     m2 = _create_full_gp_model()
@@ -50,16 +51,22 @@ def test_scipy_jit():
     opt2 = gpflow.optimizers.Scipy()
 
     def closure1():
-        return - m1.log_marginal_likelihood()
+        return -m1.log_marginal_likelihood()
 
     @tf.function
     def closure2():
-        return - m2.log_marginal_likelihood()
+        return -m2.log_marginal_likelihood()
 
-    opt1.minimize(closure1, variables=m1.trainable_variables, options=dict(maxiter=50), jit=False)
-    opt2.minimize(closure2, variables=m2.trainable_variables, options=dict(maxiter=50), jit=True)
+    opt1.minimize(
+        closure1, variables=m1.trainable_variables, options=dict(maxiter=50), jit=False
+    )
+    opt2.minimize(
+        closure2, variables=m2.trainable_variables, options=dict(maxiter=50), jit=True
+    )
 
     def get_values(model):
-        return np.array([var.value().numpy().squeeze() for var in model.trainable_variables])
+        return np.array(
+            [var.value().numpy().squeeze() for var in model.trainable_variables]
+        )
 
     np.testing.assert_allclose(get_values(m1), get_values(m2), rtol=1e-14, atol=1e-15)

--- a/tests/gpflow/test_base_prior.py
+++ b/tests/gpflow/test_base_prior.py
@@ -30,14 +30,18 @@ def test_gpr_objective_equivalence():
     l_value = Datum.lengthscale
 
     l_variable = tf.Variable(l_value, dtype=gpflow.default_float(), trainable=True)
-    m1 = gpflow.models.GPR(data, kernel=gpflow.kernels.SquaredExponential(lengthscale=l_value))
+    m1 = gpflow.models.GPR(
+        data, kernel=gpflow.kernels.SquaredExponential(lengthscale=l_value)
+    )
     m2 = gpflow.models.GPR(data, kernel=gpflow.kernels.SquaredExponential())
     m2.kernel.lengthscale = gpflow.Parameter(l_variable, transform=None)
-    assert np.allclose(m1.kernel.lengthscale.numpy(), m2.kernel.lengthscale.numpy())  # consistency check
+    assert np.allclose(
+        m1.kernel.lengthscale.numpy(), m2.kernel.lengthscale.numpy()
+    )  # consistency check
 
-    assert np.allclose(m1.log_marginal_likelihood().numpy(),
-                       m2.log_marginal_likelihood().numpy()), \
-                       "MLE objective should not depend on Parameter transform"
+    assert np.allclose(
+        m1.log_marginal_likelihood().numpy(), m2.log_marginal_likelihood().numpy()
+    ), "MLE objective should not depend on Parameter transform"
 
 
 def test_log_prior_with_no_prior():
@@ -56,10 +60,11 @@ def test_log_prior_for_uniform_prior():
     """
 
     uniform_prior = Uniform(low=np.float64(0), high=np.float64(100))
-    param = gpflow.Parameter(1., transform=gpflow.utilities.positive(),
-                             prior=uniform_prior)
+    param = gpflow.Parameter(
+        1.0, transform=gpflow.utilities.positive(), prior=uniform_prior
+    )
     low_value = param.log_prior().numpy()
-    param.assign(10.)
+    param.assign(10.0)
     high_value = param.log_prior().numpy()
 
     assert np.isclose(low_value, high_value)
@@ -71,12 +76,15 @@ def test_log_prior_on_unconstrained():
     prior in the constrained space that scales as 1/value.
     """
 
-    initial_value = 1.
-    scale_factor = 10.
+    initial_value = 1.0
+    scale_factor = 10.0
     uniform_prior = Uniform(low=np.float64(0), high=np.float64(100))
-    param = gpflow.Parameter(initial_value, transform=Exp(),
-                             prior=uniform_prior,
-                             prior_on=PriorOn.UNCONSTRAINED)
+    param = gpflow.Parameter(
+        initial_value,
+        transform=Exp(),
+        prior=uniform_prior,
+        prior_on=PriorOn.UNCONSTRAINED,
+    )
     low_value = param.log_prior().numpy()
     param.assign(scale_factor * initial_value)
     high_value = param.log_prior().numpy()
@@ -102,15 +110,15 @@ class DummyModel(gpflow.models.BayesianModel):
         self.theta = gpflow.Parameter(self.value, prior=prior, transform=transform)
 
     def log_likelihood(self):
-        return (self.theta + 5)**2
+        return (self.theta + 5) ** 2
 
 
 def test_map_invariance_to_transform():
     m1 = DummyModel(with_transform=True)
     m2 = DummyModel(with_transform=False)
-    assert np.allclose(m1.log_marginal_likelihood().numpy(),
-                       m2.log_marginal_likelihood().numpy()), \
-                       "MAP objective should not be affected by a transform"
+    assert np.allclose(
+        m1.log_marginal_likelihood().numpy(), m2.log_marginal_likelihood().numpy()
+    ), "MAP objective should not be affected by a transform"
 
 
 def get_gpmc_model_params():
@@ -121,11 +129,12 @@ def get_gpmc_model_params():
 
 
 @pytest.mark.parametrize(
-    'model_class, args',
+    "model_class, args",
     [
         (gpflow.models.GPMC, get_gpmc_model_params()),
-        #(gpflow.models.SGPMC, get_SGPMC_model_params()) # Fails due to inducing_variable=None bug
-    ])
+        # (gpflow.models.SGPMC, get_SGPMC_model_params()) # Fails due to inducing_variable=None bug
+    ],
+)
 def test_v_prior_dtypes(model_class, args):
     with gpflow.config.as_context():
         set_default_float(np.float32)

--- a/tests/gpflow/test_logdensities.py
+++ b/tests/gpflow/test_logdensities.py
@@ -25,76 +25,68 @@ from numpy.testing import assert_allclose
 rng = np.random.RandomState(1)
 
 
-@pytest.mark.parametrize('x, mu, var', [(0.9, 0.5, 1.3)])
+@pytest.mark.parametrize("x, mu, var", [(0.9, 0.5, 1.3)])
 def test_gaussian(x, mu, var):
     gpf = logdensities.gaussian(x, mu, var).numpy()
     sps = scipy.stats.norm(loc=mu, scale=np.sqrt(var)).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
 
 
-@pytest.mark.parametrize('x, mu, var', [(0.9, 0.5, 1.3)])
+@pytest.mark.parametrize("x, mu, var", [(0.9, 0.5, 1.3)])
 def test_lognormal(x, mu, var):
     gpf = logdensities.lognormal(x, mu, var).numpy()
     sps = scipy.stats.lognorm(s=np.sqrt(var), scale=np.exp(mu)).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
 
 
-@pytest.mark.parametrize('x, p', [
-    [1, 0.6],
-    [0, 0.6],
-])
+@pytest.mark.parametrize("x, p", [[1, 0.6], [0, 0.6],])
 def test_bernoulli(x, p):
     gpf = logdensities.bernoulli(x, p).numpy()
     sps = scipy.stats.bernoulli.logpmf(k=x, p=p)
     np.testing.assert_allclose(gpf, sps)
 
 
-@pytest.mark.parametrize('x, lam', [
-    [0, 1.3],
-    [1, 1.3],
-    [2, 1.3],
-])
+@pytest.mark.parametrize("x, lam", [[0, 1.3], [1, 1.3], [2, 1.3],])
 def test_poisson(x, lam):
     gpf = logdensities.poisson(x, lam).numpy()
     sps = scipy.stats.poisson.logpmf(k=x, mu=lam)
     np.testing.assert_allclose(gpf, sps)
 
 
-@pytest.mark.parametrize('x, scale', [(0.9, 1.3)])
+@pytest.mark.parametrize("x, scale", [(0.9, 1.3)])
 def test_exponential(x, scale):
     gpf = logdensities.exponential(x, scale).numpy()
     sps = scipy.stats.expon(loc=0.0, scale=scale).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
 
 
-@pytest.mark.parametrize('x, shape, scale', [(0.9, 0.5, 1.3)])
+@pytest.mark.parametrize("x, shape, scale", [(0.9, 0.5, 1.3)])
 def test_gamma(x, shape, scale):
     gpf = logdensities.gamma(x, shape, scale).numpy()
     sps = scipy.stats.gamma(a=shape, loc=0.0, scale=scale).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
 
 
-@pytest.mark.parametrize('x, mean, scale, df', [
-    (0.9, 0.5, 1.3, 1),
-    (0.9, 0.5, 1.3, 2),
-    (0.9, 0.5, 1.3, 3),
-])
+@pytest.mark.parametrize(
+    "x, mean, scale, df", [(0.9, 0.5, 1.3, 1), (0.9, 0.5, 1.3, 2), (0.9, 0.5, 1.3, 3),]
+)
 def test_student_t(x, mean, scale, df):
     def c(val):
         return tf.cast(val, default_float())
+
     gpf = logdensities.student_t(c(x), c(mean), c(scale), df).numpy()
     sps = scipy.stats.t(df=df, loc=mean, scale=scale).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
 
 
-@pytest.mark.parametrize('x, alpha, beta', [(0.9, 0.5, 1.3)])
+@pytest.mark.parametrize("x, alpha, beta", [(0.9, 0.5, 1.3)])
 def test_beta(x, alpha, beta):
     gpf = logdensities.beta(x, alpha, beta).numpy()
     sps = scipy.stats.beta(a=alpha, b=beta).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
 
 
-@pytest.mark.parametrize('x, mu, sigma', [(0.9, 0.5, 1.3)])
+@pytest.mark.parametrize("x, mu, sigma", [(0.9, 0.5, 1.3)])
 def test_laplace(x, mu, sigma):
     gpf = logdensities.laplace(x, mu, sigma).numpy()
     sps = scipy.stats.laplace(loc=mu, scale=sigma).logpdf(x)
@@ -112,13 +104,10 @@ def test_multivariate_normal(x, mu, cov_sqrt):
 
     if mu.shape[1] > 1:
         if x.shape[1] > 1:
-            sp_result = [
-                mvn.logpdf(x[:, i], mu[:, i], cov) for i in range(mu.shape[1])
-            ]
+            sp_result = [mvn.logpdf(x[:, i], mu[:, i], cov) for i in range(mu.shape[1])]
         else:
             sp_result = [
-                mvn.logpdf(x.ravel(), mu[:, i], cov)
-                for i in range(mu.shape[1])
+                mvn.logpdf(x.ravel(), mu[:, i], cov) for i in range(mu.shape[1])
             ]
     else:
         sp_result = mvn.logpdf(x.T, mu.ravel(), cov)

--- a/tests/gpflow/test_mean_functions.py
+++ b/tests/gpflow/test_mean_functions.py
@@ -19,7 +19,14 @@ from numpy.testing import assert_allclose
 import gpflow
 from gpflow.config import default_int
 from gpflow.inducing_variables import InducingPoints
-from gpflow.mean_functions import Additive, Constant, Linear, Product, SwitchedMeanFunction, Zero
+from gpflow.mean_functions import (
+    Additive,
+    Constant,
+    Linear,
+    Product,
+    SwitchedMeanFunction,
+    Zero,
+)
 
 rng = np.random.RandomState(99021)
 
@@ -31,14 +38,17 @@ class Datum:
 
 _mean_functions = [
     Zero(),
-    Linear(A=rng.randn(Datum.input_dim, Datum.output_dim), b=rng.randn(Datum.output_dim, 1).reshape(-1)),
-    Constant(c=rng.randn(Datum.output_dim, 1).reshape(-1))
+    Linear(
+        A=rng.randn(Datum.input_dim, Datum.output_dim),
+        b=rng.randn(Datum.output_dim, 1).reshape(-1),
+    ),
+    Constant(c=rng.randn(Datum.output_dim, 1).reshape(-1)),
 ]
 
 
-@pytest.mark.parametrize('mean_function_1', _mean_functions)
-@pytest.mark.parametrize('mean_function_2', _mean_functions)
-@pytest.mark.parametrize('operation', ['+', 'x'])
+@pytest.mark.parametrize("mean_function_1", _mean_functions)
+@pytest.mark.parametrize("mean_function_2", _mean_functions)
+@pytest.mark.parametrize("operation", ["+", "x"])
 def test_mean_functions_output_shape(mean_function_1, mean_function_2, operation):
     """
     Test the output shape for basic and compositional mean functions, also
@@ -50,9 +60,9 @@ def test_mean_functions_output_shape(mean_function_1, mean_function_2, operation
     assert Y.shape in [(Datum.N, Datum.output_dim), (Datum.N, 1)]
 
     # composed mean function output shape check
-    if operation == '+':
+    if operation == "+":
         mean_composed = mean_function_1 + mean_function_2
-    elif operation == 'x':
+    elif operation == "x":
         mean_composed = mean_function_1 * mean_function_2
     else:
         raise (NotImplementedError)
@@ -61,14 +71,14 @@ def test_mean_functions_output_shape(mean_function_1, mean_function_2, operation
     assert Y_composed.shape in [(Datum.N, Datum.output_dim), (Datum.N, 1)]
 
 
-@pytest.mark.parametrize('mean_function_1', _mean_functions)
-@pytest.mark.parametrize('mean_function_2', _mean_functions)
-@pytest.mark.parametrize('operation', ['+', 'x'])
+@pytest.mark.parametrize("mean_function_1", _mean_functions)
+@pytest.mark.parametrize("mean_function_2", _mean_functions)
+@pytest.mark.parametrize("operation", ["+", "x"])
 def test_mean_functions_composite_type(mean_function_1, mean_function_2, operation):
-    if operation == '+':
+    if operation == "+":
         mean_composed = mean_function_1 + mean_function_2
         assert isinstance(mean_composed, Additive)
-    elif operation == 'x':
+    elif operation == "x":
         mean_composed = mean_function_1 * mean_function_2
         assert isinstance(mean_composed, Product)
     else:
@@ -76,23 +86,32 @@ def test_mean_functions_composite_type(mean_function_1, mean_function_2, operati
 
 
 _linear_functions = [
-    Linear(A=rng.randn(Datum.input_dim, Datum.output_dim), b=rng.randn(Datum.output_dim, 1).reshape(-1))
+    Linear(
+        A=rng.randn(Datum.input_dim, Datum.output_dim),
+        b=rng.randn(Datum.output_dim, 1).reshape(-1),
+    )
     for _ in range(3)
 ]
 
 # Append inverse of first Linear mean function in _linear_functions
-_linear_functions.append(Linear(A=-1. * _linear_functions[0].A, b=-1. * _linear_functions[0].b))
+_linear_functions.append(
+    Linear(A=-1.0 * _linear_functions[0].A, b=-1.0 * _linear_functions[0].b)
+)
 
-_constant_functions = [Constant(c=rng.randn(Datum.output_dim, 1).reshape(-1)) for _ in range(3)]
+_constant_functions = [
+    Constant(c=rng.randn(Datum.output_dim, 1).reshape(-1)) for _ in range(3)
+]
 # Append inverse of first Constant mean function in _constant_functions
-_constant_functions.append(Constant(c=-1. * _constant_functions[0].c))
+_constant_functions.append(Constant(c=-1.0 * _constant_functions[0].c))
 
 
 def _create_GPR_model_with_bias(X, Y, mean_function):
-    return gpflow.models.GPR((X, Y), mean_function=mean_function, kernel=gpflow.kernels.Bias(Datum.input_dim))
+    return gpflow.models.GPR(
+        (X, Y), mean_function=mean_function, kernel=gpflow.kernels.Bias(Datum.input_dim)
+    )
 
 
-@pytest.mark.parametrize('mean_functions', [_linear_functions, _constant_functions])
+@pytest.mark.parametrize("mean_functions", [_linear_functions, _constant_functions])
 def test_mean_functions_distributive_property(mean_functions):
     """
     Tests that distributive property of addition and multiplication holds for mean functions
@@ -114,7 +133,7 @@ def test_mean_functions_distributive_property(mean_functions):
     assert_allclose(var_lhs, var_rhs)
 
 
-@pytest.mark.parametrize('mean_functions', [_linear_functions, _constant_functions])
+@pytest.mark.parametrize("mean_functions", [_linear_functions, _constant_functions])
 def test_mean_functions_A_minus_A_equals_zero(mean_functions):
     """
     Tests that the addition the inverse of a mean function to itself is equivalent to having a
@@ -136,7 +155,7 @@ def test_mean_functions_A_minus_A_equals_zero(mean_functions):
     assert_allclose(var_lhs, var_rhs)
 
 
-@pytest.mark.parametrize('mean_functions', [_linear_functions])
+@pytest.mark.parametrize("mean_functions", [_linear_functions])
 def test_linear_mean_functions_associative_property(mean_functions):
     """
     Tests that associative property of addition holds for linear mean functions:
@@ -163,7 +182,7 @@ def test_linear_mean_functions_associative_property(mean_functions):
     assert_allclose(var_b, var_rhs)
 
 
-@pytest.mark.parametrize('N, D', [[10, 3]])
+@pytest.mark.parametrize("N, D", [[10, 3]])
 def test_switched_mean_function(N, D):
     """
     Test for the SwitchedMeanFunction.
@@ -172,7 +191,7 @@ def test_switched_mean_function(N, D):
     zeros, ones = Constant(np.zeros(1)), Constant(np.ones(1))
     switched_mean = SwitchedMeanFunction([zeros, ones])
 
-    np_list = np.array([0., 1.])
+    np_list = np.array([0.0, 1.0])
     result_ref = (np_list[X[:, D].astype(default_int())]).reshape(-1, 1)
     result = switched_mean(X)
 
@@ -185,7 +204,7 @@ def test_bug_277_regression():
     """
     model1, model2 = Linear(), Linear()
     assert model1.b.numpy() == model2.b.numpy()
-    model2.b.assign([1.])
+    model2.b.assign([1.0])
     assert not model1.b.numpy() == model2.b.numpy()
 
 
@@ -197,11 +216,11 @@ _model_classes = [
     gpflow.models.SVGP,
     gpflow.models.VGP,
     gpflow.models.GPMC,
-    gpflow.models.SGPMC
+    gpflow.models.SGPMC,
 ]
 
 
-@pytest.mark.parametrize('model_class', _model_classes)
+@pytest.mark.parametrize("model_class", _model_classes)
 def test_models_with_mean_functions_changes(model_class):
     """
     Simply check that all models have a higher prediction with a constant mean
@@ -221,48 +240,64 @@ def test_models_with_mean_functions_changes(model_class):
 
     if model_class in [gpflow.models.GPR]:
         model_zero_mean = model_class(data, kernel=kernel, mean_function=zero_mean)
-        model_non_zero_mean = model_class(data, kernel=kernel, mean_function=non_zero_mean)
+        model_non_zero_mean = model_class(
+            data, kernel=kernel, mean_function=non_zero_mean
+        )
     elif model_class in [gpflow.models.VGP]:
-        model_zero_mean = model_class(data, likelihood=likelihood, kernel=kernel, mean_function=zero_mean)
-        model_non_zero_mean = model_class(data, likelihood=likelihood, kernel=kernel, mean_function=non_zero_mean)
+        model_zero_mean = model_class(
+            data, likelihood=likelihood, kernel=kernel, mean_function=zero_mean
+        )
+        model_non_zero_mean = model_class(
+            data, likelihood=likelihood, kernel=kernel, mean_function=non_zero_mean
+        )
     elif model_class in [gpflow.models.SVGP]:
-        model_zero_mean = model_class(kernel=kernel,
-                                      likelihood=likelihood,
-                                      inducing_variable=inducing_variable,
-                                      mean_function=zero_mean)
-        model_non_zero_mean = model_class(kernel=kernel,
-                                          likelihood=likelihood,
-                                          inducing_variable=inducing_variable,
-                                          mean_function=non_zero_mean)
+        model_zero_mean = model_class(
+            kernel=kernel,
+            likelihood=likelihood,
+            inducing_variable=inducing_variable,
+            mean_function=zero_mean,
+        )
+        model_non_zero_mean = model_class(
+            kernel=kernel,
+            likelihood=likelihood,
+            inducing_variable=inducing_variable,
+            mean_function=non_zero_mean,
+        )
     elif model_class in [gpflow.models.SGPR, gpflow.models.GPRFITC]:
-        model_zero_mean = model_class(data,
-                                      kernel=kernel,
-                                      inducing_variable=inducing_variable,
-                                      mean_function=zero_mean)
-        model_non_zero_mean = model_class(data,
-                                          kernel=kernel,
-                                          inducing_variable=inducing_variable,
-                                          mean_function=non_zero_mean)
+        model_zero_mean = model_class(
+            data,
+            kernel=kernel,
+            inducing_variable=inducing_variable,
+            mean_function=zero_mean,
+        )
+        model_non_zero_mean = model_class(
+            data,
+            kernel=kernel,
+            inducing_variable=inducing_variable,
+            mean_function=non_zero_mean,
+        )
     elif model_class in [gpflow.models.SGPMC]:
-        model_zero_mean = model_class(data,
-                                      kernel=kernel,
-                                      likelihood=likelihood,
-                                      inducing_variable=inducing_variable,
-                                      mean_function=zero_mean)
-        model_non_zero_mean = model_class(data,
-                                          kernel=kernel,
-                                          likelihood=likelihood,
-                                          inducing_variable=inducing_variable,
-                                          mean_function=non_zero_mean)
+        model_zero_mean = model_class(
+            data,
+            kernel=kernel,
+            likelihood=likelihood,
+            inducing_variable=inducing_variable,
+            mean_function=zero_mean,
+        )
+        model_non_zero_mean = model_class(
+            data,
+            kernel=kernel,
+            likelihood=likelihood,
+            inducing_variable=inducing_variable,
+            mean_function=non_zero_mean,
+        )
     elif model_class in [gpflow.models.GPMC]:
-        model_zero_mean = model_class(data,
-                                      kernel=kernel,
-                                      likelihood=likelihood,
-                                      mean_function=zero_mean)
-        model_non_zero_mean = model_class(data,
-                                          kernel=kernel,
-                                          likelihood=likelihood,
-                                          mean_function=non_zero_mean)
+        model_zero_mean = model_class(
+            data, kernel=kernel, likelihood=likelihood, mean_function=zero_mean
+        )
+        model_non_zero_mean = model_class(
+            data, kernel=kernel, likelihood=likelihood, mean_function=non_zero_mean
+        )
     else:
         raise (NotImplementedError)
 

--- a/tests/gpflow/test_quadrature.py
+++ b/tests/gpflow/test_quadrature.py
@@ -20,55 +20,60 @@ from numpy.testing import assert_allclose
 import gpflow.quadrature as quadrature
 
 
-@pytest.mark.parametrize('mu', [np.array([1.0, 1.3])])
-@pytest.mark.parametrize('var', [np.array([3.0, 3.5])])
+@pytest.mark.parametrize("mu", [np.array([1.0, 1.3])])
+@pytest.mark.parametrize("var", [np.array([3.0, 3.5])])
 def test_diagquad_1d(mu, var):
     num_gauss_hermite_points = 25
-    quad = quadrature.ndiagquad([lambda *X: tf.exp(X[0])],
-                                num_gauss_hermite_points, [mu], [var])
+    quad = quadrature.ndiagquad(
+        [lambda *X: tf.exp(X[0])], num_gauss_hermite_points, [mu], [var]
+    )
     expected = np.exp(mu + var / 2)
     assert_allclose(quad[0], expected)
 
 
-@pytest.mark.parametrize('mu1', [np.array([1.0, 1.3])])
-@pytest.mark.parametrize('var1', [np.array([3.0, 3.5])])
-@pytest.mark.parametrize('mu2', [np.array([-2.0, 0.3])])
-@pytest.mark.parametrize('var2', [np.array([4.0, 4.2])])
+@pytest.mark.parametrize("mu1", [np.array([1.0, 1.3])])
+@pytest.mark.parametrize("var1", [np.array([3.0, 3.5])])
+@pytest.mark.parametrize("mu2", [np.array([-2.0, 0.3])])
+@pytest.mark.parametrize("var2", [np.array([4.0, 4.2])])
 def test_diagquad_2d(mu1, var1, mu2, var2):
     alpha = 2.5
     # using logspace=True we can reduce this, see test_diagquad_logspace
     num_gauss_hermite_points = 35
-    quad = quadrature.ndiagquad(lambda *X: tf.exp(X[0] + alpha * X[1]),
-                                num_gauss_hermite_points, [mu1, mu2],
-                                [var1, var2])
-    expected = np.exp(mu1 + var1 / 2 + alpha * mu2 + alpha**2 * var2 / 2)
+    quad = quadrature.ndiagquad(
+        lambda *X: tf.exp(X[0] + alpha * X[1]),
+        num_gauss_hermite_points,
+        [mu1, mu2],
+        [var1, var2],
+    )
+    expected = np.exp(mu1 + var1 / 2 + alpha * mu2 + alpha ** 2 * var2 / 2)
     assert_allclose(quad, expected)
 
 
-@pytest.mark.parametrize('mu1', [np.array([1.0, 1.3])])
-@pytest.mark.parametrize('var1', [np.array([3.0, 3.5])])
-@pytest.mark.parametrize('mu2', [np.array([-2.0, 0.3])])
-@pytest.mark.parametrize('var2', [np.array([4.0, 4.2])])
+@pytest.mark.parametrize("mu1", [np.array([1.0, 1.3])])
+@pytest.mark.parametrize("var1", [np.array([3.0, 3.5])])
+@pytest.mark.parametrize("mu2", [np.array([-2.0, 0.3])])
+@pytest.mark.parametrize("var2", [np.array([4.0, 4.2])])
 def test_diagquad_logspace(mu1, var1, mu2, var2):
     alpha = 2.5
     num_gauss_hermite_points = 25
-    quad = quadrature.ndiagquad(lambda *X: (X[0] + alpha * X[1]),
-                                num_gauss_hermite_points, [mu1, mu2],
-                                [var1, var2],
-                                logspace=True)
-    expected = mu1 + var1 / 2 + alpha * mu2 + alpha**2 * var2 / 2
+    quad = quadrature.ndiagquad(
+        lambda *X: (X[0] + alpha * X[1]),
+        num_gauss_hermite_points,
+        [mu1, mu2],
+        [var1, var2],
+        logspace=True,
+    )
+    expected = mu1 + var1 / 2 + alpha * mu2 + alpha ** 2 * var2 / 2
     assert_allclose(quad, expected)
 
 
-@pytest.mark.parametrize('mu1', [np.array([1.0, 1.3])])
-@pytest.mark.parametrize('var1', [np.array([3.0, 3.5])])
+@pytest.mark.parametrize("mu1", [np.array([1.0, 1.3])])
+@pytest.mark.parametrize("var1", [np.array([3.0, 3.5])])
 def test_diagquad_with_kwarg(mu1, var1):
     alpha = np.array([2.5, -1.3])
     num_gauss_hermite_points = 25
-    quad = quadrature.ndiagquad(lambda X, Y: tf.exp(X * Y),
-                                num_gauss_hermite_points,
-                                mu1,
-                                var1,
-                                Y=alpha)
-    expected = np.exp(alpha * mu1 + alpha**2 * var1 / 2)
+    quad = quadrature.ndiagquad(
+        lambda X, Y: tf.exp(X * Y), num_gauss_hermite_points, mu1, var1, Y=alpha
+    )
+    expected = np.exp(alpha * mu1 + alpha ** 2 * var1 / 2)
     assert_allclose(quad, expected)

--- a/tests/gpflow/utilities/test_deepcopy.py
+++ b/tests/gpflow/utilities/test_deepcopy.py
@@ -9,10 +9,9 @@ from gpflow.utilities import deepcopy_components
 class A(tf.Module):
     def __init__(self):
         self.var = tf.Variable([1.0])
-        self.bijector = tfp.bijectors.Chain([
-            tfp.bijectors.Softplus(),
-            tfp.bijectors.Shift(1e-6)
-        ])
+        self.bijector = tfp.bijectors.Chain(
+            [tfp.bijectors.Softplus(), tfp.bijectors.Shift(1e-6)]
+        )
 
     def __call__(self, x):
         return self.bijector(x)
@@ -27,14 +26,14 @@ class B(tf.Module):
         return self.a(x)
 
 
-@pytest.mark.parametrize('module', [A(), B()])
+@pytest.mark.parametrize("module", [A(), B()])
 def test_deepcopy_component_clears_bijector_cache_and_deecopy(module):
     """
     With each forward pass through a bijector, a cache is stored inside which prohibits the deepcopy of the bijector.
     This is due to the fact that HashableWeakRef objects are not pickle-able, which raises a TypeError. Alternatively,
     one can make use of `deepcopy_component` to deepcopy a module containing used bijectors.
     """
-    input = 1.
+    input = 1.0
     _ = module(input)
     with pytest.raises(TypeError):
         deepcopy(module)

--- a/tests/gpflow/utilities/test_multipledispatch.py
+++ b/tests/gpflow/utilities/test_multipledispatch.py
@@ -25,30 +25,30 @@ class B2(B1):
 
 
 def test_our_multipledispatch():
-    test_fn = gpflow.utilities.Dispatcher('test_fn')
+    test_fn = gpflow.utilities.Dispatcher("test_fn")
 
     @test_fn.register(A1, B1)
     def test_a1_b1(x, y):
-        return 'a1-b1'
+        return "a1-b1"
 
     @test_fn.register(A2, B1)
     def test_a2_b1(x, y):
-        return 'a2-b1'
+        return "a2-b1"
 
     @test_fn.register(A1, B2)
     def test_a1_b2(x, y):
-        return 'a1-b2'
+        return "a1-b2"
 
-    assert test_fn(A1(), B1()) == 'a1-b1'
-    assert test_fn(A2(), B1()) == 'a2-b1'
-    assert test_fn(A1(), B2()) == 'a1-b2'
+    assert test_fn(A1(), B1()) == "a1-b1"
+    assert test_fn(A2(), B1()) == "a2-b1"
+    assert test_fn(A1(), B2()) == "a1-b2"
 
     # test the ambiguous case:
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
 
-        assert test_fn(A2(), B2()) == 'a1-b2'  # the last definition wins
+        assert test_fn(A2(), B2()) == "a1-b2"  # the last definition wins
 
         assert len(w) == 1
         assert issubclass(w[0].category, multipledispatch.conflict.AmbiguityWarning)
@@ -57,24 +57,26 @@ def test_our_multipledispatch():
 
     @test_fn.register(A2, B2)
     def test_a2_b2(x, y):
-        return 'a2-b2'
+        return "a2-b2"
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
 
-        assert test_fn(A2(), B2()) == 'a2-b2'
+        assert test_fn(A2(), B2()) == "a2-b2"
 
         assert len(w) == 0
 
 
-@pytest.mark.parametrize("Dispatcher, expect_autograph_warning", [
-    (multipledispatch.Dispatcher, True),
-    (gpflow.utilities.Dispatcher, False),
-])
+@pytest.mark.parametrize(
+    "Dispatcher, expect_autograph_warning",
+    [(multipledispatch.Dispatcher, True), (gpflow.utilities.Dispatcher, False),],
+)
 def test_dispatcher_autograph_warnings(capsys, Dispatcher, expect_autograph_warning):
-    tf.autograph.set_verbosity(0, alsologtostdout=True)  # to be able to capture it using capsys
+    tf.autograph.set_verbosity(
+        0, alsologtostdout=True
+    )  # to be able to capture it using capsys
 
-    test_fn = Dispatcher('test_fn')
+    test_fn = Dispatcher("test_fn")
 
     # generator would only be invoked when defining for base class...
     @test_fn.register(gpflow.inducing_variables.InducingVariables)
@@ -84,10 +86,10 @@ def test_dispatcher_autograph_warnings(capsys, Dispatcher, expect_autograph_warn
     test_fn_jit = tf.function(test_fn)  # with autograph=True by default
 
     # ...but calling using subclass
-    result = test_fn_jit(gpflow.inducing_variables.InducingPoints([1., 2.]))
+    result = test_fn_jit(gpflow.inducing_variables.InducingPoints([1.0, 2.0]))
     assert result.numpy() == 3.0  # expect computation to work either way
 
     captured = capsys.readouterr()
 
-    tf_warning = 'WARNING:.*Entity .* appears to be a generator function. It will not be converted by AutoGraph.'
+    tf_warning = "WARNING:.*Entity .* appears to be a generator function. It will not be converted by AutoGraph."
     assert bool(re.match(tf_warning, captured.out)) == expect_autograph_warning

--- a/tests/gpflow/utilities/test_printing.py
+++ b/tests/gpflow/utilities/test_printing.py
@@ -18,7 +18,11 @@ import tensorflow as tf
 
 import gpflow
 from gpflow.config import Config, as_context
-from gpflow.utilities.utilities import leaf_components, _merge_leaf_components, tabulate_module_summary
+from gpflow.utilities.utilities import (
+    leaf_components,
+    _merge_leaf_components,
+    tabulate_module_summary,
+)
 
 rng = np.random.RandomState(0)
 
@@ -69,19 +73,23 @@ def create_kernel():
 
 
 def create_compose_kernel():
-    kernel = gpflow.kernels.Product([
-        gpflow.kernels.Sum([create_kernel(), create_kernel()]),
-        gpflow.kernels.Sum([create_kernel(), create_kernel()])
-    ])
+    kernel = gpflow.kernels.Product(
+        [
+            gpflow.kernels.Sum([create_kernel(), create_kernel()]),
+            gpflow.kernels.Sum([create_kernel(), create_kernel()]),
+        ]
+    )
     return kernel
 
 
 def create_model():
     kernel = create_kernel()
-    model = gpflow.models.SVGP(kernel=kernel,
-                               likelihood=gpflow.likelihoods.Gaussian(variance_lower_bound=None),
-                               inducing_variable=Data.Z,
-                               q_diag=True)
+    model = gpflow.models.SVGP(
+        kernel=kernel,
+        likelihood=gpflow.likelihoods.Gaussian(variance_lower_bound=None),
+        inducing_variable=Data.Z,
+        q_diag=True,
+    )
     model.q_mu.trainable = False
     return model
 
@@ -91,102 +99,108 @@ def create_model():
 # ------------------------------------------
 
 example_tf_module_variable_dict = {
-    'A.var_trainable': {
-        'value': np.zeros((2, 2, 1)),
-        'trainable': True,
-        'shape': (2, 2, 1)
+    "A.var_trainable": {
+        "value": np.zeros((2, 2, 1)),
+        "trainable": True,
+        "shape": (2, 2, 1),
     },
-    'A.var_fixed': {
-        'value': np.ones((2, 2, 1)),
-        'trainable': False,
-        'shape': (2, 2, 1)
+    "A.var_fixed": {
+        "value": np.ones((2, 2, 1)),
+        "trainable": False,
+        "shape": (2, 2, 1),
     },
 }
 
 example_module_list_variable_dict = {
-    'submodule_list[0].var_trainable': example_tf_module_variable_dict['A.var_trainable'],
-    'submodule_list[0].var_fixed': example_tf_module_variable_dict['A.var_fixed'],
-    'submodule_list[1].var_trainable': example_tf_module_variable_dict['A.var_trainable'],
-    'submodule_list[1].var_fixed': example_tf_module_variable_dict['A.var_fixed'],
-    "submodule_dict['a'].var_trainable": example_tf_module_variable_dict['A.var_trainable'],
-    "submodule_dict['a'].var_fixed": example_tf_module_variable_dict['A.var_fixed'],
-    "submodule_dict['b'].var_trainable": example_tf_module_variable_dict['A.var_trainable'],
-    "submodule_dict['b'].var_fixed": example_tf_module_variable_dict['A.var_fixed'],
-    'B.var_trainable': example_tf_module_variable_dict['A.var_trainable'],
-    'B.var_fixed': example_tf_module_variable_dict['A.var_fixed'],
+    "submodule_list[0].var_trainable": example_tf_module_variable_dict[
+        "A.var_trainable"
+    ],
+    "submodule_list[0].var_fixed": example_tf_module_variable_dict["A.var_fixed"],
+    "submodule_list[1].var_trainable": example_tf_module_variable_dict[
+        "A.var_trainable"
+    ],
+    "submodule_list[1].var_fixed": example_tf_module_variable_dict["A.var_fixed"],
+    "submodule_dict['a'].var_trainable": example_tf_module_variable_dict[
+        "A.var_trainable"
+    ],
+    "submodule_dict['a'].var_fixed": example_tf_module_variable_dict["A.var_fixed"],
+    "submodule_dict['b'].var_trainable": example_tf_module_variable_dict[
+        "A.var_trainable"
+    ],
+    "submodule_dict['b'].var_fixed": example_tf_module_variable_dict["A.var_fixed"],
+    "B.var_trainable": example_tf_module_variable_dict["A.var_trainable"],
+    "B.var_fixed": example_tf_module_variable_dict["A.var_fixed"],
 }
 
 kernel_param_dict = {
-    'SquaredExponential.lengthscale': {
-        'value': Data.ls,
-        'trainable': False,
-        'shape': ()
+    "SquaredExponential.lengthscale": {
+        "value": Data.ls,
+        "trainable": False,
+        "shape": (),
     },
-    'SquaredExponential.variance': {
-        'value': Data.var,
-        'trainable': True,
-        'shape': ()
-    }
+    "SquaredExponential.variance": {"value": Data.var, "trainable": True, "shape": ()},
 }
 
 compose_kernel_param_dict = {
-    'kernels[0].kernels[0].variance': kernel_param_dict['SquaredExponential.variance'],
-    'kernels[0].kernels[0].lengthscale': kernel_param_dict['SquaredExponential.lengthscale'],
-    'kernels[0].kernels[1].variance': kernel_param_dict['SquaredExponential.variance'],
-    'kernels[0].kernels[1].lengthscale': kernel_param_dict['SquaredExponential.lengthscale'],
-    'kernels[1].kernels[0].variance': kernel_param_dict['SquaredExponential.variance'],
-    'kernels[1].kernels[0].lengthscale': kernel_param_dict['SquaredExponential.lengthscale'],
-    'kernels[1].kernels[1].variance': kernel_param_dict['SquaredExponential.variance'],
-    'kernels[1].kernels[1].lengthscale': kernel_param_dict['SquaredExponential.lengthscale']
+    "kernels[0].kernels[0].variance": kernel_param_dict["SquaredExponential.variance"],
+    "kernels[0].kernels[0].lengthscale": kernel_param_dict[
+        "SquaredExponential.lengthscale"
+    ],
+    "kernels[0].kernels[1].variance": kernel_param_dict["SquaredExponential.variance"],
+    "kernels[0].kernels[1].lengthscale": kernel_param_dict[
+        "SquaredExponential.lengthscale"
+    ],
+    "kernels[1].kernels[0].variance": kernel_param_dict["SquaredExponential.variance"],
+    "kernels[1].kernels[0].lengthscale": kernel_param_dict[
+        "SquaredExponential.lengthscale"
+    ],
+    "kernels[1].kernels[1].variance": kernel_param_dict["SquaredExponential.variance"],
+    "kernels[1].kernels[1].lengthscale": kernel_param_dict[
+        "SquaredExponential.lengthscale"
+    ],
 }
 
 model_gp_param_dict = {
-    'kernel.lengthscale': kernel_param_dict['SquaredExponential.lengthscale'],
-    'kernel.variance': kernel_param_dict['SquaredExponential.variance'],
-    'likelihood.variance': {
-        'value': 1.0,
-        'trainable': True,
-        'shape': ()
+    "kernel.lengthscale": kernel_param_dict["SquaredExponential.lengthscale"],
+    "kernel.variance": kernel_param_dict["SquaredExponential.variance"],
+    "likelihood.variance": {"value": 1.0, "trainable": True, "shape": ()},
+    "inducing_variable.Z": {
+        "value": Data.Z,
+        "trainable": True,
+        "shape": (Data.M, Data.D),
     },
-    'inducing_variable.Z': {
-        'value': Data.Z,
-        'trainable': True,
-        'shape': (Data.M, Data.D)
+    "SVGP.q_mu": {
+        "value": np.zeros((Data.M, 1)),
+        "trainable": False,
+        "shape": (Data.M, 1),
     },
-    'SVGP.q_mu': {
-        'value': np.zeros((Data.M, 1)),
-        'trainable': False,
-        'shape': (Data.M, 1)
+    "SVGP.q_sqrt": {
+        "value": np.ones((Data.M, 1)),
+        "trainable": True,
+        "shape": (Data.M, 1),
     },
-    'SVGP.q_sqrt': {
-        'value': np.ones((Data.M, 1)),
-        'trainable': True,
-        'shape': (Data.M, 1)
-    }
 }
 
 example_dag_module_param_dict = {
-    'SVGP.kernel.variance\nSVGP.kernel.lengthscale': kernel_param_dict['SquaredExponential.lengthscale'],
-    'SVGP.likelihood.variance': {
-        'value': 1.0,
-        'trainable': True,
-        'shape': ()
+    "SVGP.kernel.variance\nSVGP.kernel.lengthscale": kernel_param_dict[
+        "SquaredExponential.lengthscale"
+    ],
+    "SVGP.likelihood.variance": {"value": 1.0, "trainable": True, "shape": ()},
+    "SVGP.inducing_variable.Z": {
+        "value": Data.Z,
+        "trainable": True,
+        "shape": (Data.M, Data.D),
     },
-    'SVGP.inducing_variable.Z': {
-        'value': Data.Z,
-        'trainable': True,
-        'shape': (Data.M, Data.D)
+    "SVGP.q_mu": {
+        "value": np.zeros((Data.M, 1)),
+        "trainable": False,
+        "shape": (Data.M, 1),
     },
-    'SVGP.q_mu': {
-        'value': np.zeros((Data.M, 1)),
-        'trainable': False,
-        'shape': (Data.M, 1)
+    "SVGP.q_sqrt": {
+        "value": np.ones((Data.M, 1)),
+        "trainable": True,
+        "shape": (Data.M, 1),
     },
-    'SVGP.q_sqrt': {
-        'value': np.ones((Data.M, 1)),
-        'trainable': True,
-        'shape': (Data.M, 1)
-    }
 }
 
 compose_kernel_param_print_string = """\
@@ -279,68 +293,86 @@ def dag_module():
 
 def test_leaf_components_only_returns_parameters_and_variables(module):
     for path, variable in leaf_components(module).items():
-        assert isinstance(variable, tf.Variable) or isinstance(variable, gpflow.Parameter)
+        assert isinstance(variable, tf.Variable) or isinstance(
+            variable, gpflow.Parameter
+        )
 
 
-@pytest.mark.parametrize('module_callable, expected_param_dicts', [(create_kernel, kernel_param_dict),
-                                                                   (create_model, model_gp_param_dict)])
-def test_leaf_components_registers_variable_properties(module_callable, expected_param_dicts):
+@pytest.mark.parametrize(
+    "module_callable, expected_param_dicts",
+    [(create_kernel, kernel_param_dict), (create_model, model_gp_param_dict)],
+)
+def test_leaf_components_registers_variable_properties(
+    module_callable, expected_param_dicts
+):
     module = module_callable()
     for path, variable in leaf_components(module).items():
-        param_name = path.split('.')[-2] + '.' + path.split('.')[-1]
+        param_name = path.split(".")[-2] + "." + path.split(".")[-1]
         assert isinstance(variable, gpflow.Parameter)
-        np.testing.assert_equal(variable.value().numpy(), expected_param_dicts[param_name]['value'])
-        assert variable.trainable == expected_param_dicts[param_name]['trainable']
-        assert variable.shape == expected_param_dicts[param_name]['shape']
+        np.testing.assert_equal(
+            variable.value().numpy(), expected_param_dicts[param_name]["value"]
+        )
+        assert variable.trainable == expected_param_dicts[param_name]["trainable"]
+        assert variable.shape == expected_param_dicts[param_name]["shape"]
 
 
-@pytest.mark.parametrize('module_callable, expected_param_dicts', [
-    (create_compose_kernel, compose_kernel_param_dict),
-])
-def test_leaf_components_registers_compose_kernel_variable_properties(module_callable, expected_param_dicts):
+@pytest.mark.parametrize(
+    "module_callable, expected_param_dicts",
+    [(create_compose_kernel, compose_kernel_param_dict),],
+)
+def test_leaf_components_registers_compose_kernel_variable_properties(
+    module_callable, expected_param_dicts
+):
     module = module_callable()
     leaf_components_dict = leaf_components(module)
     assert len(leaf_components_dict) > 0
     for path, variable in leaf_components_dict.items():
-        path_as_list = path.split('.')
-        param_name = path_as_list[-3] + '.' + path_as_list[-2] + '.' + path_as_list[-1]
+        path_as_list = path.split(".")
+        param_name = path_as_list[-3] + "." + path_as_list[-2] + "." + path_as_list[-1]
         assert isinstance(variable, gpflow.Parameter)
-        np.testing.assert_equal(variable.value().numpy(), expected_param_dicts[param_name]['value'])
-        assert variable.trainable == expected_param_dicts[param_name]['trainable']
-        assert variable.shape == expected_param_dicts[param_name]['shape']
+        np.testing.assert_equal(
+            variable.value().numpy(), expected_param_dicts[param_name]["value"]
+        )
+        assert variable.trainable == expected_param_dicts[param_name]["trainable"]
+        assert variable.shape == expected_param_dicts[param_name]["shape"]
 
 
-@pytest.mark.parametrize('module_class, expected_var_dicts', [
-    (A, example_tf_module_variable_dict),
-    (B, example_module_list_variable_dict),
-])
+@pytest.mark.parametrize(
+    "module_class, expected_var_dicts",
+    [(A, example_tf_module_variable_dict), (B, example_module_list_variable_dict),],
+)
 def test_leaf_components_registers_param_properties(module_class, expected_var_dicts):
     module = module_class()
     for path, variable in leaf_components(module).items():
-        var_name = path.split('.')[-2] + '.' + path.split('.')[-1]
+        var_name = path.split(".")[-2] + "." + path.split(".")[-1]
         assert isinstance(variable, tf.Variable)
-        np.testing.assert_equal(variable.numpy(), expected_var_dicts[var_name]['value'])
-        assert variable.trainable == expected_var_dicts[var_name]['trainable']
-        assert variable.shape == expected_var_dicts[var_name]['shape']
+        np.testing.assert_equal(variable.numpy(), expected_var_dicts[var_name]["value"])
+        assert variable.trainable == expected_var_dicts[var_name]["trainable"]
+        assert variable.shape == expected_var_dicts[var_name]["shape"]
 
 
-@pytest.mark.parametrize('expected_var_dicts', [example_dag_module_param_dict])
-def test_merge_leaf_components_merges_keys_with_same_values(dag_module, expected_var_dicts):
+@pytest.mark.parametrize("expected_var_dicts", [example_dag_module_param_dict])
+def test_merge_leaf_components_merges_keys_with_same_values(
+    dag_module, expected_var_dicts
+):
     leaf_components_dict = leaf_components(dag_module)
     for path, variable in _merge_leaf_components(leaf_components_dict).items():
         assert path in expected_var_dicts
-        for sub_path in path.split('\n'):
+        for sub_path in path.split("\n"):
             assert sub_path in leaf_components_dict
             assert leaf_components_dict[sub_path] is variable
 
 
-@pytest.mark.parametrize('module_callable, expected_param_print_string', [
-    (create_compose_kernel, compose_kernel_param_print_string),
-    (create_kernel, kernel_param_print_string),
-    (create_model, model_gp_param_print_string),
-    (A, example_tf_module_variable_print_string),
-    (B, example_module_list_variable_print_string),
-])
+@pytest.mark.parametrize(
+    "module_callable, expected_param_print_string",
+    [
+        (create_compose_kernel, compose_kernel_param_print_string),
+        (create_kernel, kernel_param_print_string),
+        (create_model, model_gp_param_print_string),
+        (A, example_tf_module_variable_print_string),
+        (B, example_module_list_variable_print_string),
+    ],
+)
 def test_print_summary_output_string(module_callable, expected_param_print_string):
     with as_context(Config(positive_minimum=None)):
         assert tabulate_module_summary(module_callable()) == expected_param_print_string
@@ -348,7 +380,10 @@ def test_print_summary_output_string(module_callable, expected_param_print_strin
 
 def test_print_summary_output_string_with_positive_minimum():
     with as_context(Config(positive_minimum=1e-6)):
-        assert tabulate_module_summary(create_kernel()) == kernel_param_print_string_with_shift
+        assert (
+            tabulate_module_summary(create_kernel())
+            == kernel_param_print_string_with_shift
+        )
 
 
 def test_print_summary_for_keras_model():
@@ -362,7 +397,9 @@ def test_leaf_components_combination_kernel():
     Regression test for kernel compositions - output for printing should not be empty (issue #1066).
     """
     k = gpflow.kernels.SquaredExponential() + gpflow.kernels.SquaredExponential()
-    assert leaf_components(k), "Combination kernel should have non-empty leaf components"
+    assert leaf_components(
+        k
+    ), "Combination kernel should have non-empty leaf components"
 
 
 def test_module_parameters_return_iterators_not_generators():

--- a/tests/gpflow/utilities/test_utilities.py
+++ b/tests/gpflow/utilities/test_utilities.py
@@ -6,11 +6,14 @@ from gpflow.config import Config, as_context
 from gpflow.utilities import positive, triangular
 
 
-@pytest.mark.parametrize("env_lower, override_lower", [
-    (0.1, None),  # ensure default from config is applied
-    (None, 0.2),  # ensure override is applied
-    (0.3, 0.4),  # ensure local overrides config
-])
+@pytest.mark.parametrize(
+    "env_lower, override_lower",
+    [
+        (0.1, None),  # ensure default from config is applied
+        (None, 0.2),  # ensure override is applied
+        (0.3, 0.4),  # ensure local overrides config
+    ],
+)
 def test_positive_lower(env_lower, override_lower):
     expected_lower = override_lower or env_lower
     with as_context(Config(positive_bijector="softplus", positive_minimum=env_lower)):
@@ -19,12 +22,15 @@ def test_positive_lower(env_lower, override_lower):
         assert np.isclose(bijector.bijectors[0].shift, expected_lower)
 
 
-@pytest.mark.parametrize("env_bijector, override_bijector, expected_class", [
-    ("softplus", None, tfp.bijectors.Softplus),
-    ("softplus", "Exp", tfp.bijectors.Exp),
-    ("exp", None, tfp.bijectors.Exp),
-    ("exp", "Softplus", tfp.bijectors.Softplus),
-])
+@pytest.mark.parametrize(
+    "env_bijector, override_bijector, expected_class",
+    [
+        ("softplus", None, tfp.bijectors.Softplus),
+        ("softplus", "Exp", tfp.bijectors.Exp),
+        ("exp", None, tfp.bijectors.Exp),
+        ("exp", "Softplus", tfp.bijectors.Softplus),
+    ],
+)
 def test_positive_bijector(env_bijector, override_bijector, expected_class):
     with as_context(Config(positive_bijector=env_bijector, positive_minimum=None)):
         bijector = positive(base=override_bijector)

--- a/tests/integration/test_dynamic_shapes.py
+++ b/tests/integration/test_dynamic_shapes.py
@@ -36,8 +36,8 @@ class Datum:
     cdata = (X, Yc)
 
 
-@pytest.mark.parametrize('whiten', [True, False])
-@pytest.mark.parametrize('q_diag', [True, False])
+@pytest.mark.parametrize("whiten", [True, False])
+@pytest.mark.parametrize("q_diag", [True, False])
 def test_svgp(whiten, q_diag):
     model = gpflow.models.SVGP(
         gpflow.kernels.SquaredExponential(),
@@ -52,19 +52,21 @@ def test_svgp(whiten, q_diag):
 
     # test with explicitly unknown shapes:
     tensor_spec = tf.TensorSpec(shape=None, dtype=default_float())
-    elbo = tf.function(
-        model.elbo,
-        input_signature=[(tensor_spec, tensor_spec)],
-    )
+    elbo = tf.function(model.elbo, input_signature=[(tensor_spec, tensor_spec)],)
 
     @tf.function
     def model_closure():
-        return - elbo(Datum.data)
+        return -elbo(Datum.data)
 
     opt = gpflow.optimizers.Scipy()
 
     # simply test whether it runs without erroring...:
-    opt.minimize(model_closure, variables=model.trainable_variables, options=dict(maxiter=3), jit=True)
+    opt.minimize(
+        model_closure,
+        variables=model.trainable_variables,
+        options=dict(maxiter=3),
+        jit=True,
+    )
 
 
 def test_multiclass():
@@ -79,16 +81,18 @@ def test_multiclass():
 
     # test with explicitly unknown shapes:
     tensor_spec = tf.TensorSpec(shape=None, dtype=default_float())
-    elbo = tf.function(
-        model.elbo,
-        input_signature=[(tensor_spec, tensor_spec)],
-    )
+    elbo = tf.function(model.elbo, input_signature=[(tensor_spec, tensor_spec)],)
 
     @tf.function
     def model_closure():
-        return - elbo(Datum.cdata)
+        return -elbo(Datum.cdata)
 
     opt = gpflow.optimizers.Scipy()
 
     # simply test whether it runs without erroring...:
-    opt.minimize(model_closure, variables=model.trainable_variables, options=dict(maxiter=3), jit=True)
+    opt.minimize(
+        model_closure,
+        variables=model.trainable_variables,
+        options=dict(maxiter=3),
+        jit=True,
+    )

--- a/tests/integration/test_method_equivalence.py
+++ b/tests/integration/test_method_equivalence.py
@@ -55,18 +55,23 @@ def _create_full_gp_model():
     """
     GP Regression
     """
-    full_gp_model = gpflow.models.GPR((Datum.X, Datum.Y),
-                                      kernel=gpflow.kernels.SquaredExponential(),
-                                      mean_function=gpflow.mean_functions.Constant(),
-                                      )
+    full_gp_model = gpflow.models.GPR(
+        (Datum.X, Datum.Y),
+        kernel=gpflow.kernels.SquaredExponential(),
+        mean_function=gpflow.mean_functions.Constant(),
+    )
 
     opt = gpflow.optimizers.Scipy()
 
     @tf.function
     def full_gp_model_closure():
-        return - full_gp_model.log_marginal_likelihood()
+        return -full_gp_model.log_marginal_likelihood()
 
-    opt.minimize(full_gp_model_closure, variables=full_gp_model.trainable_variables, options=dict(maxiter=300))
+    opt.minimize(
+        full_gp_model_closure,
+        variables=full_gp_model.trainable_variables,
+        options=dict(maxiter=300),
+    )
     return full_gp_model
 
 
@@ -81,31 +86,44 @@ def _create_approximate_models():
        variables are 'collapsed' out, as in Titsias 2009)
     5) FITC Sparse GP Regression
     """
-    model_1 = gpflow.models.VGP((Datum.X, Datum.Y),
-                                gpflow.kernels.SquaredExponential(),
-                                likelihood=gpflow.likelihoods.Gaussian(),
-                                mean_function=gpflow.mean_functions.Constant())
-    model_2 = gpflow.models.SVGP(gpflow.kernels.SquaredExponential(),
-                                 gpflow.likelihoods.Gaussian(),
-                                 inducing_variable=Datum.X.copy(),
-                                 q_diag=False,
-                                 mean_function=gpflow.mean_functions.Constant(),
-                                 num_latent=Datum.Y.shape[1])
+    model_1 = gpflow.models.VGP(
+        (Datum.X, Datum.Y),
+        gpflow.kernels.SquaredExponential(),
+        likelihood=gpflow.likelihoods.Gaussian(),
+        mean_function=gpflow.mean_functions.Constant(),
+    )
+    model_2 = gpflow.models.SVGP(
+        gpflow.kernels.SquaredExponential(),
+        gpflow.likelihoods.Gaussian(),
+        inducing_variable=Datum.X.copy(),
+        q_diag=False,
+        mean_function=gpflow.mean_functions.Constant(),
+        num_latent=Datum.Y.shape[1],
+    )
     gpflow.utilities.set_trainable(model_2.inducing_variable, False)
-    model_3 = gpflow.models.SVGP(kernel=gpflow.kernels.SquaredExponential(),
-                                 likelihood=gpflow.likelihoods.Gaussian(),
-                                 inducing_variable=Datum.X.copy(), q_diag=False, whiten=True,
-                                 mean_function=gpflow.mean_functions.Constant(),
-                                 num_latent=Datum.Y.shape[1])
+    model_3 = gpflow.models.SVGP(
+        kernel=gpflow.kernels.SquaredExponential(),
+        likelihood=gpflow.likelihoods.Gaussian(),
+        inducing_variable=Datum.X.copy(),
+        q_diag=False,
+        whiten=True,
+        mean_function=gpflow.mean_functions.Constant(),
+        num_latent=Datum.Y.shape[1],
+    )
     gpflow.utilities.set_trainable(model_3.inducing_variable, False)
-    model_4 = gpflow.models.GPRFITC((Datum.X, Datum.Y),
-                                    kernel=gpflow.kernels.SquaredExponential(),
-                                    inducing_variable=Datum.X.copy(),
-                                    mean_function=Constant())
+    model_4 = gpflow.models.GPRFITC(
+        (Datum.X, Datum.Y),
+        kernel=gpflow.kernels.SquaredExponential(),
+        inducing_variable=Datum.X.copy(),
+        mean_function=Constant(),
+    )
     gpflow.utilities.set_trainable(model_4.inducing_variable, False)
-    model_5 = gpflow.models.SGPR((Datum.X, Datum.Y), gpflow.kernels.SquaredExponential(),
-                                 inducing_variable=Datum.X.copy(),
-                                 mean_function=Constant())
+    model_5 = gpflow.models.SGPR(
+        (Datum.X, Datum.Y),
+        gpflow.kernels.SquaredExponential(),
+        inducing_variable=Datum.X.copy(),
+        mean_function=Constant(),
+    )
     gpflow.utilities.set_trainable(model_5.inducing_variable, False)
 
     # Train models
@@ -114,29 +132,49 @@ def _create_approximate_models():
 
     @tf.function
     def model_1_closure():
-        return - model_1.log_marginal_likelihood()
+        return -model_1.log_marginal_likelihood()
 
     @tf.function
     def model_2_closure():
-        return - model_2.elbo(Datum.data)
+        return -model_2.elbo(Datum.data)
 
     @tf.function
     def model_3_closure():
-        return - model_3.elbo(Datum.data)
+        return -model_3.elbo(Datum.data)
 
     @tf.function
     def model_4_closure():
-        return - model_4.log_marginal_likelihood()
+        return -model_4.log_marginal_likelihood()
 
     @tf.function
     def model_5_closure():
-        return - model_5.log_marginal_likelihood()
+        return -model_5.log_marginal_likelihood()
 
-    opt.minimize(model_1_closure, variables=model_1.trainable_variables, options=dict(maxiter=300))
-    opt.minimize(model_2_closure, variables=model_2.trainable_variables, options=dict(maxiter=300))
-    opt.minimize(model_3_closure, variables=model_3.trainable_variables, options=dict(maxiter=300))
-    opt.minimize(model_4_closure, variables=model_4.trainable_variables, options=dict(maxiter=300))
-    opt.minimize(model_5_closure, variables=model_5.trainable_variables, options=dict(maxiter=300))
+    opt.minimize(
+        model_1_closure,
+        variables=model_1.trainable_variables,
+        options=dict(maxiter=300),
+    )
+    opt.minimize(
+        model_2_closure,
+        variables=model_2.trainable_variables,
+        options=dict(maxiter=300),
+    )
+    opt.minimize(
+        model_3_closure,
+        variables=model_3.trainable_variables,
+        options=dict(maxiter=300),
+    )
+    opt.minimize(
+        model_4_closure,
+        variables=model_4.trainable_variables,
+        options=dict(maxiter=300),
+    )
+    opt.minimize(
+        model_5_closure,
+        variables=model_5.trainable_variables,
+        options=dict(maxiter=300),
+    )
 
     return model_1, model_2, model_3, model_4, model_5
 
@@ -150,21 +188,29 @@ def _create_vgp_model(kernel, likelihood, q_mu=None, q_sqrt=None):
 
 
 def _create_vgpao_model(kernel, likelihood, q_alpha, q_lambda):
-    model_vgpoa = gpflow.models.VGPOpperArchambeau((DatumVGP.X, DatumVGP.Y), kernel, likelihood, num_latent=DatumVGP.DY)
+    model_vgpoa = gpflow.models.VGPOpperArchambeau(
+        (DatumVGP.X, DatumVGP.Y), kernel, likelihood, num_latent=DatumVGP.DY
+    )
     model_vgpoa.q_alpha.assign(q_alpha)
     model_vgpoa.q_lambda.assign(q_lambda)
     return model_vgpoa
 
 
 def _create_svgp_model(kernel, likelihood, q_mu, q_sqrt, whiten):
-    model_svgp = gpflow.models.SVGP(kernel, likelihood, DatumVGP.X.copy(), whiten=whiten, q_diag=False,
-                                    num_latent=DatumVGP.DY)
+    model_svgp = gpflow.models.SVGP(
+        kernel,
+        likelihood,
+        DatumVGP.X.copy(),
+        whiten=whiten,
+        q_diag=False,
+        num_latent=DatumVGP.DY,
+    )
     model_svgp.q_mu.assign(q_mu)
     model_svgp.q_sqrt.assign(q_sqrt)
     return model_svgp
 
 
-@pytest.mark.parametrize('approximate_model', _create_approximate_models())
+@pytest.mark.parametrize("approximate_model", _create_approximate_models())
 def test_equivalence(approximate_model):
     """
     With a Gaussian likelihood, and inducing points (where appropriate)
@@ -172,11 +218,11 @@ def test_equivalence(approximate_model):
     subject to some optimization).
     """
     gpr_model = _create_full_gp_model()
-    gpr_likelihood = - gpr_model.log_likelihood()
+    gpr_likelihood = -gpr_model.log_likelihood()
     if isinstance(approximate_model, gpflow.models.SVGP):
-        approximate_likelihood = - approximate_model.log_likelihood(Datum.data)
+        approximate_likelihood = -approximate_model.log_likelihood(Datum.data)
     else:
-        approximate_likelihood = - approximate_model.log_likelihood()
+        approximate_likelihood = -approximate_model.log_likelihood()
 
     assert_allclose(gpr_likelihood, approximate_likelihood, rtol=1e-6)
 
@@ -200,7 +246,9 @@ def test_equivalence_vgp_and_svgp():
     kernel = gpflow.kernels.Matern52()
     likelihood = gpflow.likelihoods.StudentT()
 
-    svgp_model = _create_svgp_model(kernel, likelihood, DatumVGP.q_mu, DatumVGP.q_sqrt, whiten=True)
+    svgp_model = _create_svgp_model(
+        kernel, likelihood, DatumVGP.q_mu, DatumVGP.q_sqrt, whiten=True
+    )
     vgp_model = _create_vgp_model(kernel, likelihood, DatumVGP.q_mu, DatumVGP.q_sqrt)
 
     likelihood_svgp = svgp_model.log_likelihood(DatumVGP.data)
@@ -218,7 +266,9 @@ def test_equivalence_vgp_and_opper_archambeau():
     kernel = gpflow.kernels.Matern52()
     likelihood = gpflow.likelihoods.StudentT()
 
-    vgp_oa_model = _create_vgpao_model(kernel, likelihood, DatumVGP.q_alpha, DatumVGP.q_lambda)
+    vgp_oa_model = _create_vgpao_model(
+        kernel, likelihood, DatumVGP.q_alpha, DatumVGP.q_lambda
+    )
 
     K = kernel(DatumVGP.X) + np.eye(DatumVGP.N) * default_jitter()
     L = np.linalg.cholesky(K)
@@ -227,13 +277,17 @@ def test_equivalence_vgp_and_opper_archambeau():
 
     mean = K @ DatumVGP.q_alpha
 
-    prec_dnn = K_inv[None, :, :] + np.array([np.diag(l ** 2) for l in DatumVGP.q_lambda.T])
+    prec_dnn = K_inv[None, :, :] + np.array(
+        [np.diag(l ** 2) for l in DatumVGP.q_lambda.T]
+    )
     var_dnn = np.linalg.inv(prec_dnn)
 
-    svgp_model_unwhitened = _create_svgp_model(kernel, likelihood, mean, np.linalg.cholesky(var_dnn), whiten=False)
+    svgp_model_unwhitened = _create_svgp_model(
+        kernel, likelihood, mean, np.linalg.cholesky(var_dnn), whiten=False
+    )
 
     mean_white_nd = L_inv.dot(mean)
-    var_white_dnn = np.einsum('nN,dNM,mM->dnm', L_inv, var_dnn, L_inv)
+    var_white_dnn = np.einsum("nN,dNM,mM->dnm", L_inv, var_dnn, L_inv)
     q_sqrt_nnd = np.linalg.cholesky(var_white_dnn)
 
     vgp_model = _create_vgp_model(kernel, likelihood, mean_white_nd, q_sqrt_nnd)
@@ -246,7 +300,9 @@ def test_equivalence_vgp_and_opper_archambeau():
     assert_allclose(likelihood_vgp, likelihood_svgp_unwhitened, rtol=1e-2)
 
     vgp_oa_mu, vgp_oa_var = vgp_oa_model.predict_f(DatumVGP.Xs)
-    svgp_unwhitened_mu, svgp_unwhitened_var = svgp_model_unwhitened.predict_f(DatumVGP.Xs)
+    svgp_unwhitened_mu, svgp_unwhitened_var = svgp_model_unwhitened.predict_f(
+        DatumVGP.Xs
+    )
     vgp_mu, vgp_var = vgp_model.predict_f(DatumVGP.Xs)
 
     assert_allclose(vgp_oa_mu, vgp_mu)
@@ -259,20 +315,29 @@ def test_upper_bound_few_inducing_points():
     """
     Test for upper bound for regression marginal likelihood
     """
-    model_vfe = gpflow.models.SGPR((DatumUpper.X, DatumUpper.Y), gpflow.kernels.SquaredExponential(),
-                                   inducing_variable=DatumUpper.X[:10, :].copy(),
-                                   mean_function=Constant())
+    model_vfe = gpflow.models.SGPR(
+        (DatumUpper.X, DatumUpper.Y),
+        gpflow.kernels.SquaredExponential(),
+        inducing_variable=DatumUpper.X[:10, :].copy(),
+        mean_function=Constant(),
+    )
     opt = gpflow.optimizers.Scipy()
 
     @tf.function
     def model_vfe_closure():
-        return - model_vfe.log_marginal_likelihood()
+        return -model_vfe.log_marginal_likelihood()
 
-    opt.minimize(model_vfe_closure, variables=model_vfe.trainable_variables, options=dict(maxiter=500))
+    opt.minimize(
+        model_vfe_closure,
+        variables=model_vfe.trainable_variables,
+        options=dict(maxiter=500),
+    )
 
-    full_gp = gpflow.models.GPR((DatumUpper.X, DatumUpper.Y),
-                                kernel=gpflow.kernels.SquaredExponential(),
-                                mean_function=Constant())
+    full_gp = gpflow.models.GPR(
+        (DatumUpper.X, DatumUpper.Y),
+        kernel=gpflow.kernels.SquaredExponential(),
+        mean_function=Constant(),
+    )
     full_gp.kernel.lengthscale.assign(model_vfe.kernel.lengthscale)
     full_gp.kernel.variance.assign(model_vfe.kernel.variance)
     full_gp.likelihood.variance.assign(model_vfe.likelihood.variance)

--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -28,13 +28,12 @@ from nbconvert.preprocessors.execute import CellExecutionError
 # but without any directory component). If there are several notebooks in
 # different directories with the same base name, they will all get blacklisted
 # (change the blacklisting check to something else in that case, if need be!)
-BLACKLISTED_NOTEBOOKS = [
-]
+BLACKLISTED_NOTEBOOKS = []
 
 
 def _nbpath():
     this_dir = os.path.dirname(__file__)
-    return os.path.join(this_dir, '../doc/source/notebooks')
+    return os.path.join(this_dir, "../doc/source/notebooks")
 
 
 def get_notebooks():
@@ -47,31 +46,35 @@ def get_notebooks():
         return os.path.basename(nb) in blacklisted_notebooks_basename
 
     # recursively traverse the notebook directory in search for ipython notebooks
-    all_py_notebooks = glob.iglob(os.path.join(_nbpath(), '**', '*.pct.py'), recursive=True)
-    all_md_notebooks = glob.iglob(os.path.join(_nbpath(), '**', '*.md'), recursive=True)
+    all_py_notebooks = glob.iglob(
+        os.path.join(_nbpath(), "**", "*.pct.py"), recursive=True
+    )
+    all_md_notebooks = glob.iglob(os.path.join(_nbpath(), "**", "*.md"), recursive=True)
     all_notebooks = itertools.chain(all_md_notebooks, all_py_notebooks)
     notebooks_to_test = [nb for nb in all_notebooks if not notebook_blacklisted(nb)]
     return notebooks_to_test
 
 
 def _preproc():
-    pythonkernel = 'python' + str(sys.version_info[0])
-    return ExecutePreprocessor(timeout=300, kernel_name=pythonkernel, interrupt_on_timeout=True)
+    pythonkernel = "python" + str(sys.version_info[0])
+    return ExecutePreprocessor(
+        timeout=300, kernel_name=pythonkernel, interrupt_on_timeout=True
+    )
 
 
 def _exec_notebook(notebook_filename):
     with open(notebook_filename) as notebook_file:
         nb = jupytext.read(notebook_file, as_version=nbformat.current_nbformat)
         try:
-            meta_data = {'path': os.path.dirname(notebook_filename)}
-            _preproc().preprocess(nb, {'metadata': meta_data})
+            meta_data = {"path": os.path.dirname(notebook_filename)}
+            _preproc().preprocess(nb, {"metadata": meta_data})
         except CellExecutionError as cell_error:
             traceback.print_exc(file=sys.stdout)
-            msg = 'Error executing the notebook {0}. See above for error.\nCell error: {1}'
+            msg = "Error executing the notebook {0}. See above for error.\nCell error: {1}"
             pytest.fail(msg.format(notebook_filename, str(cell_error)))
 
 
 @pytest.mark.notebooks
-@pytest.mark.parametrize('notebook_file', get_notebooks())
+@pytest.mark.parametrize("notebook_file", get_notebooks())
 def test_notebook(notebook_file):
     _exec_notebook(notebook_file)


### PR DESCRIPTION
The tests have very inconsistent formatting; even if we don't enforce strict formatting for future PRs it would be nice to give them a once-over to make the formatting consistent. The changes in this PR are solely from running `black tests` on `develop`, no further manual edits.