### PR TITLE
adding the sinc kernel

### DIFF
--- a/gpflow/kernels/__init__.py
+++ b/gpflow/kernels/__init__.py
@@ -20,6 +20,7 @@ from .stationaries import (
     Matern32,
     Matern52,
     RationalQuadratic,
+    Sinc,
     Stationary,
 )
 

--- a/gpflow/kernels/stationaries.py
+++ b/gpflow/kernels/stationaries.py
@@ -170,6 +170,25 @@ class Matern52(Stationary):
         return self.variance * (1.0 + sqrt5 * r + 5.0 / 3.0 * tf.square(r)) * tf.exp(-sqrt5 * r)
 
 
+class Sinc(Stationary):
+    """
+    The sinc kernel. Functions drawn from a GP with this kernel have a quasi-periodic behaviour.
+    The kernel equation is
+
+        k(r) = σ² sin{r}/r     for r>0
+        k(r) = σ²              for r=0
+
+    where:
+    r  is the Euclidean distance between the input points, scaled by the lengthscale parameter ℓ,
+    σ² is the variance parameter.
+    """
+
+    def K_r(self, r):
+        k0 = tf.ones_like(r)
+        k = tf.divide(tf.sin(r), r)
+        return self.variance * tf.where(tf.equal(r, 0), k0, k)
+
+
 class Cosine(Stationary):
     """
     The Cosine kernel. Functions drawn from a GP with this kernel are sinusoids

--- a/gpflow/kernels/stationaries.py
+++ b/gpflow/kernels/stationaries.py
@@ -186,7 +186,7 @@ class Sinc(Stationary):
     def K_r(self, r):
         k0 = tf.ones_like(r)
         k = tf.sin(r) / r
-        return self.variance * tf.where(tf.equal(r, 0), k0, k)
+        return self.variance * tf.where(tf.equal(r, 0.0), k0, k)
 
 
 class Cosine(Stationary):

--- a/gpflow/kernels/stationaries.py
+++ b/gpflow/kernels/stationaries.py
@@ -185,7 +185,7 @@ class Sinc(Stationary):
 
     def K_r(self, r):
         k0 = tf.ones_like(r)
-        k = tf.divide(tf.sin(r), r)
+        k = tf.sin(r) / r
         return self.variance * tf.where(tf.equal(r, 0), k0, k)
 
 

--- a/tests/gpflow/kernels/test_kernels.py
+++ b/tests/gpflow/kernels/test_kernels.py
@@ -64,15 +64,17 @@ def test_rbf_1d(variance, lengthscale):
 
     assert_allclose(gram_matrix, reference_gram_matrix)
 
+
 @pytest.mark.parametrize("variance, lengthscale", [[2.3, 1.3]])
 def test_cos_1d(variance, lengthscale):
     X = rng.randn(3, 1)
     kernel = gpflow.kernels.Cosine(lengthscale=lengthscale, variance=variance)
 
     gram_matrix = kernel(X)
-    reference_gram_matrix = variance * np.cos((X-X.T)/lengthscale)
+    reference_gram_matrix = variance * np.cos((X - X.T) / lengthscale)
 
     assert_allclose(gram_matrix, reference_gram_matrix)
+
 
 @pytest.mark.parametrize("variance, lengthscale", [[2.3, 1.4]])
 def test_sinc_1d(variance, lengthscale):
@@ -80,9 +82,10 @@ def test_sinc_1d(variance, lengthscale):
     kernel = gpflow.kernels.Sinc(lengthscale=lengthscale, variance=variance)
 
     gram_matrix = kernel(X)
-    reference_gram_matrix = variance * np.sinc((X-X.T)/np.pi/lengthscale)
+    reference_gram_matrix = variance * np.sinc((X - X.T) / np.pi / lengthscale)
 
     assert_allclose(gram_matrix, reference_gram_matrix)
+
 
 @pytest.mark.parametrize("variance, lengthscale", [[2.3, 1.4]])
 def test_rq_1d(variance, lengthscale):

--- a/tests/gpflow/kernels/test_kernels.py
+++ b/tests/gpflow/kernels/test_kernels.py
@@ -64,6 +64,25 @@ def test_rbf_1d(variance, lengthscale):
 
     assert_allclose(gram_matrix, reference_gram_matrix)
 
+@pytest.mark.parametrize("variance, lengthscale", [[2.3, 1.3]])
+def test_cos_1d(variance, lengthscale):
+    X = rng.randn(3, 1)
+    kernel = gpflow.kernels.Cosine(lengthscale=lengthscale, variance=variance)
+
+    gram_matrix = kernel(X)
+    reference_gram_matrix = variance * np.cos((X-X.T)/lengthscale)
+
+    assert_allclose(gram_matrix, reference_gram_matrix)
+
+@pytest.mark.parametrize("variance, lengthscale", [[2.3, 1.4]])
+def test_sinc_1d(variance, lengthscale):
+    X = rng.randn(3, 1)
+    kernel = gpflow.kernels.Sinc(lengthscale=lengthscale, variance=variance)
+
+    gram_matrix = kernel(X)
+    reference_gram_matrix = variance * np.sinc((X-X.T)/np.pi/lengthscale)
+
+    assert_allclose(gram_matrix, reference_gram_matrix)
 
 @pytest.mark.parametrize("variance, lengthscale", [[2.3, 1.4]])
 def test_rq_1d(variance, lengthscale):


### PR DESCRIPTION
### Adding new kernel: the sinc covariance function

The sinc covariance is interesting for modelling quasi-periodic signals. It is a stationary covariance defined as
    k(r) = \sigma^2 sin(r) / r     if r > 0
    k(r) = \sigma^2                  if r = 0

### Details

Tensorflow does not seem to have a sinc function, so it is implemented with a tf.where to handle the case `r=0`. I've added some tests comparing it to the numpy implementation. As I'm a good citizen, I've also added a test to the cosine covariance function on the way ;)