### PR TITLE
Bug Fix: compilation issue quadrature

### DIFF
--- a/gpflow/quadrature.py
+++ b/gpflow/quadrature.py
@@ -117,15 +117,16 @@ def ndiagquad(funcs, H: int, Fmu, Fvar, logspace: bool = False, **Ys):
     Fmu, Fvar, Ys should all have same shape, with overall size `N`
     :return: shape is the same as that of the first Fmu
     """
-
-    def unify(f_list):
-        """
-        Stack a list of means/vars into a full block
-        """
-        return tf.reshape(tf.concat([tf.reshape(f, (-1, 1)) for f in f_list], axis=1), (-1, 1, Din))
-
     if isinstance(Fmu, (tuple, list)):
         Din = len(Fmu)
+
+        def unify(f_list):
+            """Stack a list of means/vars into a full block."""
+            return tf.reshape(
+                tensor=tf.concat([tf.reshape(f, shape=(-1, 1)) for f in f_list], axis=1),
+                shape=(-1, 1, Din),
+            )
+
         shape = tf.shape(Fmu[0])
         Fmu, Fvar = map(unify, [Fmu, Fvar])  # both [N, 1, Din]
     else:


### PR DESCRIPTION
The inline-defined function `unify` in `gpflow.quadrature.py:ndiagquad` was uncompilable - as shown by the stack trace below. I imagine the problem originates from the fact that inline functions are compiled in isolation and don't have access to variables defined outside their scope.
```
    /Users/vincent/pio/GPflow/gpflow/likelihoods/likelihoods.py:289 variational_expectations  *
        ret = self._variational_expectations(Fmu, Fvar, Y)
    /Users/vincent/pio/manchester/python/heteroscedastic_likelihoods.py:63 _variational_expectations  *
        return ndiagquad(
    /Users/vincent/pio/GPflow/gpflow/quadrature.py:125 unify  *
        return tf.reshape(tf.concat([tf.reshape(f, (-1, 1)) for f in f_list], axis=1), (-1, 1, Din))

    NameError: free variable 'Din' referenced before assignment in enclosing scope
```
This is a straightforward fix for the issue.