### PR TITLE
fix pyplot import for matplotlib 3.1.3 in notebooks

### DIFF
--- a/doc/source/notebooks/advanced/coregionalisation.pct.py
+++ b/doc/source/notebooks/advanced/coregionalisation.pct.py
@@ -44,13 +44,13 @@ import gpflow
 import tensorflow as tf
 import numpy as np
 import matplotlib
+import matplotlib.pyplot as plt
 
 # %matplotlib inline
 
 from gpflow.ci_utils import ci_niter
 
-matplotlib.rcParams["figure.figsize"] = (12, 6)
-plt = matplotlib.pyplot
+plt.rcParams["figure.figsize"] = (12, 6)
 np.random.seed(123)
 
 # %% [markdown]

--- a/doc/source/notebooks/advanced/coregionalisation.pct.py
+++ b/doc/source/notebooks/advanced/coregionalisation.pct.py
@@ -43,7 +43,6 @@
 import gpflow
 import tensorflow as tf
 import numpy as np
-import matplotlib
 import matplotlib.pyplot as plt
 
 # %matplotlib inline

--- a/doc/source/notebooks/advanced/gps_for_big_data.pct.py
+++ b/doc/source/notebooks/advanced/gps_for_big_data.pct.py
@@ -26,7 +26,6 @@ import numpy as np
 import time
 import gpflow
 import tensorflow as tf
-import matplotlib
 import matplotlib.pyplot as plt
 from gpflow.ci_utils import ci_niter
 

--- a/doc/source/notebooks/advanced/mcmc.pct.py
+++ b/doc/source/notebooks/advanced/mcmc.pct.py
@@ -22,7 +22,6 @@
 # %%
 import numpy as np
 import matplotlib.pyplot as plt
-import matplotlib
 import tensorflow as tf
 import tensorflow_probability as tfp
 from tensorflow_probability import distributions as tfd

--- a/doc/source/notebooks/advanced/ordinal_regression.pct.py
+++ b/doc/source/notebooks/advanced/ordinal_regression.pct.py
@@ -23,11 +23,10 @@ import gpflow
 
 import tensorflow as tf
 import numpy as np
-import matplotlib
+import matplotlib.pyplot as plt
 
 # %matplotlib inline
-matplotlib.rcParams["figure.figsize"] = (12, 6)
-plt = matplotlib.pyplot
+plt.rcParams["figure.figsize"] = (12, 6)
 
 np.random.seed(123)  # for reproducibility
 

--- a/doc/source/notebooks/advanced/varying_noise.pct.py
+++ b/doc/source/notebooks/advanced/varying_noise.pct.py
@@ -36,7 +36,6 @@ import gpflow
 from gpflow.ci_utils import ci_niter
 from gpflow.optimizers import NaturalGradient
 from gpflow import set_trainable
-import matplotlib
 import matplotlib.pyplot as plt
 
 # %matplotlib inline

--- a/doc/source/notebooks/basics/classification.pct.py
+++ b/doc/source/notebooks/basics/classification.pct.py
@@ -27,11 +27,10 @@ import gpflow
 import tensorflow as tf
 
 import matplotlib.pyplot as plt
-import matplotlib
 
 # %matplotlib inline
 
-matplotlib.rcParams["figure.figsize"] = (8, 4)
+plt.rcParams["figure.figsize"] = (8, 4)
 
 # %% [markdown]
 # ## One-dimensional example

--- a/doc/source/notebooks/basics/regression.pct.py
+++ b/doc/source/notebooks/basics/regression.pct.py
@@ -32,14 +32,13 @@
 # %%
 import gpflow
 import numpy as np
-import matplotlib
+import matplotlib.pyplot as plt
 import tensorflow as tf
 from gpflow.utilities import print_summary
 
 # The lines below are specific to the notebook format
 # %matplotlib inline
-matplotlib.rcParams["figure.figsize"] = (12, 6)
-plt = matplotlib.pyplot
+plt.rcParams["figure.figsize"] = (12, 6)
 
 # %% [markdown]
 # `X` and `Y` denote the input and output values. **NOTE:** `X` and `Y` must be two-dimensional NumPy arrays, $N \times 1$ or $N \times D$, where $D$ is the number of input dimensions/features, with the same number of rows as $N$ (one for each data point):

--- a/doc/source/notebooks/theory/Sanity_check.pct.py
+++ b/doc/source/notebooks/theory/Sanity_check.pct.py
@@ -38,7 +38,6 @@
 import gpflow
 import numpy as np
 import tensorflow as tf
-import matplotlib
 import matplotlib.pyplot as plt
 
 from gpflow import set_trainable
@@ -47,7 +46,7 @@ from gpflow.config import default_float
 from gpflow.ci_utils import ci_niter
 
 # %matplotlib inline
-matplotlib.rcParams["figure.figsize"] = (12, 6)
+plt.rcParams["figure.figsize"] = (12, 6)
 
 # %%
 np.random.seed(0)

--- a/doc/source/notebooks/theory/upper_bound.pct.py
+++ b/doc/source/notebooks/theory/upper_bound.pct.py
@@ -19,11 +19,10 @@
 # See the [`gp_upper` repository](https://github.com/markvdw/gp_upper) by Mark van der Wilk for code to tighten the upper bound through optimization, and a more comprehensive discussion.
 
 # %%
-import matplotlib
+import matplotlib.pyplot as plt
 
 # %matplotlib inline
-matplotlib.rcParams["figure.figsize"] = (12, 6)
-plt = matplotlib.pyplot
+plt.rcParams["figure.figsize"] = (12, 6)
 
 import numpy as np
 import tensorflow as tf

--- a/doc/source/notebooks/understanding/models.pct.py
+++ b/doc/source/notebooks/understanding/models.pct.py
@@ -261,13 +261,12 @@ X = np.vstack(
 )
 Y = np.repeat(np.eye(3), 10, 0)
 
-from matplotlib import pyplot as plt
+import matplotlib.pyplot as plt
 
 plt.style.use("ggplot")
 # %matplotlib inline
-import matplotlib
 
-matplotlib.rcParams["figure.figsize"] = (12, 6)
+plt.rcParams["figure.figsize"] = (12, 6)
 _ = plt.scatter(X[:, 0], X[:, 1], 100, np.argmax(Y, 1), lw=2, cmap=plt.cm.viridis)
 
 # %%


### PR DESCRIPTION
This PR fixes notebooks to work with matplotlib 3.1.3 as reported by #1423.