### PR TITLE
Fix mypy errors -variables are not types-

### DIFF
--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -1,6 +1,6 @@
 import functools
 from enum import Enum
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, Type
 
 import numpy as np
 import tensorflow as tf
@@ -14,8 +14,8 @@ VariableData = Union[List, Tuple, np.ndarray, int, float]
 TensorLike = (
     object  # Union[tf.Tensor, tf.Variable, np.ndarray], but doesn't work with multipledispatch
 )
-Transform = tfp.bijectors.Bijector
-Prior = tfp.distributions.Distribution
+Transform = Type[tfp.bijectors.Bijector]
+Prior = Type[tfp.distributions.Distribution]
 
 
 def _IS_PARAMETER(o):

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -1,6 +1,6 @@
 import functools
 from enum import Enum
-from typing import List, Optional, Tuple, Union, Type
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import tensorflow as tf
@@ -14,8 +14,8 @@ VariableData = Union[List, Tuple, np.ndarray, int, float]
 TensorLike = (
     object  # Union[tf.Tensor, tf.Variable, np.ndarray], but doesn't work with multipledispatch
 )
-Transform = Type[tfp.bijectors.Bijector]
-Prior = Type[tfp.distributions.Distribution]
+Transform = Union[tfp.bijectors.Bijector]
+Prior = Union[tfp.distributions.Distribution]
 
 
 def _IS_PARAMETER(o):

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -141,7 +141,7 @@ def _default_summary_fmt_factory():
     return _default(_Values.SUMMARY_FMT)
 
 
-# The following type alias is for the Config class, to help a static analyser distinguish 
+# The following type alias is for the Config class, to help a static analyser distinguish
 # between the built-in 'float' type and the 'float' type defined in the that class.
 Float = Union[float]
 

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -158,11 +158,11 @@ class Config:
     """
 
     int: type = field(default_factory=_default_int_factory)
-    float: type = field(default_factory=_default_float_factory)
     jitter: float = field(default_factory=_default_jitter_factory)
     positive_bijector: str = field(default_factory=_default_positive_bijector_factory)
     positive_minimum: float = field(default_factory=_default_positive_minimum_factory)
     summary_fmt: str = field(default_factory=_default_summary_fmt_factory)
+    float: type = field(default_factory=_default_float_factory)
 
 
 def config() -> Config:

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -38,7 +38,7 @@ import contextlib
 import enum
 import os
 from dataclasses import dataclass, field, replace
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 import numpy as np
 import tabulate
@@ -141,6 +141,11 @@ def _default_summary_fmt_factory():
     return _default(_Values.SUMMARY_FMT)
 
 
+# The following type alias is for the Config class, to help a static analyser distinguish 
+# between the built-in 'float' type and the 'float' type defined in the that class.
+Float = Union[float]
+
+
 @dataclass(frozen=True)
 class Config:
     """
@@ -157,12 +162,12 @@ class Config:
         summary_fmt: Summary format for module printing.
     """
 
-    jitter: float = field(default_factory=_default_jitter_factory)
-    positive_bijector: str = field(default_factory=_default_positive_bijector_factory)
-    positive_minimum: float = field(default_factory=_default_positive_minimum_factory)
-    summary_fmt: str = field(default_factory=_default_summary_fmt_factory)
     int: type = field(default_factory=_default_int_factory)
     float: type = field(default_factory=_default_float_factory)
+    jitter: Float = field(default_factory=_default_jitter_factory)
+    positive_bijector: str = field(default_factory=_default_positive_bijector_factory)
+    positive_minimum: Float = field(default_factory=_default_positive_minimum_factory)
+    summary_fmt: str = field(default_factory=_default_summary_fmt_factory)
 
 
 def config() -> Config:

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -157,11 +157,11 @@ class Config:
         summary_fmt: Summary format for module printing.
     """
 
-    int: type = field(default_factory=_default_int_factory)
     jitter: float = field(default_factory=_default_jitter_factory)
     positive_bijector: str = field(default_factory=_default_positive_bijector_factory)
     positive_minimum: float = field(default_factory=_default_positive_minimum_factory)
     summary_fmt: str = field(default_factory=_default_summary_fmt_factory)
+    int: type = field(default_factory=_default_int_factory)
     float: type = field(default_factory=_default_float_factory)
 
 

--- a/gpflow/models/training_mixins.py
+++ b/gpflow/models/training_mixins.py
@@ -17,15 +17,15 @@ to the objective function (ExternalDataTrainingLossMixin).
 """
 
 import abc
-from typing import Callable, Iterator, Optional, Tuple, TypeVar, Union
+from typing import Callable, Iterator, Optional, Tuple, TypeVar, Union, Type
 
 import tensorflow as tf
 from tensorflow.python.data.ops.iterator_ops import OwnedIterator as DatasetOwnedIterator
 import numpy as np
 
 
-InputData = tf.Tensor
-OutputData = tf.Tensor
+InputData = Type[tf.Tensor]
+OutputData = Type[tf.Tensor]
 RegressionData = Tuple[InputData, OutputData]
 Data = TypeVar("Data", RegressionData, InputData, OutputData)
 

--- a/gpflow/models/training_mixins.py
+++ b/gpflow/models/training_mixins.py
@@ -17,15 +17,15 @@ to the objective function (ExternalDataTrainingLossMixin).
 """
 
 import abc
-from typing import Callable, Iterator, Optional, Tuple, TypeVar, Union, Type
+from typing import Callable, Iterator, Optional, Tuple, TypeVar, Union
 
 import tensorflow as tf
 from tensorflow.python.data.ops.iterator_ops import OwnedIterator as DatasetOwnedIterator
 import numpy as np
 
 
-InputData = Type[tf.Tensor]
-OutputData = Type[tf.Tensor]
+InputData = Union[tf.Tensor]
+OutputData = Union[tf.Tensor]
 RegressionData = Tuple[InputData, OutputData]
 Data = TypeVar("Data", RegressionData, InputData, OutputData)
 


### PR DESCRIPTION
### Ensure type aliases are actually types

Running MyPy over the GPFlow code raised a few type aliases which MyPy was unable to interpret as types. This PR updates those places to ensure that MyPy infers the correct type information.

### Description

GPFlow includes several type aliases which are used in function signatures. In some cases it is not possible to infer that these are aliases of types, and are interpreted by MyPy as a "variable". This causes MyPy to throw an error.
