### PR TITLE
Added references to the recently released multioutput paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ GPflow leaves installing tensorflow to the user so that you can choose whether y
 
 There is an ["Intro to GPflow 2.0"](https://github.com/GPflow/GPflow/blob/develop/doc/source/notebooks/intro_to_gpflow2.ipynb) Jupyter notebook; check it out for details. To convert your code from GPflow 1 check the [GPflow 2 upgrade guide](https://github.com/GPflow/GPflow/blob/develop/doc/source/notebooks/gpflow_2_upgrade/gpflow2_upgrade_guide.ipynb).
 
+
+
 - **GPflow 1.0**
 
   *We have stopped development and support for GPflow based on TensorFlow 1.0. We now accept only bug fixes to GPflow 1.0 in the **develop-1.0** branch. The latest available release is [v1.5.1](https://github.com/GPflow/GPflow/releases/tag/v1.5.1). [Documentation](https://gpflow.readthedocs.io/en/v1.5.1-docs/) and [tutorials](https://nbviewer.jupyter.org/github/GPflow/GPflow/blob/develop/doc/source/notebooks/intro.ipynb) will remain available.*
@@ -128,7 +130,7 @@ To cite GPflow, please reference the [JMLR paper](http://www.jmlr.org/papers/vol
 
 ```
 @ARTICLE{GPflow2017,
-   author = {Matthews, Alexander G. de G. and {van der Wilk}, Mark and Nickson, Tom and
+  author = {Matthews, Alexander G. de G. and {van der Wilk}, Mark and Nickson, Tom and
 	Fujii, Keisuke. and {Boukouvalas}, Alexis and {Le{\'o}n-Villagr{\'a}}, Pablo and
 	Ghahramani, Zoubin and Hensman, James},
     title = "{{GP}flow: A {G}aussian process library using {T}ensor{F}low}",
@@ -139,5 +141,21 @@ To cite GPflow, please reference the [JMLR paper](http://www.jmlr.org/papers/vol
   number  = {40},
   pages   = {1-6},
   url     = {http://jmlr.org/papers/v18/16-537.html}
+}
+```
+
+Since the publication of the GPflow paper, the software has been significantly extended
+with the framework for interdomain approximations and multiouput priors. We review the
+framework and describe the design in an [arXiv paper](https://arxiv.org/abs/2003.01115),
+which can be cited by users.
+
+```
+@article{GPflow2020multioutput,
+  author = {{van der Wilk}, Mark and Dutordoir, Vincent and John, ST and
+            Artemev, Artem and Adam, Vincent and Hensman, James},
+  title = {A Framework for Interdomain and Multioutput {G}aussian Processes},
+  year = {2020},
+  journal = {arXiv:2003.01115},
+  url = {https://arxiv.org/abs/2003.01115}
 }
 ```

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -39,7 +39,7 @@ GPflow has a slew of kernels that can be combined in a straightforward way. See 
 
 Regression
 """"""""""
-For GP regression with Gaussian noise, it's possible to marginalize the function values exactly: you'll find this in `gpflow.models.GPR`. You can do maximum likelihood or MCMC for the covariance function parameters  (`notebook <notebooks/regression.html>`_).
+For GP regression with Gaussian noise, it's possible to marginalize the function values exactly: you'll find this in `gpflow.models.GPR`. You can do maximum likelihood or MCMC for the covariance function parameters  (`notebook <notebooks/basics/regression.html>`_).
 
 It's also possible to do Sparse GP regression using the :class:`gpflow.models.SGPR` class. This is based on work by `Michalis Titsias <http://www.jmlr.org/proceedings/papers/v5/titsias09a.html>`_ [4].
 
@@ -64,10 +64,20 @@ The following table summarizes the model options in GPflow.
 
 A unified view of many of the relevant references, along with some extensions, and an early discussion of GPflow itself, is given in the PhD thesis of `Matthews <http://mlg.eng.cam.ac.uk/matthews/thesis.pdf>`_ [8].
 
+Interdomain inference and multioutput GPs
+"""""""""""""""""""""""""""""""""""""""""
+GPflow has an extensive and flexible framework for specifying interdomain inducing variables for variational approximations.
+Interdomain variables can greatly improve the effectiveness of a variational approximation, and are used in e.g.
+`convolutional GPs <notebooks/advanced/convolutional.html>`_. In particular, they are crucial for defining sensible sparse
+approximations for `multioutput GPs <notebooks/advanced/multioutput.html>`_.
+
+GPflow has a unifying design for using multitoutput GPs and specifying interdomain approximations. A review of the
+mathematical background and the resulting software design is described in a paper on `arxiv <https://arxiv.org/abs/2003.01115>`_ [9].
+
 GPLVM
 """""
 For visualisation, the GPLVM [6] and Bayesian GPLVM [7] models are implemented
-in GPflow (`notebook <notebooks/GPLVM.html>`_).
+in GPflow (`notebook <notebooks/advanced/GPLVM.html>`_).
 
 Contributing
 ------------
@@ -91,6 +101,24 @@ To cite GPflow, please reference the `JMLR paper <http://www.jmlr.org/papers/vol
         pages   = {1-6},
         url     = {http://jmlr.org/papers/v18/16-537.html}
     }
+
+Since the publication of the GPflow paper, the software has been significantly extended
+with the framework for interdomain approximations and multiouput priors. We review the
+framework and describe the design in an `arXiv paper <https://arxiv.org/abs/2003.01115>`_
+which can be cited by users.
+
+.. code-block:: bst
+
+    @article{GPflow2020multioutput,
+      author = {{van der Wilk}, Mark and Dutordoir, Vincent and John, ST and
+                Artemev, Artem and Adam, Vincent and Hensman, James},
+      title = {A Framework for Interdomain and Multioutput {G}aussian Processes},
+      year = {2020},
+      journal = {arXiv:2003.01115},
+      url = {https://arxiv.org/abs/2003.01115}
+    }
+
+
 
 
 References
@@ -126,6 +154,10 @@ Proceedings of AISTATS, 2010.
 [8] Scalable Gaussian process inference using variational methods.
 Alexander G. de G. Matthews.
 PhD Thesis. University of Cambridge, 2016.
+
+[9] A Framework for Interdomain and Multioutput Gaussian Processes.
+Mark van der Wilk, Vincent Dutordoir, ST John, Artem Artemev, Vincent Adam, James Hensman.
+arXiv. 2020.
 
 
 Acknowledgements

--- a/doc/source/notebooks/advanced/multioutput.pct.py
+++ b/doc/source/notebooks/advanced/multioutput.pct.py
@@ -7,7 +7,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.3.3
+#       jupytext_version: 1.4.1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -18,7 +18,31 @@
 # # Multi-output Gaussian processes in GPflow
 
 # %% [markdown]
-# This notebook shows how to construct a multi-output GP model using GPflow. We will consider a regression problem for functions $f: \mathbb{R}^D \rightarrow \mathbb{R}^P$. We assume that the dataset is of the form $(X, f_1), \dots, (X, f_P)$, that is, we observe all the outputs for a particular input location (for cases where there are **not** fully observed outputs for each input, see [A simple demonstration of coregionalization](./coregionalisation.ipynb)).
+# This notebook shows how to construct a multi-output GP model using GPflow, together with different interdomain inducing variables which lead to different approximation properties. GPflow provides a framework for specifying multioutput GP priors, and interdomain approximations which is
+# - modular, by providing a consistent interface for the user of the resulting `SVGP` model,
+# - extensible, by allowing new interdomain variables and kernels to be specified while reusing exising code where possible,
+# - efficient, by allowing the most efficient custom code path to be specified where desired.
+#
+# Getting to grips with the maths and code can be a bit daunting, so to accompany the documentation there is an in-depth review on [arXiv](https://arxiv.org/abs/2003.01115), which provides a unified mathematical framework, together with a high-level description of software design choices in GPflow.
+#
+# This notebook shows the various design choices that can be made, to show the reader the flexibility of the framework. This is done in the hope that an example is provided that can be easily adapted to the special case that the reader wants to implement.
+#
+# A reader who just wants to use a multioutput kernel should simply choose the most efficient set of inducing variables.
+#
+# To cite this framework, please reference our [arXiv](https://arxiv.org/abs/2003.01115) paper.
+# ```
+# @article{GPflow2020multioutput,
+#   author = {{van der Wilk}, Mark and Dutordoir, Vincent and John, ST and
+#             Artemev, Artem and Adam, Vincent and Hensman, James},
+#   title = {A Framework for Interdomain and Multioutput {G}aussian Processes},
+#   year = {2020},
+#   journal = {arXiv:2003.01115},
+#   url = {https://arxiv.org/abs/2003.01115}
+# }
+# ```
+#
+# ## Task
+# We will consider a regression problem for functions $f: \mathbb{R}^D \rightarrow \mathbb{R}^P$. We assume that the dataset is of the form $(X, f_1), \dots, (X, f_P)$, that is, we observe all the outputs for a particular input location (for cases where there are **not** fully observed outputs for each input, see [A simple demonstration of coregionalization](./coregionalisation.ipynb)).
 #
 # Here we assume a model of the form:
 # $$f(x) = W g(x),$$
@@ -395,3 +419,5 @@ inspect_conditional(
 # %% [markdown]
 # ## Further Reading:
 # - [A simple demonstration of coregionalization](./coregionalisation.ipynb), which details other GPflow features for multi-output prediction without fully observed outputs.
+
+# %%

--- a/doc/source/notebooks/advanced/multioutput.pct.py
+++ b/doc/source/notebooks/advanced/multioutput.pct.py
@@ -41,24 +41,7 @@
 # }
 # ```
 #
-# ## Task
-# We will consider a regression problem for functions $f: \mathbb{R}^D \rightarrow \mathbb{R}^P$. We assume that the dataset is of the form $(X, f_1), \dots, (X, f_P)$, that is, we observe all the outputs for a particular input location (for cases where there are **not** fully observed outputs for each input, see [A simple demonstration of coregionalization](./coregionalisation.ipynb)).
-#
-# Here we assume a model of the form:
-# $$f(x) = W g(x),$$
-# where $g(x) \in \mathbb{R}^L$, $f(x) \in \mathbb{R}^P$ and $W \in \mathbb{R}^{P \times L}$. We assume that the outputs of $g$ are uncorrelated, and that by *mixing* them with $W$ they become correlated. In this notebook, we show how to build this model using Sparse Variational Gaussian Process (SVGP) for $g$, which scales well with the numbers of data points and outputs.
-#
-# Here we have two options for $g$:
-# 1. The output dimensions of $g$ share the same kernel.
-# 2. Each output of $g$ has a separate kernel.
-#
-#
-# In addition, we have two further suboptions for the inducing inputs of $g$:
-# 1. The instances of $g$ share the same inducing inputs.
-# 2. Each output of $g$ has its own set of inducing inputs.
-#
-# The notation is as follows:
-# $$
+# \begin{equation}
 # \newcommand{\GP}{\mathcal{GP}}
 # \newcommand{\NN}{\mathcal{N}}
 # \newcommand{\LL}{\mathcal{L}}
@@ -76,7 +59,29 @@
 # \newcommand{\vX}{\mathbf{X}}
 # \newcommand{\vY}{\mathbf{Y}}
 # \newcommand{\identity}{\mathbb{I}}
-# $$
+# \end{equation}
+#
+#
+#
+# ## Task
+# We will consider a regression problem for functions $f: \mathbb{R}^D \rightarrow \mathbb{R}^P$. We assume that the dataset is of the form $(X, f_1), \dots, (X, f_P)$, that is, we observe all the outputs for a particular input location (for cases where there are **not** fully observed outputs for each input, see [A simple demonstration of coregionalization](./coregionalisation.ipynb)).
+#
+# Here we assume a model of the form:
+# \begin{equation}
+# f(x) = W g(x),
+# \end{equation}
+# where $g(x) \in \mathbb{R}^L$, $f(x) \in \mathbb{R}^P$ and $W \in \mathbb{R}^{P \times L}$. We assume that the outputs of $g$ are uncorrelated, and that by *mixing* them with $W$ they become correlated. In this notebook, we show how to build this model using Sparse Variational Gaussian Process (SVGP) for $g$, which scales well with the numbers of data points and outputs.
+#
+# Here we have two options for $g$:
+# 1. The output dimensions of $g$ share the same kernel.
+# 1. Each output of $g$ has a separate kernel.
+#
+#
+# In addition, we have two further suboptions for the inducing inputs of $g$:
+# 1. The instances of $g$ share the same inducing inputs.
+# 1. Each output of $g$ has its own set of inducing inputs.
+#
+# The notation is as follows:
 # - $X \in \mathbb{R}^{N \times D}$ denotes the input
 # - $Y \in \RR^{N \times P}$ denotes the output
 # - $k_{1..L}$, $L$ are kernels on $\RR^{N \times D}$
@@ -152,9 +157,9 @@ def plot_model(m, lower=-8.0, upper=8.0):
 # %% [markdown]
 # ## Model the outputs of $f(x)$ directly
 # The three following examples show how to model the outputs of the model $f(x)$ directly. Mathematically, this case is equivalent to having:
-# $$
+# \begin{equation}
 # f(x) = I g(x),
-# $$
+# \end{equation}
 # i.e. $W = I$ and $P = L$.
 
 # %% [markdown]
@@ -292,8 +297,8 @@ m.inducing_variable.inducing_variable_list
 # We assume that the outputs of $g$ are uncorrelated, and by *mixing* them with $W$ they become correlated.
 # With this setup we perform the optimal routine to calculate the conditional. Namely, calculate the conditional of the uncorrelated latent $g$ and afterwards project the mean and variance using the mixing matrix: $\mu_f = W \mu_g$ and $\Sigma_f = W\Sigma_g W^\top$
 #
-# - $ K_{uu} = L \times M \times M $
-# - $ K_{uf} = L \times M \times N $
+# - $K_{uu} = L \times M \times M$
+# - $K_{uf} = L \times M \times N$
 
 # %%
 # Create list of kernels for each output


### PR DESCRIPTION
Added some references to the recently released multioutput paper.

I also fixed some broken links in `intro.rst`.

Also, the maths in the multioutput notebook is broken in the docs, but it renders fine in the notebook. Does anyone have an idea why this could happen?