### PR TITLE
_scalar_log_density -> _scalar_log_prob

### DIFF
--- a/gpflow/likelihoods/likelihoods.py
+++ b/gpflow/likelihoods/likelihoods.py
@@ -365,12 +365,7 @@ class ScalarLikelihood(Likelihood):
         """
         return tf.reduce_sum(
             ndiagquad(
-                self._scalar_log_prob,
-                self.num_gauss_hermite_points,
-                Fmu,
-                Fvar,
-                logspace=True,
-                Y=Y,
+                self._scalar_log_prob, self.num_gauss_hermite_points, Fmu, Fvar, logspace=True, Y=Y,
             ),
             axis=-1,
         )


### PR DESCRIPTION
In GPflow2, the log probability density itself (summed over multiple outputs, if applicable) was called `log_prob` to be consistent with tensorflow_probability.
In #1334 the element-wise log probability density to be implemented by ScalarLikelihood subclasses was called `_scalar_log_density`.
This PR renames the latter to `_scalar_log_prob` to make it more self-consistent.