### PR TITLE
Use a type alias in the function signature of leading_transpose

### DIFF
--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -6,6 +6,9 @@ import tensorflow_probability as tfp
 import numpy as np
 
 
+EllipsisType = type(...)
+
+
 def cast(
     value: Union[tf.Tensor, np.ndarray], dtype: tf.DType, name: Optional[str] = None
 ) -> tf.Tensor:
@@ -23,7 +26,7 @@ def eye(num: int, value: tf.Tensor, dtype: Optional[tf.DType] = None) -> tf.Tens
 
 
 def leading_transpose(
-    tensor: tf.Tensor, perm: List[Union[int, type(...)]], leading_dim: int = 0
+    tensor: tf.Tensor, perm: List[Union[int, EllipsisType]], leading_dim: int = 0
 ) -> tf.Tensor:
     """
     Transposes tensors with leading dimensions. Leading dimensions in

--- a/tests/gpflow/conditionals/test_util.py
+++ b/tests/gpflow/conditionals/test_util.py
@@ -61,7 +61,7 @@ def test_leading_transpose_with_tf_function_wrapper(caplog):
     # When Autograph cannot compile a function it sends a WARNING message to the
     # logs.
     log_message_levels = [record.levelname for record in caplog.records]
-    assert 'WARNING' not in log_message_levels
+    assert "WARNING" not in log_message_levels
 
 
 # rollaxis

--- a/tests/gpflow/conditionals/test_util.py
+++ b/tests/gpflow/conditionals/test_util.py
@@ -47,6 +47,23 @@ def test_leading_transpose_fails():
         leading_transpose(a, [-1, -2])
 
 
+def test_leading_transpose_with_tf_function_wrapper(caplog):
+    """ Check that no warnings are thrown when compiling `leading_transpose` """
+    dims = [1, 2, 3, 4]
+    a = tf.zeros(dims)
+
+    @tf.function
+    def compiled_wrapper():
+        return leading_transpose(a, [..., -1, -2])
+
+    compiled_wrapper()
+
+    # When Autograph cannot compile a function it sends a WARNING message to the
+    # logs.
+    log_message_levels = [record.levelname for record in caplog.records]
+    assert 'WARNING' not in log_message_levels
+
+
 # rollaxis
 @pytest.mark.parametrize("rolls", [1, 2])
 @pytest.mark.parametrize("direction", ["left", "right"])


### PR DESCRIPTION
 I am seeing a warning when attempting to use a `gpflow` model inside a function which has been decorated with `@tf.function`.

WARNING:tensorflow:AutoGraph could not transform <function leading_transpose at 0x7f976ca75e60> and will run it as-is.
Please report this to the TensorFlow team. When filing the bug, set the verbosity to 10 (on Linux, `export AUTOGRAPH_VERBOSITY=10`) and attach the full output.
Cause: name 'fscope' is not defined

I think this means that the function `leading_transpose` will not be compiled into a static graph.

That will impact performance for code paths which use that function (granted, it seems to be used primarily to do sampling with a full covariance matrix, so it is expected to be a slower approach). I don't know nearly enough about `@tf.function` to know if this would have a performance impact for the whole graph.

This is caused by the type signature including `type(...)`, which is mis-interpreted by `@tf.function`'. This PR replaces that function call with a type alias, and adds a unit test for this failure mode.
