### PR TITLE
Add ipynb to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ target/
 
 # IPython Notebooks
 .ipynb_checkpoints
+*.ipynb
+
 
 # VSCode
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,6 @@ target/
 .ipynb_checkpoints
 *.ipynb
 
-
 # VSCode
 .vscode
 


### PR DESCRIPTION
Add *.ipynb to .gitignore since we switched to .pct.py.

cc Gustavo Carvalho