### PR TITLE
Update setup.py for tensorflow 2(.2)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,7 @@ if sys.version_info < (3, 7):
     requirements.append("dataclasses")
 
 if not on_readthedocs:
-    requirements.extend(
-        ["tensorflow>=2.1.0", "tensorflow-probability>=0.9"]
-    )
+    requirements.extend(["tensorflow>=2.1.0", "tensorflow-probability>=0.9"])
 
 
 def read_file(filename):

--- a/setup.py
+++ b/setup.py
@@ -31,50 +31,9 @@ if sys.version_info < (3, 7):
     requirements.append("dataclasses")
 
 if not on_readthedocs:
-    requirements.append("tensorflow-probability>=0.9")
-
-min_tf_version = "2.1.0"
-tf_cpu = "tensorflow"
-tf_gpu = "tensorflow-gpu"
-
-
-# for latest_version() [see https://github.com/GPflow/GPflow/issues/1348]:
-def latest_version(package_name):
-    import json
-    from urllib import request
-    import re
-
-    url = f"https://pypi.python.org/pypi/{package_name}/json"
-    data = json.load(request.urlopen(url))
-    # filter out rc and beta releases and, more generally, any releases that
-    # do not contain exclusively numbers and dots.
-    versions = [parse_version(v) for v in data["releases"].keys() if re.match("^[0-9.]+$", v)]
-    versions.sort()
-    return versions[-1]  # return latest version
-
-
-# Only detect TF if not installed or outdated. If not, do not do not list as
-# requirement to avoid installing over e.g. tensorflow-gpu
-# To avoid this, rely on importing rather than the package name (like pip).
-
-try:
-    # If tf not installed, import raises ImportError
-    import tensorflow as tf
-
-    if parse_version(tf.__version__) < parse_version(min_tf_version):
-        # TF pre-installed, but below the minimum required version
-        raise DeprecationWarning("TensorFlow version below minimum requirement")
-except (ImportError, DeprecationWarning):
-    # Add TensorFlow to dependencies to trigger installation/update
-    if not on_readthedocs:
-        # Do not add TF if we are installing GPflow on readthedocs
-        requirements.append(tf_cpu)
-        gast_requirement = (
-            "gast>=0.2.2,<0.3"
-            if latest_version("tensorflow") < parse_version("2.2")
-            else "gast>=0.3.3"
-        )
-        requirements.append(gast_requirement)
+    requirements.extend(
+        ["tensorflow>=2.1.0", "tensorflow-probability>=0.9"]
+    )
 
 
 def read_file(filename):
@@ -105,7 +64,7 @@ setup(
     packages=packages,
     include_package_data=True,
     install_requires=requirements,
-    extras_require={"Tensorflow with GPU": [tf_gpu], "ImageToTensorBoard": ["matplotlib"]},
+    extras_require={"ImageToTensorBoard": ["matplotlib"]},
     python_requires=">=3.6",
     classifiers=[
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,8 @@
 
 import os
 import sys
-from pathlib import Path
 
-from pkg_resources import parse_version
 from setuptools import find_packages, setup
-
-
-# We do not want to install tensorflow in the readthedocs environment, where we
-# use autodoc_mock_imports instead. Hence we use this flag to decide whether or
-# not to append tensorflow and tensorflow_probability to the requirements:
-on_readthedocs = os.environ.get("READTHEDOCS", None) == "True"
 
 
 # Dependencies of GPflow
@@ -30,7 +22,10 @@ if sys.version_info < (3, 7):
     # became part of stdlib in python 3.7
     requirements.append("dataclasses")
 
-if not on_readthedocs:
+# We do not want to install tensorflow in the readthedocs environment, where we
+# use autodoc_mock_imports instead. Hence we use this flag to decide whether or
+# not to append tensorflow and tensorflow_probability to the requirements:
+if os.environ.get("READTHEDOCS") != "True":
     requirements.extend(["tensorflow>=2.1.0", "tensorflow-probability>=0.9"])
 
 

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,3 +1,4 @@
+black
 pytest>=3.5.0
 pytest-random-order
 


### PR DESCRIPTION
We had some complicated workarounds for TensorFlow CPU vs GPU and gast 0.2.2 vs 0.3.3 (#1348, #1350). Unfortunately, they turned out not to be compatible with `pip install gpflow` now that TensorFlow 2.2 is released - I don't understand WHY the logic isn't working, but it's not; pip seems to believe that gpflow requires gast 0.2.2 (despite the workaround logic!). In any case, the CPU vs GPU workaround is no longer required for TensorFlow 2.x as there is no separate GPU package. The gast workaround should no longer required either because TensorFlow 2.2 is compatible with the latest gast release so the CI should be happy. This PR removes both (and adds black to tests_requirements, which had been missing).