### PR TITLE
Broadcasting of kernels reintroduced

### DIFF
--- a/gpflow/conditionals/conditionals.py
+++ b/gpflow/conditionals/conditionals.py
@@ -109,9 +109,9 @@ def _conditional(
         - mean:     [N, R]
         - variance: [N, R] (full_cov = False), [R, N, N] (full_cov = True)
     """
-    Kmm = kernel(X) + eye(tf.shape(X)[-2], value=default_jitter(), dtype=X.dtype)
-    Kmn = kernel(X, Xnew)
-    Knn = kernel(Xnew, full=full_cov)
+    Kmm = kernel(X) + eye(tf.shape(X)[-2], value=default_jitter(), dtype=X.dtype)  # [..., M, M]
+    Kmn = kernel(X, Xnew)  # [M, ..., N]
+    Knn = kernel(Xnew, full=full_cov)  # [..., N] (full_cov = False) or [..., N, N] (True)
     mean, var = base_conditional(
         Kmn, Kmm, Knn, function, full_cov=full_cov, q_sqrt=q_sqrt, white=white
     )

--- a/gpflow/kernels/base.py
+++ b/gpflow/kernels/base.py
@@ -16,6 +16,14 @@ Kernels form a core component of GPflow models and allow prior information to
 be encoded about a latent function of interest. The effect of choosing
 different kernels, and how it is possible to combine multiple kernels is shown
 in the `"Using kernels in GPflow" notebook <notebooks/kernels.html>`_.
+
+Broadcasting over leading dimensions:
+`kernel.K(X1, X2)` returns the kernel evaluated on every pair in X1 and X2.
+E.g. if X1 has shape [S1, N1, D] and X2 has shape [S2, N2, D], kernel.K(X1, X2)
+will return a tensor of shape [S1, N1, S2, N2]. Similarly, kernel.K(X1, X1)
+returns a tensor of shape [S1, N1, S1, N1]. In contrast, the return shape of
+kernel.K(X1) is [S1, N1, N1]. (Without leading dimensions, the behaviour of
+kernel.K(X, None) is identical to kernel.K(X, X).)
 """
 
 import abc

--- a/gpflow/kernels/linears.py
+++ b/gpflow/kernels/linears.py
@@ -40,7 +40,7 @@ class Linear(Kernel):
             return tf.tensordot(X * self.variance, X2, [[-1], [-1]])
 
     def K_diag(self, X):
-        return tf.reduce_sum(tf.square(X) * self.variance, -1)
+        return tf.reduce_sum(tf.square(X) * self.variance, axis=-1)
 
 
 class Polynomial(Linear):

--- a/gpflow/kernels/linears.py
+++ b/gpflow/kernels/linears.py
@@ -35,12 +35,12 @@ class Linear(Kernel):
 
     def K(self, X, X2=None):
         if X2 is None:
-            X2 = X
-
-        return tf.linalg.matmul(X * self.variance, X2, transpose_b=True)
+            return tf.matmul(X * self.variance, X, transpose_b=True)
+        else:
+            return tf.tensordot(X * self.variance, X2, [[-1], [-1]])
 
     def K_diag(self, X):
-        return tf.reduce_sum(tf.square(X) * self.variance, 1)
+        return tf.reduce_sum(tf.square(X) * self.variance, -1)
 
 
 class Polynomial(Linear):

--- a/gpflow/kernels/statics.py
+++ b/gpflow/kernels/statics.py
@@ -35,7 +35,7 @@ class White(Static):
             d = tf.fill(tf.shape(X)[:-1], tf.squeeze(self.variance))
             return tf.linalg.diag(d)
         else:
-            shape = tf.concat([tf.shape(X)[:-1], tf.shape(X2)[:-1]], 0)
+            shape = tf.concat([tf.shape(X)[:-1], tf.shape(X2)[:-1]], axis=0)
             return tf.zeros(shape, dtype=X.dtype)
 
 
@@ -58,9 +58,9 @@ class Constant(Static):
                     tf.reshape(tf.shape(X)[-2], [1]),
                     tf.reshape(tf.shape(X)[-2], [1]),
                 ],
-                0,
+                axis=0,
             )
         else:
-            shape = tf.concat([tf.shape(X)[:-1], tf.shape(X2)[:-1]], 0)
+            shape = tf.concat([tf.shape(X)[:-1], tf.shape(X2)[:-1]], axis=0)
 
         return tf.fill(shape, tf.squeeze(self.variance))

--- a/gpflow/kernels/statics.py
+++ b/gpflow/kernels/statics.py
@@ -16,7 +16,7 @@ class Static(Kernel):
         self.variance = Parameter(variance, transform=positive())
 
     def K_diag(self, X):
-        return tf.fill((tf.shape(X)[0],), tf.squeeze(self.variance))
+        return tf.fill(tf.shape(X)[:-1], tf.squeeze(self.variance))
 
 
 class White(Static):
@@ -32,10 +32,10 @@ class White(Static):
 
     def K(self, X, X2=None):
         if X2 is None:
-            d = tf.fill((tf.shape(X)[0],), tf.squeeze(self.variance))
+            d = tf.fill(tf.shape(X)[:-1], tf.squeeze(self.variance))
             return tf.linalg.diag(d)
         else:
-            shape = [tf.shape(X)[0], tf.shape(X2)[0]]
+            shape = tf.concat([tf.shape(X)[:-1], tf.shape(X2)[:-1]], 0)
             return tf.zeros(shape, dtype=X.dtype)
 
 
@@ -52,7 +52,15 @@ class Constant(Static):
 
     def K(self, X, X2=None):
         if X2 is None:
-            shape = [tf.shape(X)[0], tf.shape(X)[0]]
+            shape = tf.concat(
+                [
+                    tf.shape(X)[:-2],
+                    tf.reshape(tf.shape(X)[-2], [1]),
+                    tf.reshape(tf.shape(X)[-2], [1]),
+                ],
+                0,
+            )
         else:
-            shape = [tf.shape(X)[0], tf.shape(X2)[0]]
+            shape = tf.concat([tf.shape(X)[:-1], tf.shape(X2)[:-1]], 0)
+
         return tf.fill(shape, tf.squeeze(self.variance))

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -80,6 +80,12 @@ def square_distance(X, X2):
     Due to the implementation and floating-point imprecision, the
     result may actually be very slightly negative for entries very
     close to each other.
+
+    This function can deal with leading dimensions in X and X2. 
+    In the sample case, where X and X2 are both 2 dimensional, 
+    for example, X is [N, D] and X2 is [M, D], then a tensor of shape 
+    [N, M] is returned. If X is [N1, S1, D] and X2 is [N2, S2, D] 
+    then the output will be [N1, S1, N2, S2].
     """
     if X2 is None:
         Xs = tf.reduce_sum(tf.square(X), axis=-1, keepdims=True)

--- a/tests/gpflow/conditionals/test_conditionals.py
+++ b/tests/gpflow/conditionals/test_conditionals.py
@@ -145,3 +145,51 @@ def test_q_sqrt_constraints(Xdata, Xnew, kernel, mu, white):
 
     diff_after_gradient_step = (q_sqrt_constrained - q_sqrt_unconstrained).numpy()
     assert_allclose(diff_after_gradient_step, 0)
+
+
+@pytest.mark.parametrize("full_cov", [True, False])
+@pytest.mark.parametrize("features_inducing_points", [False, True])
+def test_base_conditional_vs_ref(full_cov, features_inducing_points):
+    """
+    Test that conditionals agree with a slow-but-clear numpy implementation
+    """
+    Dy, N, M, Dx = 5, 4, 3, 2
+    X = np.random.randn(N, Dx)
+    Z = np.random.randn(M, Dx)
+    kern = gpflow.kernels.Matern52(lengthscale=0.5)
+    q_mu = np.random.randn(M, Dy)
+    q_sqrt = np.tril(np.random.randn(Dy, M, M), -1)
+
+    def numpy_conditional(X, Z, kern, q_mu, q_sqrt):
+        Kmm = kern(Z, Z) + np.eye(M) * gpflow.config.default_jitter()
+        Kmn = kern(Z, X)
+        Knn = kern(X, X)
+
+        Kmm, Kmn, Knn = [k.numpy() for k in [Kmm, Kmn, Knn]]
+
+        Kmm, Kmn, Knm, Knn = [np.tile(k[None, :, :], [Dy, 1, 1]) for k in [Kmm, Kmn, Kmn.T, Knn]]
+
+        S = q_sqrt @ np.transpose(q_sqrt, [0, 2, 1])
+
+        Kmm_inv = np.linalg.inv(Kmm)
+        mean = np.einsum("dmn,dmM,Md->nd", Kmn, Kmm_inv, q_mu)
+        cov = Knn + Knm @ Kmm_inv @ (S - Kmm) @ Kmm_inv @ Kmn
+        return mean, cov
+
+    mean_np, cov_np = numpy_conditional(X, Z, kern, q_mu, q_sqrt)
+
+    if features_inducing_points:
+        Z = gpflow.inducing_variables.InducingPoints(Z)
+
+    mean_gpflow, cov_gpflow = [
+        v.numpy()
+        for v in gpflow.conditionals.conditional(
+            X, Z, kern, q_mu, q_sqrt=tf.identity(q_sqrt), white=False, full_cov=full_cov
+        )
+    ]
+
+    if not full_cov:
+        cov_np = np.diagonal(cov_np, axis1=-1, axis2=-2).T
+
+    assert_allclose(mean_np, mean_gpflow)
+    assert_allclose(cov_np, cov_gpflow)

--- a/tests/gpflow/conditionals/test_util.py
+++ b/tests/gpflow/conditionals/test_util.py
@@ -38,11 +38,13 @@ def test_leading_transpose():
     assert d.shape == e.shape == f.shape
 
 
-@pytest.mark.xfail(raises=ValueError)
-def test_leading_transpose_fail():
+def test_leading_transpose_fails():
+    """ Check that error is thrown if `perm` is not compatible with `a` """
     dims = [1, 2, 3, 4]
     a = tf.zeros(dims)
-    leading_transpose(a, [-1, -2])
+
+    with pytest.raises(ValueError):
+        leading_transpose(a, [-1, -2])
 
 
 # rollaxis

--- a/tests/gpflow/conditionals/test_util.py
+++ b/tests/gpflow/conditionals/test_util.py
@@ -57,7 +57,7 @@ def test_rollaxis(rolls, direction):
     elif direction == "right":
         perm = [2, 0, 1] if rolls == 1 else [1, 2, 0]
     else:
-        raise (NotImplementedError)
+        raise NotImplementedError
 
     A_rolled_ref = np.transpose(A, perm)
 
@@ -66,7 +66,7 @@ def test_rollaxis(rolls, direction):
     elif direction == "right":
         A_rolled_tf = rollaxis_right(A_tf, rolls)
     else:
-        raise (NotImplementedError)
+        raise NotImplementedError
 
     assert_allclose(A_rolled_ref, A_rolled_tf)
 

--- a/tests/gpflow/conditionals/test_util.py
+++ b/tests/gpflow/conditionals/test_util.py
@@ -1,0 +1,82 @@
+# Copyright 2020 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from numpy.testing import assert_allclose
+
+from gpflow.conditionals.util import leading_transpose, rollaxis_left, rollaxis_right
+
+
+def test_leading_transpose():
+    dims = [1, 2, 3, 4]
+    a = tf.zeros(dims)
+    b = leading_transpose(a, [..., -1, -2])
+    c = leading_transpose(a, [-1, ..., -2])
+    d = leading_transpose(a, [-1, -2, ...])
+    e = leading_transpose(a, [3, 2, ...])
+    f = leading_transpose(a, [3, -2, ...])
+
+    assert len(a.shape) == len(b.shape) == len(c.shape) == len(d.shape)
+    assert len(a.shape) == len(e.shape) == len(f.shape)
+    assert b.shape[-2:] == [4, 3]
+    assert c.shape[0] == 4 and c.shape[-1] == 3
+    assert d.shape[:2] == [4, 3]
+    assert d.shape == e.shape == f.shape
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_leading_transpose_fail():
+    dims = [1, 2, 3, 4]
+    a = tf.zeros(dims)
+    leading_transpose(a, [-1, -2])
+
+
+# rollaxis
+@pytest.mark.parametrize("rolls", [1, 2])
+@pytest.mark.parametrize("direction", ["left", "right"])
+def test_rollaxis(rolls, direction):
+    A = np.random.randn(10, 5, 3)
+    A_tf = tf.convert_to_tensor(A)
+
+    if direction == "left":
+        perm = [1, 2, 0] if rolls == 1 else [2, 0, 1]
+    elif direction == "right":
+        perm = [2, 0, 1] if rolls == 1 else [1, 2, 0]
+    else:
+        raise (NotImplementedError)
+
+    A_rolled_ref = np.transpose(A, perm)
+
+    if direction == "left":
+        A_rolled_tf = rollaxis_left(A_tf, rolls)
+    elif direction == "right":
+        A_rolled_tf = rollaxis_right(A_tf, rolls)
+    else:
+        raise (NotImplementedError)
+
+    assert_allclose(A_rolled_ref, A_rolled_tf)
+
+
+@pytest.mark.parametrize("rolls", [1, 2])
+def test_rollaxis_idempotent(rolls):
+    A = np.random.randn(10, 5, 3, 20, 1)
+    A_tf = tf.convert_to_tensor(A)
+    A_left_right = rollaxis_left(rollaxis_right(A_tf, 2), 2)
+    A_right_left = rollaxis_right(rollaxis_left(A_tf, 2), 2)
+
+    assert_allclose(A, A_left_right)
+    assert_allclose(A, A_right_left)

--- a/tests/gpflow/kernels/test_broadcasting.py
+++ b/tests/gpflow/kernels/test_broadcasting.py
@@ -37,9 +37,9 @@ KERNEL_CLASSES = [
     kernels.Linear,
     kernels.Polynomial,
     # Following kernels do not broadcast:
-    # kernels.Coregion
-    # kernels.ArcCosine,
-    # kernels.Periodic,
+    pytest.param(kernels.ArcCosine, marks=pytest.mark.xfail),  # broadcasting not implemented
+    pytest.param(kernels.Coregion, marks=pytest.mark.xfail),  # broadcasting not implemented
+    pytest.param(kernels.Periodic, marks=pytest.mark.xfail),  # broadcasting not implemented
 ]
 
 

--- a/tests/gpflow/kernels/test_broadcasting.py
+++ b/tests/gpflow/kernels/test_broadcasting.py
@@ -1,0 +1,103 @@
+# Copyright 2020 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+import gpflow
+from gpflow import kernels
+
+
+KERNEL_CLASSES = [
+    # Static
+    kernels.White,
+    kernels.Constant,
+    # Stationary
+    kernels.SquaredExponential,
+    kernels.RationalQuadratic,
+    kernels.Exponential,
+    kernels.Matern12,
+    kernels.Matern32,
+    kernels.Matern52,
+    kernels.Cosine,
+    kernels.Linear,
+    kernels.Polynomial,
+    # Following kernels do not broadcast:
+    # kernels.Coregion
+    # kernels.ArcCosine,
+    # kernels.Periodic,
+]
+
+
+def _test_no_active_dims(Kernel):
+    S, N, M, D = 5, 4, 3, 2
+    X1 = np.random.randn(S, N, D)
+    X2 = np.random.randn(M, D)
+    kernel = Kernel() + gpflow.kernels.White()
+
+    compare_vs_map(X1, X2, kernel)
+
+
+def _test_slice_active_dims(Kernel):
+    S, N, M, D = 5, 4, 3, 4
+    d = 2
+    X1 = np.random.randn(S, N, D)
+    X2 = np.random.randn(M, D)
+    kernel = Kernel(active_dims=slice(1, 1 + d))
+
+    compare_vs_map(X1, X2, kernel)
+
+
+def _test_indices_active_dims(Kernel):
+    S, N, M, D = 5, 4, 3, 4
+
+    X1 = np.random.randn(S, N, D)
+    X2 = np.random.randn(M, D)
+    kernel = Kernel(active_dims=[1, 3])
+
+    compare_vs_map(X1, X2, kernel)
+
+
+def compare_vs_map(X1, X2, kernel):
+    K12_loop = tf.stack([kernel(x, X2) for x in X1])  # [S, N, M]
+    K12_native = kernel(X1, X2)  # [S, N, M]
+    assert_allclose(K12_loop.numpy(), K12_native.numpy())
+
+    K11_loop = tf.stack([kernel(x) for x in X1])
+    K11_native = kernel(X1)
+    assert_allclose(K11_loop.numpy(), K11_native.numpy())
+
+    K1_loop = tf.stack([kernel(x, full=False) for x in X1])
+    K1_native = kernel(X1, full=False)
+    assert_allclose(K1_loop.numpy(), K1_native.numpy())
+
+
+def test_squaredexponential():
+    _test_no_active_dims(gpflow.kernels.SquaredExponential)
+
+
+def test_squaredexponential_slice():
+    _test_slice_active_dims(gpflow.kernels.SquaredExponential)
+
+
+def test_squaredexponential_indices():
+    _test_indices_active_dims(gpflow.kernels.SquaredExponential)
+
+
+@pytest.mark.parametrize("Kernel", KERNEL_CLASSES)
+def test_all_no_active_dims(Kernel):
+    _test_no_active_dims(Kernel)

--- a/tests/gpflow/kernels/test_broadcasting.py
+++ b/tests/gpflow/kernels/test_broadcasting.py
@@ -45,34 +45,34 @@ KERNEL_CLASSES = [
 ]
 
 
-@pytest.mark.parametrize("Kernel", KERNEL_CLASSES)
-def test_broadcast_no_active_dims(Kernel):
+@pytest.mark.parametrize("kernel_class", KERNEL_CLASSES)
+def test_broadcast_no_active_dims(kernel_class):
     S, N, M, D = 5, 4, 3, 2
     X1 = np.random.randn(S, N, D)
     X2 = np.random.randn(M, D)
-    kernel = Kernel() + gpflow.kernels.White()
+    kernel = kernel_class() + gpflow.kernels.White()
 
     compare_vs_map(X1, X2, kernel)
 
 
-@pytest.mark.parametrize("Kernel", [gpflow.kernels.SquaredExponential])
-def test_broadcast_slice_active_dims(Kernel):
+@pytest.mark.parametrize("kernel_class", [gpflow.kernels.SquaredExponential])
+def test_broadcast_slice_active_dims(kernel_class):
     S, N, M, D = 5, 4, 3, 4
     d = 2
     X1 = np.random.randn(S, N, D)
     X2 = np.random.randn(M, D)
-    kernel = Kernel(active_dims=slice(1, 1 + d))
+    kernel = kernel_class(active_dims=slice(1, 1 + d))
 
     compare_vs_map(X1, X2, kernel)
 
 
-@pytest.mark.parametrize("Kernel", [gpflow.kernels.SquaredExponential])
-def test_broadcast_indices_active_dims(Kernel):
+@pytest.mark.parametrize("kernel_class", [gpflow.kernels.SquaredExponential])
+def test_broadcast_indices_active_dims(kernel_class):
     S, N, M, D = 5, 4, 3, 4
 
     X1 = np.random.randn(S, N, D)
     X2 = np.random.randn(M, D)
-    kernel = Kernel(active_dims=[1, 3])
+    kernel = kernel_class(active_dims=[1, 3])
 
     compare_vs_map(X1, X2, kernel)
 


### PR DESCRIPTION
Hi all,

Reintroduce broadcasting functionality we had in GPflow 1 (added in #895) back into GPflow 2.  

## Synopsis of #895 

This PR generalises gpflow's conditional code to work with tensors that have an arbitrary number of leading dimension. Before we assumed that `Xnew` passed in `gpflow.conditional` was a two-dimensional tensor, typically referred to as `[N, D]`. This PR makes it possible to pass in `Xnew` tensors of shape `[..., N, D]`, where `[...]` can be any leading dimensions. The changes required for this are minor:
1) A couple of `tf.matmul`'s are replaced with `tf.tensordot`'s.
2) `kernels.K(X1, X2)` returns the kernel evaluated on every pair in `X1` and `X2`. This is the same behaviour as before, but now tensors with leading dims are supported. 
E.g. if `X1` is `[N1, S1, D]` and `X2: [N2, S2, D]`, `kernel.K(X1, X2)` will return a tensor of shape `[N1, S1, N2, S2]`.  `kernel.K(X1)` returns `[N1, S1, S1]`.


