### PR TITLE
Set kernelspec to Py3 in monitoring.pct.py

### DIFF
--- a/doc/source/notebooks/basics/monitoring.pct.py
+++ b/doc/source/notebooks/basics/monitoring.pct.py
@@ -8,8 +8,9 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.4.0
 #   kernelspec:
-#     display_name: 'Python 3.7.4 64-bit (''gpflow2'': conda)'
-#     name: python37464bitgpflow2conda97d7f93b14fc49f496551bb0d0f2e18e
+#     display_name: Python 3
+#     language: python
+#     name: python3
 # ---
 
 # %% [markdown]


### PR DESCRIPTION
Quickfix for the failing `monitoring.pct.py` notebook during the doc generation on [CircleCi](https://app.circleci.com/pipelines/github/GPflow/docs/147/workflows/92eaf3db-a089-462d-adcc-53121f12bf02/jobs/151). 

Problem was caused by an unknown Python version in the notebook's `kernelspec`. 