### PR TITLE
enable mypy on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,21 @@ runtest: &runtest
 version: 2.1
 
 jobs:
+  type-check:
+    docker:
+      - image: awav/tensorflow:2.1
+
+    steps:
+      - checkout
+      - run:
+          name: Install mypy
+          command: |
+            pip install mypy
+      - run:
+          name: Run type checker
+          command: |
+            mypy .
+
   unit-test:
     <<: *runtest
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,13 +26,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install mypy
-          command: |
-            pip install mypy
+          name: Install type checker
+          command: pip install mypy
       - run:
           name: Run type checker
-          command: |
-            mypy .
+          command: mypy .
 
   unit-test:
     <<: *runtest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,12 @@ jobs:
       - checkout
       - run:
           name: Install type checker
-          command: pip install mypy
+          command: |
+            pip install mypy
       - run:
           name: Run type checker
-          command: mypy .
+          command: |
+            mypy .
 
   unit-test:
     <<: *runtest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,10 @@ jobs:
       - checkout
       - run:
           name: Install type checker
-          command: |
-            pip install mypy
+          command: pip install mypy
       - run:
           name: Run type checker
-          command: |
-            mypy .
+          command: mypy .
 
   unit-test:
     <<: *runtest
@@ -118,6 +116,10 @@ workflows:
   version: 2.1
   build_test_and_deploy:
     jobs:
+      - type-check:
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
       - format-checker:
           filters:
             tags:

--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,8 @@ package:
 format:
 	black -t py36 -l 100 gpflow tests doc setup.py
 
+type-check:
+    mypy .
+
 test:
 	pytest -v --durations=10 tests/

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -107,7 +107,7 @@ class Parameter(tf.Module):
 
         self._transform = transform
         self.prior = prior
-        self.prior_on = prior_on
+        self._prior_on = PriorOn(value)
 
         if isinstance(value, tf.Variable):
             self._unconstrained = value

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -107,7 +107,7 @@ class Parameter(tf.Module):
 
         self._transform = transform
         self.prior = prior
-        self._prior_on = PriorOn(value)
+        self.prior_on = prior_on  # type: ignore  # see https://github.com/python/mypy/issues/3004
 
         if isinstance(value, tf.Variable):
             self._unconstrained = value

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,14 @@
 [mypy]
 ignore_missing_imports = True
+
+[mypy-gpflow.conditionals.*,gpflow.config.*,gpflow.covariances.*,gpflow.expectations.*]
+ignore_errors = True
+
+[mypy-gpflow.kernels.*,gpflow.models.*,gpflow.monitor.*,gpflow.optimizers.*,gpflow.utilities.*]
+ignore_errors = True
+
+[mypy-gpflow.mean_functions]
+ignore_errors = True
+
+[mypy-tests.*]
+ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,11 @@
 [mypy]
 ignore_missing_imports = True
 
+; the following modules are not passing mypy, so we're skipping them until they've been fixed up.
+; see github issue https://github.com/GPflow/GPflow/issues/1368 for more information. Note that some
+; modules that haven't had types added are passing anyway so may not appear below.
+;
+; remove modules from this skip list when types have been added
 [mypy-gpflow.conditionals.*,gpflow.config.*,gpflow.covariances.*,gpflow.expectations.*]
 ignore_errors = True
 

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,3 +1,4 @@
+mypy
 black
 pytest>=3.5.0
 pytest-random-order


### PR DESCRIPTION
does [this](https://github.com/GPflow/GPflow/issues/1368#issuecomment-628704285) so as to avoid regressions in types. Mypy will not block merge (for now at least). It should however show a warning