### PR TITLE
Use a boolean for full covariance in sample_mvn.

### DIFF
--- a/gpflow/conditionals/multioutput/sample_conditionals.py
+++ b/gpflow/conditionals/multioutput/sample_conditionals.py
@@ -43,7 +43,7 @@ def _sample_conditional(
     g_mu, g_var = ind_conditional(
         Xnew, inducing_variable, kernel, f, white=white, q_sqrt=q_sqrt
     )  # [..., N, L], [..., N, L]
-    g_sample = sample_mvn(g_mu, g_var, "diag", num_samples=num_samples)  # [..., (S), N, L]
+    g_sample = sample_mvn(g_mu, g_var, full_cov, num_samples=num_samples)  # [..., (S), N, L]
     f_mu, f_var = mix_latent_gp(kernel.W, g_mu, g_var, full_cov, full_output_cov)
     f_sample = tf.tensordot(g_sample, kernel.W, [[-1], [-1]])  # [..., N, P]
     return f_sample, f_mu, f_var

--- a/gpflow/conditionals/sample_conditionals.py
+++ b/gpflow/conditionals/sample_conditionals.py
@@ -50,13 +50,14 @@ def _sample_conditional(
         # cov: [..., P, N, N]
         mean_for_sample = tf.linalg.adjoint(mean)  # [..., P, N]
         samples = sample_mvn(
-            mean_for_sample, cov, "full", num_samples=num_samples
+            mean_for_sample, cov, full_cov=True, num_samples=num_samples
         )  # [..., (S), P, N]
         samples = tf.linalg.adjoint(samples)  # [..., (S), N, P]
     else:
         # mean: [..., N, P]
         # cov: [..., N, P] or [..., N, P, P]
-        cov_structure = "full" if full_output_cov else "diag"
-        samples = sample_mvn(mean, cov, cov_structure, num_samples=num_samples)  # [..., (S), N, P]
+        samples = sample_mvn(
+            mean, cov, full_cov=full_output_cov, num_samples=num_samples
+        )  # [..., (S), N, P]
 
     return samples, mean, cov

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -134,22 +134,19 @@ def base_conditional(
     return fmean, fvar
 
 
-def sample_mvn(mean, cov, cov_structure=None, num_samples=None):
+def sample_mvn(mean, cov, full_cov, num_samples=None):
     """
     Returns a sample from a D-dimensional Multivariate Normal distribution
     :param mean: [..., N, D]
     :param cov: [..., N, D] or [..., N, D, D]
-    :param cov_structure: "diag" or "full"
-    - "diag": cov holds the diagonal elements of the covariance matrix
+    :param full_cov: if `True` return a "full" covariance matrix, otherwise a "diag":
     - "full": cov holds the full covariance matrix (without jitter)
+    - "diag": cov holds the diagonal elements of the covariance matrix
     :return: sample from the MVN of shape [..., (S), N, D], S = num_samples
     """
-    if cov_structure not in ("diag", "full"):
-        raise ValueError("cov_structure must be 'diag' or 'full'")
-
     shape_constraints = [
         (mean, [..., "N", "D"]),
-        (cov, [..., "N", "D"] if cov_structure == "diag" else [..., "N", "D", "D"]),
+        (cov, [..., "N", "D", "D"] if full_cov else [..., "N", "D"]),
     ]
     tf.debugging.assert_shapes(shape_constraints, message="sample_mvn() arguments")
 
@@ -158,13 +155,13 @@ def sample_mvn(mean, cov, cov_structure=None, num_samples=None):
     D = mean_shape[-1]
     leading_dims = mean_shape[:-2]
 
-    if cov_structure == "diag":
+    if not full_cov:
         # mean: [..., N, D] and cov [..., N, D]
         eps_shape = tf.concat([leading_dims, [S], mean_shape[-2:]], 0)
         eps = tf.random.normal(eps_shape, dtype=default_float())  # [..., S, N, D]
         samples = mean[..., None, :, :] + tf.sqrt(cov)[..., None, :, :] * eps  # [..., S, N, D]
 
-    elif cov_structure == "full":
+    else:
         # mean: [..., N, D] and cov [..., N, D, D]
         jittermat = (
             tf.eye(D, batch_shape=mean_shape[:-1], dtype=default_float()) * default_jitter()

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -205,15 +205,14 @@ class GPModel(BayesianModel):
             # cov: [..., P, N, N]
             mean_for_sample = tf.linalg.adjoint(mean)  # [..., P, N]
             samples = sample_mvn(
-                mean_for_sample, cov, "full", num_samples=num_samples
+                mean_for_sample, cov, full_cov, num_samples=num_samples
             )  # [..., (S), P, N]
             samples = tf.linalg.adjoint(samples)  # [..., (S), N, P]
         else:
             # mean: [..., N, P]
             # cov: [..., N, P] or [..., N, P, P]
-            cov_structure = "full" if full_output_cov else "diag"
             samples = sample_mvn(
-                mean, cov, cov_structure, num_samples=num_samples
+                mean, cov, full_output_cov, num_samples=num_samples
             )  # [..., (S), N, P]
         return samples  # [..., (S), N, P]
 

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -197,8 +197,8 @@ class DataMixedKernel(Data):
 # ------------------------------------------
 
 
-@pytest.mark.parametrize("cov_structure", ["full", "diag"])
-def test_sample_mvn(cov_structure):
+@pytest.mark.parametrize("full_cov", [True, False])
+def test_sample_mvn(full_cov):
     """
     Draws 10,000 samples from a distribution
     with known mean and covariance. The test checks
@@ -207,14 +207,12 @@ def test_sample_mvn(cov_structure):
     """
     N, D = 10000, 2
     means = tf.ones((N, D), dtype=float_type)
-    if cov_structure == "full":
+    if full_cov:
         covs = tf.eye(D, batch_shape=[N], dtype=float_type)
-    elif cov_structure == "diag":
-        covs = tf.ones((N, D), dtype=float_type)
     else:
-        raise (NotImplementedError)
+        covs = tf.ones((N, D), dtype=float_type)
 
-    samples = sample_mvn(means, covs, cov_structure)
+    samples = sample_mvn(means, covs, full_cov)
     samples_mean = np.mean(samples, axis=0)
     samples_cov = np.cov(samples, rowvar=False)
 

--- a/tests/gpflow/conditionals/test_util.py
+++ b/tests/gpflow/conditionals/test_util.py
@@ -19,9 +19,7 @@ import tensorflow as tf
 from numpy.testing import assert_allclose, assert_equal
 
 from gpflow import default_float
-from gpflow.conditionals.util import (
-    leading_transpose, rollaxis_left, rollaxis_right, sample_mvn
-)
+from gpflow.conditionals.util import leading_transpose, rollaxis_left, rollaxis_right, sample_mvn
 
 
 def test_leading_transpose():

--- a/tests/gpflow/conditionals/test_util.py
+++ b/tests/gpflow/conditionals/test_util.py
@@ -16,9 +16,12 @@
 import numpy as np
 import pytest
 import tensorflow as tf
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
-from gpflow.conditionals.util import leading_transpose, rollaxis_left, rollaxis_right
+from gpflow import default_float
+from gpflow.conditionals.util import (
+    leading_transpose, rollaxis_left, rollaxis_right, sample_mvn
+)
 
 
 def test_leading_transpose():
@@ -99,3 +102,30 @@ def test_rollaxis_idempotent(rolls):
 
     assert_allclose(A, A_left_right)
     assert_allclose(A, A_right_left)
+
+
+@pytest.mark.parametrize("leading_dims", [tuple(), (1,), (5,)])
+@pytest.mark.parametrize("n", [1, 5])
+@pytest.mark.parametrize("d", [1, 5])
+@pytest.mark.parametrize("num_samples", [None, 1, 5])
+@pytest.mark.parametrize("full_cov", [True, False])
+def test_sample_mvn_shapes(leading_dims, n, d, num_samples, full_cov):
+    mean_shape = leading_dims + (n, d)
+    means = tf.zeros(mean_shape, dtype=default_float())
+
+    if full_cov:
+        covariance_shape = leading_dims + (n, d, d)
+        sqrt_cov = tf.random.normal(covariance_shape, dtype=default_float())
+        covariances = tf.matmul(sqrt_cov, sqrt_cov, transpose_b=True)
+    else:
+        covariance_shape = leading_dims + (n, d)
+        covariances = tf.random.normal(covariance_shape, dtype=default_float())
+
+    samples = sample_mvn(means, covariances, full_cov, num_samples)
+
+    if num_samples:
+        expected_shape = leading_dims + (num_samples, n, d)
+    else:
+        expected_shape = leading_dims + (n, d)
+
+    assert_equal(samples.shape, expected_shape)


### PR DESCRIPTION
Addressing #1447 .

This PR replaces the string comparison in the `conditionals.utils.sample_mvn` function with the same boolean that is used in other places in GPFlow.