### PR TITLE
Fix "comprehensiveness" tests

### DIFF
--- a/gpflow/ci_utils.py
+++ b/gpflow/ci_utils.py
@@ -38,3 +38,12 @@ def ci_range(n: int, test_n: int = 2):
 
 def ci_list(lst: list, test_n=2):
     return lst[:test_n] if is_continuous_integration() else lst
+
+
+def subclasses(cls):
+    """
+    Generator that returns all (not just direct) subclasses of `cls`
+    """
+    for subclass in cls.__subclasses__():
+        yield from subclasses(subclass)
+        yield subclass

--- a/tests/gpflow/kernels/test_broadcasting.py
+++ b/tests/gpflow/kernels/test_broadcasting.py
@@ -70,7 +70,7 @@ def test_no_kernels_missed(kernel_class):
     if kernel_class in abstract_base_classes:
         return  # cannot test abstract base classes
     if issubclass(kernel_class, kernels.MultioutputKernel):
-        return  # cannot currently test MultioutputKernels
+        return  # TODO: cannot currently test MultioutputKernels - see https://github.com/GPflow/GPflow/issues/1339
     assert False, f"no broadcasting test for kernel class {kernel_class}"
 
 

--- a/tests/gpflow/kernels/test_broadcasting.py
+++ b/tests/gpflow/kernels/test_broadcasting.py
@@ -56,18 +56,19 @@ def test_no_kernels_missed(kernel_class):
     skipped_kernel_classes = [
         p.values[0] for p in KERNEL_CLASSES if isinstance(p, type(pytest.param()))
     ]
-    if kernel_class in tested_kernels:
-        return  # tested
-    if kernel_class in skipped_kernel_classes:
-        return  # not tested but currently expected to fail
-    if kernel_class in [
+    abstract_base_classes = [
         kernels.Kernel,
         kernels.Combination,
         gpflow.kernels.base.ReducingCombination,
         kernels.Static,
         kernels.Stationary,
-    ]:  # abstract base classes
-        return
+    ]
+    if kernel_class in tested_kernel_classes:
+        return  # tested
+    if kernel_class in skipped_kernel_classes:
+        return  # not tested but currently expected to fail
+    if kernel_class in abstract_base_classes:
+        return  # cannot test abstract base classes
     if issubclass(kernel_class, kernels.MultioutputKernel):
         return  # cannot currently test MultioutputKernels
     assert False, f"no broadcasting test for kernel class {kernel_class}"

--- a/tests/gpflow/kernels/test_broadcasting.py
+++ b/tests/gpflow/kernels/test_broadcasting.py
@@ -19,30 +19,60 @@ from numpy.testing import assert_allclose
 import pytest
 
 import gpflow
+import gpflow.ci_utils
 from gpflow import kernels
 
 
 KERNEL_CLASSES = [
-    # Static
+    # Static kernels:
     kernels.White,
     kernels.Constant,
-    # Stationary
+    # Stationary kernels:
     kernels.SquaredExponential,
     kernels.RationalQuadratic,
     kernels.Exponential,
     kernels.Matern12,
     kernels.Matern32,
     kernels.Matern52,
+    # other kernels:
     kernels.Cosine,
     kernels.Linear,
     kernels.Polynomial,
-    # Following kernels do not broadcast:
+    # sum and product kernels:
+    lambda: kernels.White() + kernels.Matern12(),
+    lambda: kernels.White() * kernels.Matern12(),
+    # Following kernels do not broadcast: see https://github.com/GPflow/GPflow/issues/1339
     pytest.param(kernels.ArcCosine, marks=pytest.mark.xfail),  # broadcasting not implemented
     pytest.param(kernels.Coregion, marks=pytest.mark.xfail),  # broadcasting not implemented
     pytest.param(kernels.Periodic, marks=pytest.mark.xfail),  # broadcasting not implemented
-    lambda: kernels.White() + kernels.Matern12(),
-    lambda: kernels.White() * kernels.Matern12(),
+    pytest.param(kernels.ChangePoints, marks=pytest.mark.xfail),  # broadcasting not implemented
+    pytest.param(kernels.Convolutional, marks=pytest.mark.xfail),  # broadcasting not implemented
 ]
+
+
+@pytest.mark.parametrize("kernel_class", gpflow.ci_utils.subclasses(kernels.Kernel))
+def test_no_kernels_missed(kernel_class):
+    if kernel_class in (KERNEL_CLASSES + [kernels.Sum, kernels.Product]):
+        return  # tested
+    if kernel_class in [
+        kernels.ArcCosine,
+        kernels.Coregion,
+        kernels.Periodic,
+        kernels.ChangePoints,
+        kernels.Convolutional,
+    ]:  # not tested but currently expected to fail
+        return
+    if kernel_class in [
+        kernels.Kernel,
+        kernels.Combination,
+        gpflow.kernels.base.ReducingCombination,
+        kernels.Static,
+        kernels.Stationary,
+    ]:  # abstract base classes
+        return
+    if issubclass(kernel_class, kernels.MultioutputKernel):
+        return  # cannot currently test MultioutputKernels
+    assert False, f"no test for kernel class {kernel_class}"
 
 
 @pytest.mark.parametrize("kernel_class", KERNEL_CLASSES)
@@ -50,7 +80,7 @@ def test_broadcast_no_active_dims(kernel_class):
     S, N, M, D = 5, 4, 3, 2
     X1 = np.random.randn(S, N, D)
     X2 = np.random.randn(M, D)
-    kernel = kernel_class() + gpflow.kernels.White()
+    kernel = kernel_class()
 
     compare_vs_map(X1, X2, kernel)
 

--- a/tests/gpflow/kernels/test_broadcasting.py
+++ b/tests/gpflow/kernels/test_broadcasting.py
@@ -52,16 +52,14 @@ KERNEL_CLASSES = [
 
 @pytest.mark.parametrize("kernel_class", gpflow.ci_utils.subclasses(kernels.Kernel))
 def test_no_kernels_missed(kernel_class):
-    if kernel_class in (KERNEL_CLASSES + [kernels.Sum, kernels.Product]):
+    tested_kernel_classes = KERNEL_CLASSES + [kernels.Sum, kernels.Product]
+    skipped_kernel_classes = [
+        p.values[0] for p in KERNEL_CLASSES if isinstance(p, type(pytest.param()))
+    ]
+    if kernel_class in tested_kernels:
         return  # tested
-    if kernel_class in [
-        kernels.ArcCosine,
-        kernels.Coregion,
-        kernels.Periodic,
-        kernels.ChangePoints,
-        kernels.Convolutional,
-    ]:  # not tested but currently expected to fail
-        return
+    if kernel_class in skipped_kernel_classes:
+        return  # not tested but currently expected to fail
     if kernel_class in [
         kernels.Kernel,
         kernels.Combination,
@@ -72,7 +70,7 @@ def test_no_kernels_missed(kernel_class):
         return
     if issubclass(kernel_class, kernels.MultioutputKernel):
         return  # cannot currently test MultioutputKernels
-    assert False, f"no test for kernel class {kernel_class}"
+    assert False, f"no broadcasting test for kernel class {kernel_class}"
 
 
 @pytest.mark.parametrize("kernel_class", KERNEL_CLASSES)

--- a/tests/gpflow/likelihoods/test_likelihoods.py
+++ b/tests/gpflow/likelihoods/test_likelihoods.py
@@ -108,9 +108,8 @@ def get_likelihood(likelihood_setup):
 
 
 def test_no_missing_likelihoods():
-    all_likelihood_types = Likelihood.__subclasses__()
     tested_likelihood_types = [get_likelihood(l).__class__ for l in likelihood_setups]
-    for likelihood_class in all_likelihood_types:
+    for likelihood_class in gpflow.ci_utils.subclasses(Likelihood):
         if likelihood_class in tested_likelihood_types:
             continue  # already tested
         if likelihood_class is SwitchedLikelihood:


### PR DESCRIPTION
There is a test in test_likelihoods that checks whether we missed any likelihood in the test - this is so we are reminded to add tests when we add new likelihoods! But the test was broken, and this PR fixes the test. I've also done the same for the kernel broadcasting test.