### PR TITLE
gast dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ tf_gpu = 'tensorflow-gpu'
 def latest_version(package_name):
     url = f"https://pypi.python.org/pypi/{package_name}/json"
     data = json.load(request.urlopen(url))
-    # filter out rc and b releases and, more in general, any realeses that do not contain exclusively numbers and dots.
+    # filter out rc and beta releases and, more generally, any releases that
+    # do not contain exclusively numbers and dots.
     versions = [v for v in data["releases"].keys() if re.match('[0-9\.]+$',v)]  
     versions.sort(key=StrictVersion)
     return versions[-1]  # return latest version

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,6 @@ from pathlib import Path
 
 from pkg_resources import parse_version
 from setuptools import find_packages, setup
-# for latest_version() [see https://github.com/GPflow/GPflow/issues/1348]:
-import json
-from urllib import request
-import re
 
 is_py37 = sys.version_info.major == 3 and sys.version_info.minor == 7
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'  # copied from the docs
@@ -36,7 +32,12 @@ tf_cpu = 'tensorflow'
 tf_gpu = 'tensorflow-gpu'
 
 
+# for latest_version() [see https://github.com/GPflow/GPflow/issues/1348]:
 def latest_version(package_name):
+    import json
+    from urllib import request
+    import re
+
     url = f"https://pypi.python.org/pypi/{package_name}/json"
     data = json.load(request.urlopen(url))
     # filter out rc and beta releases and, more generally, any releases that

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ tf_gpu = 'tensorflow-gpu'
 
 
 def latest_version(package_name):
-    url = "https://pypi.python.org/pypi/%s/json" % (package_name,)
+    url = f"https://pypi.python.org/pypi/{package_name}/json"
     data = json.load(request.urlopen(url))
     # filter out rc and b releases and, more in general, any realeses that do not contain exclusively numbers and dots.
     versions = [v for v in data["releases"].keys() if re.match('[0-9\.]+$',v)]  

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ from pkg_resources import parse_version
 from setuptools import find_packages, setup
 import json
 from urllib import request
-from distutils.version import StrictVersion
 import re
 
 is_py37 = sys.version_info.major == 3 and sys.version_info.minor == 7

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ def latest_version(package_name):
     # filter out rc and beta releases and, more generally, any releases that
     # do not contain exclusively numbers and dots.
     versions = [parse_version(v) for v in data["releases"].keys() if re.match("^[0-9.]+$", v)]  
-    versions.sort(key=StrictVersion)
+    versions.sort()
     return versions[-1]  # return latest version
 
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def latest_version(package_name):
     data = json.load(request.urlopen(url))
     # filter out rc and beta releases and, more generally, any releases that
     # do not contain exclusively numbers and dots.
-    versions = [v for v in data["releases"].keys() if re.match('[0-9\.]+$',v)]  
+    versions = [parse_version(v) for v in data["releases"].keys() if re.match("^[0-9.]+$", v)]  
     versions.sort(key=StrictVersion)
     return versions[-1]  # return latest version
 

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,10 @@ tf_gpu = 'tensorflow-gpu'
 def latest_version(package_name):
     url = "https://pypi.python.org/pypi/%s/json" % (package_name,)
     data = json.load(request.urlopen(url))
-    versions = [v for v in data["releases"].keys() if not re.search('[a-z]',v)]
+    # filter out rc and b releases and, more in general, any realeses that do not contain exclusively numbers and dots.
+    versions = [v for v in data["releases"].keys() if re.match('[0-9\.]+$',v)]  
     versions.sort(key=StrictVersion)
-    return versions[-1]
+    return versions[-1]  # return latest version
 
 
 # Only detect TF if not installed or outdated. If not, do not do not list as

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from pkg_resources import parse_version
 from setuptools import find_packages, setup
+# for latest_version() [see https://github.com/GPflow/GPflow/issues/1348]:
 import json
 from urllib import request
 import re

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,13 @@ from setuptools import find_packages, setup
 
 is_py37 = sys.version_info.major == 3 and sys.version_info.minor == 7
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'  # copied from the docs
-
+gast_requirement = 'gast==0.2.2'
 # Dependencies of GPflow
 requirements = [
     'numpy>=1.10.0',
     'scipy>=0.18.0',
     'multipledispatch>=0.4.9',
-    'tabulate',
-    'gast==0.2.2',
+    'tabulate'
 ]
 
 if not is_py37:
@@ -47,6 +46,7 @@ except (ImportError, DeprecationWarning):
     if not on_rtd:
         # Do not add TF if we are installing GPflow on readthedocs
         requirements.append(tf_cpu)
+        requirements.append(gast_requirement)
 
 with open(str(Path(".", "VERSION").absolute())) as version_file:
     version = version_file.read().strip()

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ except (ImportError, DeprecationWarning):
     if not on_rtd:
         # Do not add TF if we are installing GPflow on readthedocs
         requirements.append(tf_cpu)
-        gast_requirement = 'gast>=0.2.2,<0.3' if parse_version(latest_version('tensorflow')) < parse_version('2.2') else 'gast>=0.3.3'
+        gast_requirement = 'gast>=0.2.2,<0.3' if latest_version('tensorflow') < parse_version('2.2') else 'gast>=0.3.3'
         requirements.append(gast_requirement)
         
 


### PR DESCRIPTION
Hi,

This could fix #1348 as:
- gast is only added as a requirement if tensorflow is not already installed;
- we read check what's the latest available version of tensorflow on pypi and pin a version of gast accordingly.

Make sense?

Best Regards,

Marco