### PR TITLE
refactor natgrads to be more efficient

### DIFF
--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -48,7 +48,8 @@ class XiTransform(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def meanvarsqrt_to_xi(self, mean, varsqrt):
+    @staticmethod
+    def meanvarsqrt_to_xi(mean, varsqrt):
         """
         Transforms the parameter `mean` and `varsqrt` to `xi1`, `xi2`
 
@@ -58,7 +59,8 @@ class XiTransform(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def xi_to_meanvarsqrt(self, xi1, xi2):
+    @staticmethod
+    def xi_to_meanvarsqrt(xi1, xi2):
         """
         Transforms the parameter `xi1`, `xi2` to `mean`, `varsqrt`
 
@@ -68,7 +70,8 @@ class XiTransform(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def naturals_to_xi(self, nat1, nat2):
+    @staticmethod
+    def naturals_to_xi(nat1, nat2):
         """
         Applies the transform so that `nat1`, `nat2` is mapped to `xi1`, `xi2`
 
@@ -85,13 +88,16 @@ class XiNat(XiTransform):
     of Gaussian likelihood.
     """
 
-    def meanvarsqrt_to_xi(self, mean, varsqrt):
+    @staticmethod
+    def meanvarsqrt_to_xi(mean, varsqrt):
         return meanvarsqrt_to_natural(mean, varsqrt)
 
-    def xi_to_meanvarsqrt(self, xi1, xi2):
+    @staticmethod
+    def xi_to_meanvarsqrt(xi1, xi2):
         return natural_to_meanvarsqrt(xi1, xi2)
 
-    def naturals_to_xi(self, nat1, nat2):
+    @staticmethod
+    def naturals_to_xi(nat1, nat2):
         return nat1, nat2
 
 
@@ -101,13 +107,16 @@ class XiSqrtMeanVar(XiTransform):
     so saves the conversion to and from Xi.
     """
 
-    def meanvarsqrt_to_xi(self, mean, varsqrt):
+    @staticmethod
+    def meanvarsqrt_to_xi(mean, varsqrt):
         return mean, varsqrt
 
-    def xi_to_meanvarsqrt(self, xi1, xi2):
+    @staticmethod
+    def xi_to_meanvarsqrt(xi1, xi2):
         return xi1, xi2
 
-    def naturals_to_xi(self, nat1, nat2):
+    @staticmethod
+    def naturals_to_xi(nat1, nat2):
         return natural_to_meanvarsqrt(nat1, nat2)
 
 

--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -245,9 +245,7 @@ class NaturalGradient(tf.optimizers.Optimizer):
 
         # 1) the ordinary gpflow gradient
         dL_dmean = q_mu_grad
-        dL_dvarsqrt = q_sqrt.transform.forward(
-            q_sqrt_grad
-        )
+        dL_dvarsqrt = q_sqrt.transform.forward(q_sqrt_grad)
 
         with tf.GradientTape(persistent=True, watch_accessed_variables=False) as tape:
             tape.watch([q_mu.unconstrained_variable, q_sqrt.unconstrained_variable])

--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -14,7 +14,7 @@
 
 import abc
 import functools
-from typing import Callable, Sequence, Tuple, Union
+from typing import Callable, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import tensorflow as tf

--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -47,8 +47,8 @@ class XiTransform(metaclass=abc.ABCMeta):
     the parameters pairs are always of shape (N, D) and (D, N, N).
     """
 
-    @abc.abstractmethod
     @staticmethod
+    @abc.abstractmethod
     def meanvarsqrt_to_xi(mean, varsqrt):
         """
         Transforms the parameter `mean` and `varsqrt` to `xi1`, `xi2`
@@ -58,8 +58,8 @@ class XiTransform(metaclass=abc.ABCMeta):
         :return: tuple (xi1, xi2), the xi parameters (N, D), (D, N, N)
         """
 
-    @abc.abstractmethod
     @staticmethod
+    @abc.abstractmethod
     def xi_to_meanvarsqrt(xi1, xi2):
         """
         Transforms the parameter `xi1`, `xi2` to `mean`, `varsqrt`
@@ -69,8 +69,8 @@ class XiTransform(metaclass=abc.ABCMeta):
         :return: tuple (mean, varsqrt), the meanvarsqrt parameters
         """
 
-    @abc.abstractmethod
     @staticmethod
+    @abc.abstractmethod
     def naturals_to_xi(nat1, nat2):
         """
         Applies the transform so that `nat1`, `nat2` is mapped to `xi1`, `xi2`

--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -179,7 +179,9 @@ class NaturalGradient(tf.optimizers.Optimizer):
         self._natgrad_steps(loss_fn, parameters)
 
     def _natgrad_steps(
-        self, loss_fn: LossClosure, parameters: Sequence[Tuple[Parameter, Parameter, Optional[XiTransform]]]
+        self,
+        loss_fn: LossClosure,
+        parameters: Sequence[Tuple[Parameter, Parameter, Optional[XiTransform]]],
     ):
         """
         Computes gradients of loss_fn() w.r.t. q_mu and q_sqrt, and updates

--- a/tests/gpflow/optimizers/test_natural_gradient.py
+++ b/tests/gpflow/optimizers/test_natural_gradient.py
@@ -152,13 +152,16 @@ def test_svgp_vs_sgpr(sgpr_and_svgp):
 
 
 class XiEta(gpflow.optimizers.XiTransform):
-    def meanvarsqrt_to_xi(self, mean: tf.Tensor, varsqrt: tf.Tensor) -> tf.Tensor:
+    @staticmethod
+    def meanvarsqrt_to_xi(mean: tf.Tensor, varsqrt: tf.Tensor) -> tf.Tensor:
         return gpflow.optimizers.natgrad.meanvarsqrt_to_expectation(mean, varsqrt)
 
-    def xi_to_meanvarsqrt(self, xi1: tf.Tensor, xi2: tf.Tensor) -> tf.Tensor:
+    @staticmethod
+    def xi_to_meanvarsqrt(xi1: tf.Tensor, xi2: tf.Tensor) -> tf.Tensor:
         return gpflow.optimizers.natgrad.expectation_to_meanvarsqrt(xi1, xi2)
 
-    def naturals_to_xi(self, nat1: tf.Tensor, nat2: tf.Tensor) -> tf.Tensor:
+    @staticmethod
+    def naturals_to_xi(nat1: tf.Tensor, nat2: tf.Tensor) -> tf.Tensor:
         return gpflow.optimizers.natgrad.natural_to_expectation(nat1, nat2)
 
 


### PR DESCRIPTION
Previously, GPflow's NaturalGradient optimizer would call the loss_function once for each (q_mu, q_sqrt) set in the var_list. This is a light refactor that separates out applying the natural gradient step from computing the gradients (`_natgrad_apply_gradients`), and changes `_natgrad_steps` to only evaluate the loss function once, computing the gradients for all (q_mu, q_sqrt) tuples passed in the var_list.

Other changes:
- The no-longer-used `_natgrad_step` method got removed.
- NaturalGradient now takes a `xi_transform` argument that is used for all parameter sets without explicitly specified xi transform (i.e. tuples rather than triplets).
- XiTransform has been changed to have staticmethods.

None of this should affect any downstream code; this PR is backwards-compatible.