### PR TITLE
Fix predict_f_samples

### DIFF
--- a/gpflow/conditionals/sample_conditionals.py
+++ b/gpflow/conditionals/sample_conditionals.py
@@ -52,11 +52,11 @@ def _sample_conditional(
         samples = sample_mvn(
             mean_for_sample, cov, "full", num_samples=num_samples
         )  # [..., (S), P, N]
-        samples = tf.linalg.adjoint(samples)  # [..., (S), P, N]
+        samples = tf.linalg.adjoint(samples)  # [..., (S), N, P]
     else:
         # mean: [..., N, P]
         # cov: [..., N, P] or [..., N, P, P]
         cov_structure = "full" if full_output_cov else "diag"
-        samples = sample_mvn(mean, cov, cov_structure, num_samples=num_samples)  # [..., (S), P, N]
+        samples = sample_mvn(mean, cov, cov_structure, num_samples=num_samples)  # [..., (S), N, P]
 
     return samples, mean, cov

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -20,6 +20,7 @@ import numpy as np
 import tensorflow as tf
 
 from ..base import Module
+from ..conditionals.util import sample_mvn
 from ..config import default_float, default_jitter
 from ..kernels import Kernel
 from ..likelihoods import Likelihood
@@ -118,16 +119,43 @@ class GPModel(BayesianModel):
     ) -> tf.Tensor:
         """
         Produce samples from the posterior latent function(s) at the input points.
+
+        :param Xnew: DataPoint
+            Input locations at which to draw samples
+        :param num_samples: int
+            Number of samples to draw.
+            If `None` a one sample is drawn and the return shape is [..., N, P],
+            for any other positive integer the return shape contains an extra batch
+            dimension, [..., S, N, P], with S = num_samples.
+        :param full_cov: bool, default to `True`,
+            Draw correlated samples over the inputs. Computes the cholesky over the
+            dense covariance matrix of size [num_data, num_data].
+        :param full_output_cov: bool, defaults to `False`.
+            Draw correlated samples over the outputs.
+            The method currently only supports `full_output_cov` equals to `False`.
         """
-        mu, var = self.predict_f(Xnew, full_cov=full_cov)  # [N, P], [P, N, N]
-        num_latent_gps = var.shape[0]
-        num_elems = tf.shape(var)[1]
-        var_jitter = ops.add_to_diagonal(var, default_jitter())
-        L = tf.linalg.cholesky(var_jitter)  # [P, N, N]
-        V = tf.random.normal([num_latent_gps, num_elems, num_samples], dtype=mu.dtype)  # [P, N, S]
-        LV = L @ V  # [P, N, S]
-        mu_t = tf.linalg.adjoint(mu)  # [P, N]
-        return tf.transpose(mu_t[..., np.newaxis] + LV)  # [S, N, P]
+        if full_output_cov:
+            raise NotImplementedError(
+                "`full_output_cov` True is currently not supported by `predict_f_samples`"
+            )
+
+        mean, cov = self.predict_f(Xnew, full_cov=full_cov)  # [N, P], [P, N, N] or [N, P]
+        if full_cov:
+            # mean: [..., N, P]
+            # cov: [..., P, N, N]
+            mean_for_sample = tf.linalg.adjoint(mean)  # [..., P, N]
+            samples = sample_mvn(
+                mean_for_sample, cov, "full", num_samples=num_samples
+            )  # [..., (S), P, N]
+            samples = tf.linalg.adjoint(samples)  # [..., (S), N, P]
+        else:
+            # mean: [..., N, P]
+            # cov: [..., N, P] or [..., N, P, P]
+            cov_structure = "full" if full_output_cov else "diag"
+            samples = sample_mvn(
+                mean, cov, cov_structure, num_samples=num_samples
+            )  # [..., (S), N, P]
+        return samples  # [..., (S), N, P]
 
     def predict_y(
         self, Xnew: DataPoint, full_cov: bool = False, full_output_cov: bool = False

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -128,15 +128,18 @@ class GPModel(BayesianModel):
             for any positive integer the return shape contains an extra batch
             dimension, [..., S, N, P], with S = num_samples.
         :param full_cov:
-            Draw correlated samples over the inputs. Computes the cholesky over the
+            If True, draw correlated samples over the inputs. Computes the Cholesky over the
             dense covariance matrix of size [num_data, num_data].
+            If False, draw samples that are uncorrelated over the inputs.
         :param full_output_cov: bool, defaults to `False`.
-            Draw correlated samples over the outputs.
-            The method currently only supports `full_output_cov` equals to `False`.
+            If True, draw correlated samples over the outputs.
+            If False, draw samples that are uncorrelated over the outputs.
+
+        Currently, the method does not support `full_output_cov=True` and `full_cov=True`.
         """
-        if full_output_cov:
+        if full_cov and full_output_cov:
             raise NotImplementedError(
-                "`full_output_cov=True` is currently not supported by `predict_f_samples`"
+                "The combination of both `full_cov` and `full_output_cov` is not supported."
             )
 
         mean, cov = self.predict_f(Xnew, full_cov=full_cov)  # [N, P], [P, N, N] or [N, P]

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -113,7 +113,7 @@ class GPModel(BayesianModel):
     def predict_f_samples(
         self,
         Xnew: DataPoint,
-        num_samples: Optional[int] = 1,
+        num_samples: Optional[int] = None,
         full_cov: bool = True,
         full_output_cov: bool = False,
     ) -> tf.Tensor:

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -113,7 +113,7 @@ class GPModel(BayesianModel):
     def predict_f_samples(
         self,
         Xnew: DataPoint,
-        num_samples: int = 1,
+        num_samples: Optional[int] = 1,
         full_cov: bool = True,
         full_output_cov: bool = False,
     ) -> tf.Tensor:
@@ -122,12 +122,12 @@ class GPModel(BayesianModel):
 
         :param Xnew: DataPoint
             Input locations at which to draw samples
-        :param num_samples: int
+        :param num_samples:
             Number of samples to draw.
-            If `None` a one sample is drawn and the return shape is [..., N, P],
-            for any other positive integer the return shape contains an extra batch
+            If `None`, a single sample is drawn and the return shape is [..., N, P],
+            for any positive integer the return shape contains an extra batch
             dimension, [..., S, N, P], with S = num_samples.
-        :param full_cov: bool, default to `True`,
+        :param full_cov:
             Draw correlated samples over the inputs. Computes the cholesky over the
             dense covariance matrix of size [num_data, num_data].
         :param full_output_cov: bool, defaults to `False`.
@@ -136,7 +136,7 @@ class GPModel(BayesianModel):
         """
         if full_output_cov:
             raise NotImplementedError(
-                "`full_output_cov` True is currently not supported by `predict_f_samples`"
+                "`full_output_cov=True` is currently not supported by `predict_f_samples`"
             )
 
         mean, cov = self.predict_f(Xnew, full_cov=full_cov)  # [N, P], [P, N, N] or [N, P]

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -142,7 +142,8 @@ class GPModel(BayesianModel):
                 "The combination of both `full_cov` and `full_output_cov` is not supported."
             )
 
-        mean, cov = self.predict_f(Xnew, full_cov=full_cov)  # [N, P], [P, N, N] or [N, P]
+        # check below for shape info
+        mean, cov = self.predict_f(Xnew, full_cov=full_cov, full_output_cov=full_output_cov)
         if full_cov:
             # mean: [..., N, P]
             # cov: [..., P, N, N]

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -12,12 +12,6 @@ def eye(num: int, value: tf.Tensor, dtype: Optional[tf.DType] = None) -> tf.Tens
     return tf.linalg.diag(tf.fill([num], value))
 
 
-def add_to_diagonal(to_tensor: tf.Tensor, value: tf.Tensor):
-    diag = tf.linalg.diag_part(to_tensor)
-    new_diag = diag + value
-    return tf.linalg.set_diag(to_tensor, new_diag)
-
-
 def leading_transpose(
     tensor: tf.Tensor, perm: List[Union[int, type(...)]], leading_dim: int = 0
 ) -> tf.Tensor:

--- a/tests/gpflow/models/test_model_predict.py
+++ b/tests/gpflow/models/test_model_predict.py
@@ -144,6 +144,9 @@ def test_gaussian_full_cov_samples(input_dim, output_dim, N, Ntest, M, num_sampl
     samples = model_gp.predict_f_samples(Xtest, num_samples)
     assert samples.shape == samples_shape
 
+    samples = model_gp.predict_f_samples(Xtest, num_samples, full_cov=False)
+    assert samples.shape == samples_shape
+
 
 @pytest.mark.parametrize("model_setup", model_setups)
 @pytest.mark.parametrize("input_dim", [3])


### PR DESCRIPTION
`model.predict_f_samples` was broken: it did not work for `full_cov` equals `False`. This PR fixes this and adds a test. The code reuses `sample_mvn` which also makes more sense. 