### PR TITLE
Jitter

### DIFF
--- a/gpflow/models/sgpr.py
+++ b/gpflow/models/sgpr.py
@@ -103,7 +103,7 @@ class SGPRBase(GPModel, InternalDataTrainingLossMixin):
         num_data = to_default_float(tf.shape(Y_data)[0])
 
         Kdiag = self.kernel(X_data, full_cov=False)
-        kuu = Kuu(self.inducing_variable, self.kernel, jitter=default_jitter())
+        kuu = Kuu(self.inducing_variable, self.kernel, jitter=self.jitter_variance)
         kuf = Kuf(self.inducing_variable, self.kernel, X_data)
 
         I = tf.eye(tf.shape(kuu)[0], dtype=default_float())
@@ -172,7 +172,7 @@ class SGPR(SGPRBase):
         err = Y_data - self.mean_function(X_data)
         Kdiag = self.kernel(X_data, full_cov=False)
         kuf = Kuf(self.inducing_variable, self.kernel, X_data)
-        kuu = Kuu(self.inducing_variable, self.kernel, jitter=default_jitter())
+        kuu = Kuu(self.inducing_variable, self.kernel, jitter=self.jitter_variance)
         L = tf.linalg.cholesky(kuu)
         sigma = tf.sqrt(self.likelihood.variance)
 
@@ -205,7 +205,7 @@ class SGPR(SGPRBase):
         num_inducing = len(self.inducing_variable)
         err = Y_data - self.mean_function(X_data)
         kuf = Kuf(self.inducing_variable, self.kernel, X_data)
-        kuu = Kuu(self.inducing_variable, self.kernel, jitter=default_jitter())
+        kuu = Kuu(self.inducing_variable, self.kernel, jitter=self.jitter_variance)
         Kus = Kuf(self.inducing_variable, self.kernel, Xnew)
         sigma = tf.sqrt(self.likelihood.variance)
         L = tf.linalg.cholesky(kuu)
@@ -243,7 +243,7 @@ class SGPR(SGPRBase):
         X_data, Y_data = self.data
 
         kuf = Kuf(self.inducing_variable, self.kernel, X_data)
-        kuu = Kuu(self.inducing_variable, self.kernel, jitter=default_jitter())
+        kuu = Kuu(self.inducing_variable, self.kernel, jitter=self.jitter_variance)
 
         sig = kuu + (self.likelihood.variance ** -1) * tf.matmul(kuf, kuf, transpose_b=True)
         sig_sqrt = tf.linalg.cholesky(sig)
@@ -290,7 +290,7 @@ class GPRFITC(SGPRBase):
         err = Y_data - self.mean_function(X_data)  # size [N, R]
         Kdiag = self.kernel(X_data, full_cov=False)
         kuf = Kuf(self.inducing_variable, self.kernel, X_data)
-        kuu = Kuu(self.inducing_variable, self.kernel, jitter=default_jitter())
+        kuu = Kuu(self.inducing_variable, self.kernel, jitter=self.jitter_variance)
 
         Luu = tf.linalg.cholesky(kuu)  # => Luu Luu^T = kuu
         V = tf.linalg.triangular_solve(Luu, kuf)  # => V^T V = Qff = kuf^T kuu^-1 kuf

--- a/gpflow/models/sgpr.py
+++ b/gpflow/models/sgpr.py
@@ -22,11 +22,12 @@ from .model import GPModel, InputData, RegressionData, MeanAndVariance
 from .training_mixins import InternalDataTrainingLossMixin
 from .util import inducingpoint_wrapper
 from .. import likelihoods
+from ..base import Parameter
 from ..config import default_float, default_jitter
 from ..covariances.dispatch import Kuf, Kuu
 from ..inducing_variables import InducingPoints
 from ..mean_functions import MeanFunction
-from ..utilities import to_default_float
+from ..utilities import to_default_float, positive
 
 
 class SGPRBase(GPModel, InternalDataTrainingLossMixin):
@@ -64,6 +65,9 @@ class SGPRBase(GPModel, InternalDataTrainingLossMixin):
         self.num_data = X_data.shape[0]
 
         self.inducing_variable = inducingpoint_wrapper(inducing_variable)
+        self.jitter_variance = Parameter(
+            default_jitter(), transform=positive(0.0), trainable=False, name="jitter"
+        )
 
     def upper_bound(self) -> tf.Tensor:
         """

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -51,7 +51,8 @@ def set_trainable(model: tf.Module, flag: bool):
     Set trainable flag for all `tf.Variable`s and `gpflow.Parameter`s in a module.
     """
     for variable in model.variables:
-        variable._trainable = flag
+        if "jitter" not in variable.name:
+            variable._trainable = flag
 
 
 def multiple_assign(module: tf.Module, parameters: Dict[str, tf.Tensor]):


### PR DESCRIPTION
Following some discussion on the Slack channel, here is a version of SGPR which has jitter as a parameter. By default, the parameter is not trainable. Moreover, `set_trainable()` has been adapted to not change the trainability of this parameter.

It is still possible for the parameter to become trainable, by a user directly setting the `_trainable` flag in the `tf.Variable` object.

Originally, I thought this solution would be a bit dangerous, in that the jitter could accidentally be set to be trainable. However, given that a _private_ method needs to be adapted to do this, I now don't feel so bad about this.

I believe that *some* kind of model-level jitter adaptation is very important in the longer term, for some work on making the training of SGPR models more robust.

We can also think about adding a similar property to `SVGP`. 