### PR TITLE
fix Cosine kernel for multivariate inputs

### DIFF
--- a/doc/source/notebooks/tailor/kernel_design.pct.py
+++ b/doc/source/notebooks/tailor/kernel_design.pct.py
@@ -34,7 +34,7 @@ plt.style.use("ggplot")
 
 # %% [markdown]
 # To make this new kernel class, we inherit from the base class `gpflow.kernels.Kernel` and implement the three functions below. **NOTE:** Depending on the kernel to be implemented, other classes can be more adequate. For example, if the kernel to be implemented is isotropic stationary, you can immediately subclass `gpflow.kernels.IsotropicStationary` (at which point you
-# only have to override `K_r` or `K_r2`; see the `IsotropicStationary` class docstring). Anisotropic kernels should subclass `gpflow.kernels.AnisotropicStationary` and override `K_d`.
+# only have to override `K_r` or `K_r2`; see the `IsotropicStationary` class docstring). Stationary but anisotropic kernels should subclass `gpflow.kernels.AnisotropicStationary` and override `K_d`.
 #
 # #### `__init__`
 # In this simple example, the constructor takes no argument (though it could, if that was convenient, for example to pass in an initial value for `variance`). It *must* call the constructor of the superclass with appropriate arguments. Brownian motion is only defined in one dimension, and we'll assume that the `active_dims` are `[0]`, for simplicity.

--- a/doc/source/notebooks/tailor/kernel_design.pct.py
+++ b/doc/source/notebooks/tailor/kernel_design.pct.py
@@ -33,8 +33,8 @@ plt.style.use("ggplot")
 # %matplotlib inline
 
 # %% [markdown]
-# To make this new kernel class, we inherit from the base class `gpflow.kernels.Kernel` and implement the three functions below. **NOTE:** Depending on the kernel to be implemented, other classes can be more adequate. For example, if the kernel to be implemented is stationary, you can immediately subclass `gpflow.kernels.Stationary` (at which point you
-# only have to override `K_r` or `K_r2`; see the `Stationary` class docstring).
+# To make this new kernel class, we inherit from the base class `gpflow.kernels.Kernel` and implement the three functions below. **NOTE:** Depending on the kernel to be implemented, other classes can be more adequate. For example, if the kernel to be implemented is stationary, you can immediately subclass `gpflow.kernels.Stationary` (at which point you 
+# only have to override `K_r`, `K_r2`, or `K_d`; see the `Stationary` class docstring).
 #
 # #### `__init__`
 # In this simple example, the constructor takes no argument (though it could, if that was convenient, for example to pass in an initial value for `variance`). It *must* call the constructor of the superclass with appropriate arguments. Brownian motion is only defined in one dimension, and we'll assume that the `active_dims` are `[0]`, for simplicity.

--- a/doc/source/notebooks/tailor/kernel_design.pct.py
+++ b/doc/source/notebooks/tailor/kernel_design.pct.py
@@ -33,8 +33,8 @@ plt.style.use("ggplot")
 # %matplotlib inline
 
 # %% [markdown]
-# To make this new kernel class, we inherit from the base class `gpflow.kernels.Kernel` and implement the three functions below. **NOTE:** Depending on the kernel to be implemented, other classes can be more adequate. For example, if the kernel to be implemented is stationary, you can immediately subclass `gpflow.kernels.Stationary` (at which point you 
-# only have to override `K_r`, `K_r2`, or `K_d`; see the `Stationary` class docstring).
+# To make this new kernel class, we inherit from the base class `gpflow.kernels.Kernel` and implement the three functions below. **NOTE:** Depending on the kernel to be implemented, other classes can be more adequate. For example, if the kernel to be implemented is isotropic stationary, you can immediately subclass `gpflow.kernels.IsotropicStationary` (at which point you
+# only have to override `K_r` or `K_r2`; see the `IsotropicStationary` class docstring). Anisotropic kernels should subclass `gpflow.kernels.AnisotropicStationary` and override `K_d`.
 #
 # #### `__init__`
 # In this simple example, the constructor takes no argument (though it could, if that was convenient, for example to pass in an initial value for `variance`). It *must* call the constructor of the superclass with appropriate arguments. Brownian motion is only defined in one dimension, and we'll assume that the `active_dims` are `[0]`, for simplicity.

--- a/gpflow/kernels/__init__.py
+++ b/gpflow/kernels/__init__.py
@@ -21,6 +21,8 @@ from .stationaries import (
     Matern52,
     RationalQuadratic,
     Stationary,
+    IsotropicStationary,
+    AnisotropicStationary,
 )
 
 Bias = Constant

--- a/gpflow/kernels/periodic.py
+++ b/gpflow/kernels/periodic.py
@@ -5,7 +5,7 @@ import tensorflow as tf
 
 from ..base import Parameter
 from ..utilities import positive
-from ..utilities.ops import distance
+from ..utilities.ops import difference_matrix
 from .base import Kernel
 from .stationaries import Stationary, IsotropicStationary
 
@@ -66,7 +66,7 @@ class Periodic(Kernel):
         return self.base_kernel.K_diag(X)
 
     def K(self, X: tf.Tensor, X2: Optional[tf.Tensor] = None) -> tf.Tensor:
-        r = np.pi * (distance(X, X2)) / self.period
+        r = np.pi * (difference_matrix(X, X2)) / self.period
         scaled_sine = tf.sin(r) / self.base_kernel.lengthscales
         if isinstance(self.base_kernel, IsotropicStationary):
             if hasattr(self.base_kernel, "K_r"):

--- a/gpflow/kernels/stationaries.py
+++ b/gpflow/kernels/stationaries.py
@@ -194,7 +194,7 @@ class Cosine(Stationary):
     The Cosine kernel. Functions drawn from a GP with this kernel are sinusoids
     (with a random phase).  The kernel equation is
 
-        k(r) = σ² cos{d}
+        k(r) = σ² cos{2πd}
 
     where:
     d  is the sum of the per-dimension differences between the input points, scaled by the lengthscale parameter ℓ (i.e. Σ_i [(X - X2ᵀ) / ℓ]_i),
@@ -202,4 +202,4 @@ class Cosine(Stationary):
     """
 
     def K_d(self, d):
-        return self.variance * tf.cos(d)
+        return self.variance * tf.cos(2 * np.pi * d)

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -117,8 +117,8 @@ def difference_matrix(X, X2):
         X2 = X
         diff = X[..., :, tf.newaxis, :] - X2[..., tf.newaxis, :, :]
         return diff
-    Xshape = X.shape
-    X2shape = X2.shape
+    Xshape = tf.shape(X)
+    X2shape = tf.shape(X2)
     X = tf.reshape(X, (-1, Xshape[-1]))
     X2 = tf.reshape(X2, (-1, X2shape[-1]))
     diff = X[:, tf.newaxis, :] - X2[tf.newaxis, :, :]

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -103,6 +103,18 @@ def square_distance(X, X2):
     return dist
 
 
+def distance(X, X2):
+    """
+    Returns Σ_i (X - X2ᵀ)_i
+
+    This funciton can deal with leading dimensions in X and X2.
+    """
+    if X2 is None:
+        X2 = X
+    dist = X[..., :, tf.newaxis, :] - X2[..., tf.newaxis, :, :]
+    return tf.reduce_sum(dist, axis=-1)
+
+
 def pca_reduce(X: tf.Tensor, latent_dim: tf.Tensor) -> tf.Tensor:
     """
     A helpful function for linearly reducing the dimensionality of the input

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -103,15 +103,21 @@ def square_distance(X, X2):
     return dist
 
 
-def distance(X, X2):
+def difference_matrix(X, X2):
     """
     Returns (X - X2ᵀ)
 
     This function can deal with leading dimensions in X and X2.
+    If X has shape [..., N, D] and X2 has shape [..., M, D], the
+    output will have shape [..., N, M, D].
     """
     if X2 is None:
         X2 = X
-    return X[..., :, tf.newaxis, :] - X2[..., tf.newaxis, :, :]
+    diff = X[..., :, tf.newaxis, :] - X2[..., tf.newaxis, :, :]
+    tf.debugging.assert_shapes(
+        [(diff, [..., "M", "N", "D"]), (X, [..., "M", "D"]), (X2, [..., "N", "D"])]
+    )
+    return diff
 
 
 def pca_reduce(X: tf.Tensor, latent_dim: tf.Tensor) -> tf.Tensor:

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -107,7 +107,7 @@ def distance(X, X2):
     """
     Returns Σ_i (X - X2ᵀ)_i
 
-    This funciton can deal with leading dimensions in X and X2.
+    This function can deal with leading dimensions in X and X2.
     """
     if X2 is None:
         X2 = X

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -85,10 +85,10 @@ def square_distance(X, X2):
     result may actually be very slightly negative for entries very
     close to each other.
 
-    This function can deal with leading dimensions in X and X2. 
-    In the sample case, where X and X2 are both 2 dimensional, 
-    for example, X is [N, D] and X2 is [M, D], then a tensor of shape 
-    [N, M] is returned. If X is [N1, S1, D] and X2 is [N2, S2, D] 
+    This function can deal with leading dimensions in X and X2.
+    In the sample case, where X and X2 are both 2 dimensional,
+    for example, X is [N, D] and X2 is [M, D], then a tensor of shape
+    [N, M] is returned. If X is [N1, S1, D] and X2 is [N2, S2, D]
     then the output will be [N1, S1, N2, S2].
     """
     if X2 is None:
@@ -105,14 +105,13 @@ def square_distance(X, X2):
 
 def distance(X, X2):
     """
-    Returns Σ_i (X - X2ᵀ)_i
+    Returns (X - X2ᵀ)
 
     This function can deal with leading dimensions in X and X2.
     """
     if X2 is None:
         X2 = X
-    dist = X[..., :, tf.newaxis, :] - X2[..., tf.newaxis, :, :]
-    return tf.reduce_sum(dist, axis=-1)
+    return X[..., :, tf.newaxis, :] - X2[..., tf.newaxis, :, :]
 
 
 def pca_reduce(X: tf.Tensor, latent_dim: tf.Tensor) -> tf.Tensor:

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -111,7 +111,7 @@ def difference_matrix(X, X2):
     For example, If X has shape [M, D] and X2 has shape [N, D],
     the output will have shape [M, N, D]. If X has shape [I, J, M, D]
     and X2 has shape [K, L, N, D], the output will have shape
-    [I, J, M, K,L, N, D].
+    [I, J, M, K, L, N, D].
     """
     if X2 is None:
         X2 = X

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -108,15 +108,19 @@ def difference_matrix(X, X2):
     Returns (X - X2ᵀ)
 
     This function can deal with leading dimensions in X and X2.
-    If X has shape [..., N, D] and X2 has shape [..., M, D], the
-    output will have shape [..., N, M, D].
+    For example, If X has shape [M, D] and X2 has shape [N, D],
+    the output will have shape [N, M, D]. If X has shape [I, J, M, D]
+    and X2 has shape [K, L, N, D], the output will have shape
+    [I, J, M, K,L, N, D].
     """
     if X2 is None:
         X2 = X
-    diff = X[..., :, tf.newaxis, :] - X2[..., tf.newaxis, :, :]
-    tf.debugging.assert_shapes(
-        [(diff, [..., "M", "N", "D"]), (X, [..., "M", "D"]), (X2, [..., "N", "D"])]
-    )
+    Xshape = X.shape
+    X2shape = X2.shape
+    X = tf.reshape(X, (-1, Xshape[-1]))
+    X2 = tf.reshape(X2, (-1, X2shape[-1]))
+    diff = X[:, tf.newaxis, :] - X2[tf.newaxis, :, :]
+    diff = tf.reshape(diff, tf.concat((Xshape[:-1], X2shape[:-1], [Xshape[-1]]), 0))
     return diff
 
 

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -109,12 +109,14 @@ def difference_matrix(X, X2):
 
     This function can deal with leading dimensions in X and X2.
     For example, If X has shape [M, D] and X2 has shape [N, D],
-    the output will have shape [N, M, D]. If X has shape [I, J, M, D]
+    the output will have shape [M, N, D]. If X has shape [I, J, M, D]
     and X2 has shape [K, L, N, D], the output will have shape
     [I, J, M, K,L, N, D].
     """
     if X2 is None:
         X2 = X
+        diff = X[..., :, tf.newaxis, :] - X2[..., tf.newaxis, :, :]
+        return diff
     Xshape = X.shape
     X2shape = X2.shape
     X = tf.reshape(X, (-1, Xshape[-1]))

--- a/tests/gpflow/kernels/test_broadcasting.py
+++ b/tests/gpflow/kernels/test_broadcasting.py
@@ -92,14 +92,9 @@ def test_broadcast_no_active_dims(kernel_class):
 
 
 @pytest.mark.parametrize(
-    "base_class",
-    [
-        kernel
-        for kernel in gpflow.ci_utils.subclasses(kernels.Stationary)
-        if kernel not in (kernels.IsotropicStationary, kernels.AnisotropicStationary)
-    ],
+    "base_class", [kernel for kernel in gpflow.ci_utils.subclasses(kernels.IsotropicStationary)],
 )
-def test_broadcast_no_active_dims_periodc(base_class):
+def test_broadcast_no_active_dims_periodic(base_class):
     kernel = gpflow.kernels.Periodic(base_class())
     broadcast_no_no_active_dims(kernel)
 

--- a/tests/gpflow/kernels/test_broadcasting.py
+++ b/tests/gpflow/kernels/test_broadcasting.py
@@ -49,7 +49,7 @@ KERNEL_CLASSES = [
 ]
 
 
-def broadcast_no_no_active_dims(kernel):
+def check_broadcasting(kernel):
     S, N, M, D = 5, 4, 3, 2
     X1 = np.random.randn(S, N, D)
     X2 = np.random.randn(M, D)
@@ -74,13 +74,13 @@ def test_no_kernels_missed(kernel_class):
     ]
     needs_constructor_parameters = [kernels.Periodic]
     if kernel_class in tested_kernel_classes:
-        return  # tested
+        return  # tested by test_broadcast_no_active_dims
     if kernel_class in skipped_kernel_classes:
         return  # not tested but currently expected to fail
     if kernel_class in abstract_base_classes:
         return  # cannot test abstract base classes
     if kernel_class in needs_constructor_parameters:
-        return  # this has a separate test
+        return  # this has a separate test, see test_broadcast_no_active_dims_periodic
     if issubclass(kernel_class, kernels.MultioutputKernel):
         return  # TODO: cannot currently test MultioutputKernels - see https://github.com/GPflow/GPflow/issues/1339
     assert False, f"no broadcasting test for kernel class {kernel_class}"
@@ -88,7 +88,7 @@ def test_no_kernels_missed(kernel_class):
 
 @pytest.mark.parametrize("kernel_class", KERNEL_CLASSES)
 def test_broadcast_no_active_dims(kernel_class):
-    broadcast_no_no_active_dims(kernel_class())
+    check_broadcasting(kernel_class())
 
 
 @pytest.mark.parametrize(
@@ -96,7 +96,7 @@ def test_broadcast_no_active_dims(kernel_class):
 )
 def test_broadcast_no_active_dims_periodic(base_class):
     kernel = gpflow.kernels.Periodic(base_class())
-    broadcast_no_no_active_dims(kernel)
+    check_broadcasting(kernel)
 
 
 @pytest.mark.parametrize("kernel_class", [gpflow.kernels.SquaredExponential])

--- a/tests/gpflow/kernels/test_kernels.py
+++ b/tests/gpflow/kernels/test_kernels.py
@@ -172,7 +172,11 @@ def test_periodic_bad_ard_period():
         gpflow.kernels.Periodic(base_kernel, period=[1.0, 1.0, 1.0])
 
 
-kernel_setups = [kernel() for kernel in gpflow.kernels.Stationary.__subclasses__()] + [
+kernel_setups = [
+    kernel()
+    for stationary in gpflow.kernels.Stationary.__subclasses__()
+    for kernel in stationary.__subclasses__()
+] + [
     gpflow.kernels.Constant(),
     gpflow.kernels.Linear(),
     gpflow.kernels.Polynomial(),
@@ -297,11 +301,11 @@ def test_white(N, D):
     assert not np.allclose(Kff_sym, Kff_asym)
 
 
-_kernel_classes_slice = [kernel for kernel in gpflow.kernels.Stationary.__subclasses__()] + [
-    gpflow.kernels.Constant,
-    gpflow.kernels.Linear,
-    gpflow.kernels.Polynomial,
-]
+_kernel_classes_slice = [
+    kernel
+    for stationary in gpflow.kernels.Stationary.__subclasses__()
+    for kernel in stationary.__subclasses__()
+] + [gpflow.kernels.Constant, gpflow.kernels.Linear, gpflow.kernels.Polynomial,]
 
 _kernel_triples_slice = [
     (k1(active_dims=[0]), k2(active_dims=[1]), k3(active_dims=slice(0, 1)))

--- a/tests/gpflow/kernels/test_kernels.py
+++ b/tests/gpflow/kernels/test_kernels.py
@@ -173,7 +173,11 @@ def test_periodic_bad_ard_period():
         gpflow.kernels.Periodic(base_kernel, period=[1.0, 1.0, 1.0])
 
 
-kernel_setups = [kernel() for kernel in gpflow.ci_utils.subclasses(gpflow.kernels.Stationary)] + [
+kernel_setups = [
+    kernel()
+    for kernel in gpflow.ci_utils.subclasses(gpflow.kernels.Stationary)
+    if kernel not in (gpflow.kernels.IsotropicStationary, gpflow.kernels.AnisotropicStationary)
+] + [
     gpflow.kernels.Constant(),
     gpflow.kernels.Linear(),
     gpflow.kernels.Polynomial(),
@@ -299,7 +303,9 @@ def test_white(N, D):
 
 
 _kernel_classes_slice = [
-    kernel for kernel in gpflow.ci_utils.subclasses(gpflow.kernels.Stationary)
+    kernel
+    for kernel in gpflow.ci_utils.subclasses(gpflow.kernels.Stationary)
+    if kernel not in (gpflow.kernels.IsotropicStationary, gpflow.kernels.AnisotropicStationary)
 ] + [gpflow.kernels.Constant, gpflow.kernels.Linear, gpflow.kernels.Polynomial,]
 
 _kernel_triples_slice = [

--- a/tests/gpflow/kernels/test_kernels.py
+++ b/tests/gpflow/kernels/test_kernels.py
@@ -20,6 +20,7 @@ from numpy.testing import assert_allclose
 import gpflow
 from gpflow.config import default_float
 from gpflow.kernels import SquaredExponential, ArcCosine, Linear
+import gpflow.ci_utils
 from tests.gpflow.kernels.reference import (
     ref_rbf_kernel,
     ref_arccosine_kernel,
@@ -172,11 +173,7 @@ def test_periodic_bad_ard_period():
         gpflow.kernels.Periodic(base_kernel, period=[1.0, 1.0, 1.0])
 
 
-kernel_setups = [
-    kernel()
-    for stationary in gpflow.kernels.Stationary.__subclasses__()
-    for kernel in stationary.__subclasses__()
-] + [
+kernel_setups = [kernel() for kernel in gpflow.ci_utils.subclasses(gpflow.kernels.Stationary)] + [
     gpflow.kernels.Constant(),
     gpflow.kernels.Linear(),
     gpflow.kernels.Polynomial(),
@@ -302,9 +299,7 @@ def test_white(N, D):
 
 
 _kernel_classes_slice = [
-    kernel
-    for stationary in gpflow.kernels.Stationary.__subclasses__()
-    for kernel in stationary.__subclasses__()
+    kernel for kernel in gpflow.ci_utils.subclasses(gpflow.kernels.Stationary)
 ] + [gpflow.kernels.Constant, gpflow.kernels.Linear, gpflow.kernels.Polynomial,]
 
 _kernel_triples_slice = [

--- a/tests/gpflow/kernels/test_kernels.py
+++ b/tests/gpflow/kernels/test_kernels.py
@@ -161,7 +161,7 @@ def test_periodic_diag(base_class):
 
 
 def test_periodic_non_stationary_base_kernel():
-    error_msg = r"Periodic requires a Stationary kernel as the `base_kernel`"
+    error_msg = r"Periodic requires an IsotropicStationary kernel as the `base_kernel`"
     with pytest.raises(TypeError, match=error_msg):
         gpflow.kernels.Periodic(gpflow.kernels.Linear())
 

--- a/tests/gpflow/kernels/test_positive_semidefinite.py
+++ b/tests/gpflow/kernels/test_positive_semidefinite.py
@@ -1,0 +1,49 @@
+# Copyright 2018 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import tensorflow as tf
+from numpy.testing import assert_array_less
+
+from gpflow import kernels
+
+KERNEL_CLASSES = [
+    # Static
+    kernels.White,
+    kernels.Constant,
+    # Stationary
+    kernels.SquaredExponential,
+    kernels.RationalQuadratic,
+    kernels.Exponential,
+    kernels.Matern12,
+    kernels.Matern32,
+    kernels.Matern52,
+    kernels.Cosine,
+    kernels.Linear,
+    kernels.Polynomial,
+]
+
+rng = np.random.RandomState(42)
+
+
+@pytest.mark.parametrize("kernel", KERNEL_CLASSES)
+def test_positive_semidefinite(kernel):
+    N, D = 100, 5
+    X = rng.randn(N, D)
+    kern = kernel()
+
+    cov = kern(X)
+    eig = tf.linalg.eigvalsh(cov).numpy()
+    assert_array_less(-np.finfo(eig.dtype).eps * 1e4, eig)

--- a/tests/gpflow/utilities/test_utilities.py
+++ b/tests/gpflow/utilities/test_utilities.py
@@ -4,6 +4,7 @@ import tensorflow_probability as tfp
 
 from gpflow.config import Config, as_context
 from gpflow.utilities import positive, triangular
+from gpflow.utilities.ops import difference_matrix
 
 
 @pytest.mark.parametrize(
@@ -48,3 +49,16 @@ def test_positive_calculation_order():
 
 def test_triangular():
     assert isinstance(triangular(), tfp.bijectors.FillTriangular)
+
+
+def test_difference_matrix_broadcasting_symmetric():
+    X = np.random.randn(5, 4, 3, 2)
+    d = difference_matrix(X, None)
+    assert d.shape == (5, 4, 3, 3, 2)
+
+
+def test_difference_matrix_broadcasting_cross():
+    X = np.random.randn(2, 3, 4, 5)
+    X2 = np.random.randn(8, 7, 6, 5)
+    d = difference_matrix(X, X2)
+    assert d.shape == (2, 3, 4, 8, 7, 6, 5)


### PR DESCRIPTION
The previous version operating on euclidean distance was returning indefinite covariance matrices on multivariate data. This version, derived from eq. 4.7 of Wilson (2014), is always positive semidefinite.
Closes #1328.

This PR also changes the definition of the cosine kernel slightly, from sigma * cos((x - x') / l) to sigma * cos(2 * pi * (x - x') / l). This makes the lengthscale parameter directly interpretable as period length.