### PR TITLE
Make Scipy more robust & faster

### DIFF
--- a/doc/source/notebooks/advanced/gps_for_big_data.pct.py
+++ b/doc/source/notebooks/advanced/gps_for_big_data.pct.py
@@ -189,7 +189,7 @@ def optimization_step(optimizer, model: gpflow.models.SVGP, batch):
     with tf.GradientTape(watch_accessed_variables=False) as tape:
         tape.watch(model.trainable_variables)
         objective = -model.elbo(batch)
-        grads = tape.gradient(objective, model.trainable_variables)
+    grads = tape.gradient(objective, model.trainable_variables)
     optimizer.apply_gradients(zip(grads, model.trainable_variables))
     return objective
 

--- a/doc/source/notebooks/intro_to_gpflow2.pct.py
+++ b/doc/source/notebooks/intro_to_gpflow2.pct.py
@@ -181,10 +181,10 @@ model
 # %%
 optimizer = tf.optimizers.Adam()
 
-with tf.GradientTape() as tape:
+with tf.GradientTape(watch_accessed_variables=False) as tape:
     tape.watch(model.trainable_variables)
     obj = -model.elbo(data)
-    grads = tape.gradient(obj, model.trainable_variables)
+grads = tape.gradient(obj, model.trainable_variables)
 
 optimizer.apply_gradients(zip(grads, model.trainable_variables))
 
@@ -197,7 +197,7 @@ def optimization_step(model: gpflow.models.SVGP, batch: Tuple[tf.Tensor, tf.Tens
     with tf.GradientTape(watch_accessed_variables=False) as tape:
         tape.watch(model.trainable_variables)
         obj = -model.elbo(batch)
-        grads = tape.gradient(obj, model.trainable_variables)
+    grads = tape.gradient(obj, model.trainable_variables)
     optimizer.apply_gradients(zip(grads, model.trainable_variables))
 
 

--- a/doc/source/notebooks/tailor/external-mean-function.pct.py
+++ b/doc/source/notebooks/tailor/external-mean-function.pct.py
@@ -140,7 +140,7 @@ def create_optimization_step(optimizer, model: gpflow.models.GPR):
         with tf.GradientTape(watch_accessed_variables=False) as tape:
             tape.watch(model.trainable_variables)
             objective = -model.log_marginal_likelihood()
-            grads = tape.gradient(objective, model.trainable_variables)
+        grads = tape.gradient(objective, model.trainable_variables)
         optimizer.apply_gradients(zip(grads, model.trainable_variables))
         return objective
 

--- a/doc/source/notebooks/tailor/mixture_density_network.pct.py
+++ b/doc/source/notebooks/tailor/mixture_density_network.pct.py
@@ -182,7 +182,7 @@ from gpflow.ci_utils import ci_niter
 
 Scipy().minimize(
     tf.function(lambda: -model.log_marginal_likelihood(data)),
-    variables=model.trainable_parameters,
+    variables=model.trainable_variables,
     options=dict(maxiter=ci_niter(1500)),
 )
 
@@ -234,7 +234,7 @@ model = MDN(inner_dims=[100, 100], num_mixtures=5)
 # %%
 Scipy().minimize(
     tf.function(lambda: -model.log_marginal_likelihood(data)),
-    variables=model.trainable_parameters,
+    variables=model.trainable_variables,
     options=dict(maxiter=ci_niter(int(10e3))),
 )
 

--- a/doc/source/notebooks/tailor/mixture_density_network.pct.py
+++ b/doc/source/notebooks/tailor/mixture_density_network.pct.py
@@ -182,7 +182,7 @@ from gpflow.ci_utils import ci_niter
 
 Scipy().minimize(
     tf.function(lambda: -model.log_marginal_likelihood(data)),
-    variables=model.trainable_variables,
+    model.trainable_variables,
     options=dict(maxiter=ci_niter(1500)),
 )
 
@@ -234,7 +234,7 @@ model = MDN(inner_dims=[100, 100], num_mixtures=5)
 # %%
 Scipy().minimize(
     tf.function(lambda: -model.log_marginal_likelihood(data)),
-    variables=model.trainable_variables,
+    model.trainable_variables,
     options=dict(maxiter=ci_niter(int(10e3))),
 )
 

--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -162,7 +162,7 @@ class NaturalGradient(tf.optimizers.Optimizer):
                         [xi1_nat, xi2_nat], [nat1, nat2], output_gradients=dummy_tensors
                     )
 
-        # 1) the oridinary gpflow gradient
+        # 1) the ordinary gpflow gradient
         dL_dmean, dL_dvarsqrt = tape.gradient(loss, [q_mu, q_sqrt])
         dL_dvarsqrt = q_sqrt.transform.forward(dL_dvarsqrt)
 
@@ -178,7 +178,7 @@ class NaturalGradient(tf.optimizers.Optimizer):
         else:
             nat_dL_xi1, nat_dL_xi2 = dL_deta1, dL_deta2
 
-        del tape  # Remove "persitent" tape
+        del tape  # Remove "persistent" tape
 
         xi1, xi2 = xi_transform.meanvarsqrt_to_xi(q_mu, q_sqrt)
         xi1_new = xi1 - self.gamma * nat_dL_xi1

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -52,8 +52,10 @@ class Scipy:
             object. See the Scipy documentation for description of attributes.
         """
         if not callable(closure):
-            raise TypeError("Callable object expected.")  # pragma: no cover
+            raise TypeError("`closure` is expected to be a callable object.")  # pragma: no cover
         variables = tuple(variables)
+        if not all(isinstance(v, tf.Variable) for v in variables):
+            raise TypeError("`variables` is expected to only contain tf.Variable instances (use model.trainable_variables, not model.trainable_parameters)")
         initial_params = self.initial_parameters(variables)
 
         func = self.eval_func(closure, variables, jit=jit)

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -55,7 +55,9 @@ class Scipy:
             raise TypeError("`closure` is expected to be a callable object.")  # pragma: no cover
         variables = tuple(variables)
         if not all(isinstance(v, tf.Variable) for v in variables):
-            raise TypeError("`variables` is expected to only contain tf.Variable instances (use model.trainable_variables, not model.trainable_parameters)")
+            raise TypeError(
+                "`variables` is expected to only contain tf.Variable instances (use model.trainable_variables, not model.trainable_parameters)"
+            )
         initial_params = self.initial_parameters(variables)
 
         func = self.eval_func(closure, variables, jit=jit)

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -52,12 +52,12 @@ class Scipy:
             object. See the Scipy documentation for description of attributes.
         """
         if not callable(closure):
-            raise TypeError("`closure` is expected to be a callable object.")  # pragma: no cover
+            raise TypeError("The 'closure' argument is expected to be a callable object.")  # pragma: no cover
         variables = tuple(variables)
         if not all(isinstance(v, tf.Variable) for v in variables):
             raise TypeError(
-                "`variables` is expected to only contain tf.Variable instances (use model.trainable_variables, not model.trainable_parameters)"
-            )
+                "The 'variables' argument is expected to only contain tf.Variable instances (use model.trainable_variables, not model.trainable_parameters)"
+            )  # pragma: no cover
         initial_params = self.initial_parameters(variables)
 
         func = self.eval_func(closure, variables, jit=jit)

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -142,5 +142,5 @@ def _compute_loss_and_gradients(loss_closure: LossClosure, variables: V) -> Tupl
     with tf.GradientTape(watch_accessed_variables=False) as tape:
         tape.watch(variables)
         loss = loss_closure()
-        grads = tape.gradient(loss, variables)
+    grads = tape.gradient(loss, variables)
     return loss, grads

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -52,7 +52,9 @@ class Scipy:
             object. See the Scipy documentation for description of attributes.
         """
         if not callable(closure):
-            raise TypeError("The 'closure' argument is expected to be a callable object.")  # pragma: no cover
+            raise TypeError(
+                "The 'closure' argument is expected to be a callable object."
+            )  # pragma: no cover
         variables = tuple(variables)
         if not all(isinstance(v, tf.Variable) for v in variables):
             raise TypeError(

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -134,8 +134,9 @@ class Scipy:
 V = TypeVar("V", bound=Variables)
 
 
-def _compute_loss_and_gradients(loss_cb: LossClosure, variables: V) -> Tuple[tf.Tensor, V]:
-    with tf.GradientTape() as tape:
-        loss = loss_cb()
-    grads = tape.gradient(loss, variables)
+def _compute_loss_and_gradients(loss_closure: LossClosure, variables: V) -> Tuple[tf.Tensor, V]:
+    with tf.GradientTape(watch_accessed_variables=False) as tape:
+        tape.watch(variables)
+        loss = loss_closure()
+        grads = tape.gradient(loss, variables)
     return loss, grads

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -98,7 +98,7 @@ def parameter_dict(module: tf.Module) -> Dict[str, Union[Parameter, tf.Variable]
 
 
 def training_loop(
-    closure: Callable[..., tf.Tensor],
+    closure: Callable[[], tf.Tensor],
     optimizer: Optional[tf.optimizers.Optimizer] = None,
     var_list: List[tf.Variable] = None,
     maxiter=1e3,
@@ -119,7 +119,7 @@ def training_loop(
     optimizer = tf.optimizers.Adam() if optimizer is None else optimizer
 
     def optimization_step():
-        with tf.GradientTape() as tape:
+        with tf.GradientTape(watch_accessed_variables=False) as tape:
             tape.watch(var_list)
             loss = closure()
         grads = tape.gradient(loss, var_list)

--- a/tests/gpflow/expectations/test_expectations.py
+++ b/tests/gpflow/expectations/test_expectations.py
@@ -214,8 +214,8 @@ def test_RBF_eKzxKxz_gradient_notNaN():
 
     with tf.GradientTape() as tape:
         ekz = expectation(p, (kernel, z), (kernel, z))
-        grad = tape.gradient(ekz, kernel.lengthscales)
-        assert grad is not None and not np.isnan(grad)
+    grad = tape.gradient(ekz, kernel.lengthscales)
+    assert grad is not None and not np.isnan(grad)
 
 
 @pytest.mark.parametrize("distribution", distrs("gauss_diag"))

--- a/tests/gpflow/kernels/test_scaled_euclid_dist.py
+++ b/tests/gpflow/kernels/test_scaled_euclid_dist.py
@@ -50,7 +50,7 @@ def test_kernel_euclidean_distance(kernel):
     X_as_param = tf.Variable(Datum.X)
     with tf.GradientTape() as tape:
         K_value = kernel(X_as_param, X_as_param)
-        dK = tape.gradient(K_value, X_as_param)[0]
+    dK = tape.gradient(K_value, X_as_param)[0]
 
     assert not np.isnan(dK).any(), "NaNs in the gradient of the " + kernel.__name__ + " kernel."
     assert np.isfinite(dK).all(), "Infs in the output of the " + kernel.__name__ + " kernel."

--- a/tests/gpflow/models/test_svgp.py
+++ b/tests/gpflow/models/test_svgp.py
@@ -177,7 +177,7 @@ def test_stochastic_gradients(indices_1, indices_2, num_data1, num_data2, max_it
         for _ in range(max_iter):
             with tf.GradientTape() as tape:
                 loss = model.log_likelihood(data)
-                grads = tape.gradient(loss, model.trainable_variables)
+            grads = tape.gradient(loss, model.trainable_variables)
             opt.apply_gradients(zip(grads, model.trainable_variables))
         return model
 


### PR DESCRIPTION
* Adds an explicit check to Scipy() that all elements of `variables` are actually tf.Variable instances (unconstrained variables) - accidentally passing `model.trainable_parameters` may work but give the wrong answers for parameters with transforms! Passing `model.trainable_variables` is the right thing to do.
* Updates _compute_loss_and_gradients to only compute gradients wrt passed-in variables.
* Fix mixture density network notebook, which had erroneously passed model.trainable_parameters instead of model.trainable_variables.