### PR TITLE
Added code to clear cache for the Invert bijector.

### DIFF
--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -246,6 +246,8 @@ def reset_cache_bijectors(input_module: tf.Module) -> tf.Module:
         if isinstance(bijector, tfp.bijectors.Chain):
             for m in bijector.submodules:
                 clear_cache(m)
+        elif isinstance(bijector, tfp.bijectors.Invert):
+            clear_cache(bijector.bijector)
         return state
 
     _ = traverse_module(input_module, accumulator, clear_bijector, target_types)


### PR DESCRIPTION
To properly clear cache for the Invert bijector, we need to go into its contained bijector and clear that as well.