### PR TITLE
Fix MCMC sampler in documentation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -18,7 +18,7 @@ To compile the GPflow documentation locally:
 
 2. Install doc dependencies
    ```
-   pip install sphinx sphinx_rtd_theme numpydoc nbsphinx sphinx_autodoc_typehints ipython
+   pip install sphinx sphinx_rtd_theme numpydoc nbsphinx sphinx_autodoc_typehints ipython jupytext jupyter_client ipywidgets
    ```
 
 3. Install pandoc

--- a/doc/source/notebooks/advanced/mcmc.pct.py
+++ b/doc/source/notebooks/advanced/mcmc.pct.py
@@ -493,8 +493,8 @@ _ = optimizer.minimize(
 # We then run the sampler,
 
 # %%
-num_burnin_steps = ci_niter(300)
-num_samples = ci_niter(500)
+num_burnin_steps = ci_niter(600)
+num_samples = ci_niter(1000)
 
 # Note that here we need model.trainable_parameters, not trainable_variables - only parameters can have priors!
 hmc_helper = gpflow.optimizers.SamplingHelper(

--- a/doc/source/notebooks/advanced/mcmc.pct.py
+++ b/doc/source/notebooks/advanced/mcmc.pct.py
@@ -47,9 +47,9 @@ tf.random.set_seed(123)
 #
 # In this notebook, we provide three examples:
 #
-# * [Example 1](#Example-1-GP-regression): Sampling hyperparameters in Gaussian process regression
-# * [Example 2](#Example-2-Sparse-MC-for-multiclass-classification): Sparse Variational MC applied to the multiclass classification problem
-# * [Example 3](#Example-3-Fully-Bayesian-inference-for-generalized-GP-models-with-HMC): Full Bayesian inference for Gaussian process models
+# * [Example 1](#Example-1:-GP-regression): Sampling hyperparameters in Gaussian process regression
+# * [Example 2](#Example-2:-Sparse-MC-for-multiclass-classification): Sparse Variational MC applied to the multiclass classification problem
+# * [Example 3](#Example-3:-Fully-Bayesian-inference-for-generalized-GP-models-with-HMC): Full Bayesian inference for Gaussian process models
 
 # %% [markdown]
 # ## Example 1: GP regression


### PR DESCRIPTION
This is a fix for HMC sampler used in Example 3 of the MCMC documentation notebook. Currently, the predictive performance of the `GPMC` object is poor. This is likely due to the bad mixing of the HMC chain, in particular, those of the kernel lengthscale. By running the sampler for longer and increasing the length of the burn-in phase, it does appear that the problem can be rectified as good predictive performance is re-established, and good mixing is present in the chain.

I've also added two requirements to the list needed to locally compile documentation. After doing a clean install of GPFlow and the previously listed set of requirements, `jupytext`,  `jupyter_client`, and `ipywidgets` were still required to compile the notebooks.

### Minimal working example

This is a very small PR, and all that has been changed is the hyperlinking to subsections within the MCMC example notebook, along with the number of samples and burn-in length used in the exponential likelihood example. An example would be:

```diff
-num_burnin_steps = ci_niter(300)
-num_samples = ci_niter(500)
+num_burnin_steps = ci_niter(600)
+num_samples = ci_niter(1000)
```
