### PR TITLE
training_loss: one more iteration

### DIFF
--- a/gpflow/models/gpmc.py
+++ b/gpflow/models/gpmc.py
@@ -24,10 +24,10 @@ from ..kernels import Kernel
 from ..likelihoods import Likelihood
 from ..mean_functions import MeanFunction
 from ..utilities import to_default_float
-from .model import RegressionData, MeanAndVariance, GPModel
+from .model import RegressionData, MeanAndVariance, InternalDataGPModel
 
 
-class GPMC(GPModel):
+class GPMC(InternalDataGPModel):
     def __init__(
         self,
         data: RegressionData,
@@ -61,6 +61,9 @@ class GPMC(GPModel):
         self.V.prior = tfp.distributions.Normal(
             loc=to_default_float(0.0), scale=to_default_float(1.0)
         )
+
+    def training_loss(self) -> tf.Tensor:
+        return -self.log_posterior_density()
 
     def log_posterior_density(self) -> tf.Tensor:
         return self.log_likelihood() + self.log_prior_density()

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -80,9 +80,19 @@ class BayesianModel(Module, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
 
+class InternalDataBayesianModel(BayesianModel, ExternalDataTrainingInterface):
+    """
+    Base class for models that encapsulate their data and store it as
+    self.data; training_loss does not take any arguments.
+    """
+
+    def training_loss(self):
+        return -self.maximum_a_posteriori_objective()
+
+
 class ExternalDataBayesianModel(BayesianModel, ExternalDataTrainingInterface):
     """
-    Base class for GP models that do not encapsulate the data; training_loss takes
+    Base class for models that do not encapsulate the data; training_loss takes
     data as argument.
     """
 
@@ -249,21 +259,15 @@ class GPModel(BayesianModel):
         return self.likelihood.predict_density(f_mean, f_var, Y)
 
 
-class InternalDataGPModel(GPModel, InternalDataTrainingInterface):
+class InternalDataGPModel(GPModel, InternalDataBayesianModel):
     """
-    Base class for models that encapsulate their data and store it as
+    Base class for GP models that encapsulate their data and store it as
     self.data; training_loss does not take any arguments.
     """
 
-    def training_loss(self):
-        return -self.maximum_a_posteriori_objective()
 
-
-class ExternalDataGPModel(GPModel, ExternalDataTrainingInterface):
+class ExternalDataGPModel(GPModel, ExternalDataBayesianModel):
     """
     Base class for GP models that do not encapsulate the data; training_loss takes
     data as argument.
     """
-
-    def training_loss(self, data):
-        return -self.maximum_a_posteriori_objective(data)

--- a/gpflow/models/sgpmc.py
+++ b/gpflow/models/sgpmc.py
@@ -24,11 +24,11 @@ from ..kernels import Kernel
 from ..likelihoods import Likelihood
 from ..mean_functions import MeanFunction
 from ..utilities import to_default_float
-from .model import RegressionData, MeanAndVariance, GPModel
+from .model import RegressionData, MeanAndVariance, InternalDataGPModel
 from .util import inducingpoint_wrapper
 
 
-class SGPMC(GPModel):
+class SGPMC(InternalDataGPModel):
     r"""
     This is the Sparse Variational GP using MCMC (SGPMC). The key reference is
 
@@ -85,6 +85,9 @@ class SGPMC(GPModel):
         self.V.prior = tfp.distributions.Normal(
             loc=to_default_float(0.0), scale=to_default_float(1.0)
         )
+
+    def training_loss(self) -> tf.Tensor:
+        return -self.log_posterior_density()
 
     def log_posterior_density(self) -> tf.Tensor:
         return self.log_conditional_likelihood_lower_bound() + self.log_prior_density()

--- a/gpflow/models/training_interface.py
+++ b/gpflow/models/training_interface.py
@@ -12,7 +12,8 @@ RegressionData = Tuple[InputData, OutputData]
 Data = TypeVar("Data", RegressionData, InputData)
 
 
-class InternalDataTrainingInterface:
+class InternalDataTrainingInterface(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
     def training_loss(self):
         """
         Specify a training loss for this model
@@ -26,6 +27,7 @@ class InternalDataTrainingInterface:
 
 
 class ExternalDataTrainingInterface:
+    @abc.abstractmethod
     def training_loss(self, data):
         """
         Specify a training loss for this model


### PR DESCRIPTION
Based off #1352 (eric/training-loss-proposal). This contains the changes I would make to @condnsdmatters's proposal such that I'd be happy to merge it in.

The key change from #1352 / eric/training-loss-proposal is that InternalDataGPModel and ExternalDataGPModel inherit from InternalDataBayesianModel and ExternalDataBayesianModel, respectively, instead of re-defining `training_loss`.

This introduces a diamond inheritance structure in amongst these base classes (as InternalDataGPModel and ExternalDataGPModel also inherit from GPModel, which in turn inherits from BayesianModel - just as Internal- and ExternalDataBayesianModel do); I believe this does not pose any issues as there are no shared methods between GPModel (`__init__`, predict_* methods) and Internal/ExternalDataBayesianModel (`training_loss`), so we don't have to worry about super() going sideways etc.