### PR TITLE
minimum required multipledispatch version is 0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import find_packages, setup
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"  # copied from the docs
 
 # Dependencies of GPflow
-requirements = ["numpy>=1.10.0", "scipy>=0.18.0", "multipledispatch>=0.4.9", "tabulate"]
+requirements = ["numpy>=1.10.0", "scipy>=0.18.0", "multipledispatch>=0.6", "tabulate"]
 
 if sys.version_info < (3, 7):
     # became part of stdlib in python 3.7


### PR DESCRIPTION
As shown by #1381, gpflow does not work with older versions of multipledispatch - this change reflects this in the setup.py version requirements.