### PR TITLE
Improve representation of GPflow objects in IPython/Jupyter notebook

### DIFF
--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -8,7 +8,7 @@ import tensorflow_probability as tfp
 from tensorflow.python.ops import array_ops
 from typing_extensions import Final
 
-from .config import default_float
+from .config import default_float, default_summary_fmt
 
 DType = Union[np.dtype, tf.DType]
 VariableData = Union[List, Tuple, np.ndarray, int, float]
@@ -33,15 +33,22 @@ class Module(tf.Module):
     def trainable_parameters(self):
         return tuple(self._flatten(predicate=_IS_TRAINABLE_PARAMETER))
 
-    def _repr_html_(self):
-        from .utilities import tabulate_module_summary
+    def _representation_table(self, object_name, tablefmt):
+        from .utilities import leaf_components, tabulate_module_summary
+        repr_components = [object_name]
+        if leaf_components(self):
+            repr_components.append(tabulate_module_summary(self, tablefmt=tablefmt))
+        return "\n".join(repr_components)
 
-        return tabulate_module_summary(self, tablefmt="html")
+    def _repr_html_(self):
+        """ Nice representation of GPflow objects in IPython/Jupyter notebooks """
+        from html import escape
+        return self._representation_table(escape(repr(self)), "html")
 
     def _repr_pretty_(self, p, cycle):
-        from .utilities import tabulate_module_summary
-
-        p.text(tabulate_module_summary(self, tablefmt=""))
+        """ Nice representation of GPflow objects in the IPython shell """
+        repr_str = self._representation_table(repr(self), default_summary_fmt())
+        p.text(repr_str)
 
 
 class PriorOn(Enum):

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -35,6 +35,7 @@ class Module(tf.Module):
 
     def _representation_table(self, object_name, tablefmt):
         from .utilities import leaf_components, tabulate_module_summary
+
         repr_components = [object_name]
         if leaf_components(self):
             repr_components.append(tabulate_module_summary(self, tablefmt=tablefmt))
@@ -43,6 +44,7 @@ class Module(tf.Module):
     def _repr_html_(self):
         """ Nice representation of GPflow objects in IPython/Jupyter notebooks """
         from html import escape
+
         return self._representation_table(escape(repr(self)), "html")
 
     def _repr_pretty_(self, p, cycle):

--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -37,10 +37,11 @@ def test_notebook_dir_exists():
     assert os.path.isdir(_nbpath())
 
 
-# To blacklist a notebook, add its full base name (including .ipynb extension,
-# but without any directory component). If there are several notebooks in
-# different directories with the same base name, they will all get blacklisted
-# (change the blacklisting check to something else in that case, if need be!)
+# To blacklist a notebook, add its full base name (including .pct.py or .md
+# extension, but without any directory component). NOTE that if there are
+# several notebooks in different directories with the same base name, they will
+# all get blacklisted (change the blacklisting check to something else in that
+# case, if need be!)
 BLACKLISTED_NOTEBOOKS = []
 
 


### PR DESCRIPTION
The IPython shell and Jupyter notebooks make use of special methods `_repr_html` and `_repr_pretty` to pretty-print objects with a rich representation. We support this in GPflow in the base.Module base class. So far, this *only* included the tabular representation of a module's parameters (equivalent to gpflow.utilities.print_summary()). This had the down-side that, particularly in Jupyter notebooks, parameter-free Modules - such as gpflow.mean_functions.Zero() - had a representation that looked almost identical to that of `None`.

This PR improves working with GPflow objects interactively:
* adds the `repr()` string as well, i.e. fully-qualified class name and object hash (memory address), which helps distinguish objects from each other,
* only displays the parameter table when it is not empty,
* makes use of default_summary_fmt() for IPython shell.

**Example IPython shell representations before this PR:**
`gpflow.mean_functions.Zero()`:
```
name    class    transform    prior    trainable    shape    dtype    value
------  -------  -----------  -------  -----------  -------  -------  -------
```
`gpflow.mean_functions.Linear()`:
```
name      class      transform    prior    trainable    shape    dtype    value
--------  ---------  -----------  -------  -----------  -------  -------  -------
Linear.A  Parameter                        True         (1, 1)   float64  [[1.]]
Linear.b  Parameter                        True         (1,)     float64  [0.]
```

**With this PR:**
`gpflow.mean_functions.Zero()`:
```
<gpflow.mean_functions.Zero object at 0x7fe00c0da050>
```
`gpflow.mean_functions.Linear()`:
```
<gpflow.mean_functions.Linear object at 0x7fdf2ee14850>
╒══════════╤═══════════╤═════════════╤═════════╤═════════════╤═════════╤═════════╤═════════╕
│ name     │ class     │ transform   │ prior   │ trainable   │ shape   │ dtype   │ value   │
╞══════════╪═══════════╪═════════════╪═════════╪═════════════╪═════════╪═════════╪═════════╡
│ Linear.A │ Parameter │             │         │ True        │ (1, 1)  │ float64 │ [[1.]]  │
├──────────┼───────────┼─────────────┼─────────┼─────────────┼─────────┼─────────┼─────────┤
│ Linear.b │ Parameter │             │         │ True        │ (1,)    │ float64 │ [0.]    │
╘══════════╧═══════════╧═════════════╧═════════╧═════════════╧═════════╧═════════╧═════════╛
```