### PR TITLE
Increased tolerance for sqrt in kernels K_r2.

### DIFF
--- a/gpflow/kernels/stationaries.py
+++ b/gpflow/kernels/stationaries.py
@@ -77,7 +77,7 @@ class IsotropicStationary(Stationary):
     def K_r2(self, r2):
         if hasattr(self, "K_r"):
             # Clipping around the (single) float precision which is ~1e-45.
-            r = tf.sqrt(tf.maximum(r2, 1e-40))
+            r = tf.sqrt(tf.maximum(r2, 1e-36))
             return self.K_r(r)  # pylint: disable=no-member
         raise NotImplementedError
 


### PR DESCRIPTION
I remember once I ran into numerical problems when the tolerance was 1e-40. So I changed it to 1e-36. This change was in GPflow 1, but wasn't ported to GPflow 2, hence why we're fixing it now.