### PR TITLE
make set_trainable return its argument

### DIFF
--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -46,12 +46,13 @@ def to_default_float(x):
     return cast(x, dtype=default_float())
 
 
-def set_trainable(model: tf.Module, flag: bool):
+def set_trainable(module: tf.Module, flag: bool):
     """
     Set trainable flag for all `tf.Variable`s and `gpflow.Parameter`s in a module.
     """
-    for variable in model.variables:
+    for variable in module.variables:
         variable._trainable = flag
+    return module
 
 
 def multiple_assign(module: tf.Module, parameters: Dict[str, tf.Tensor]):


### PR DESCRIPTION
This would allow it to clean up some model setup code, e.g.
```python
model = VGP((X, Y), set_trainable(kernel, False), likelihood)
```