### PR TITLE
Workaround for tensorflow_probability==0.10 in gpflow.utilities.traverse_module

### DIFF
--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -421,10 +421,10 @@ def traverse_module(
             new_state = traverse_module(subterm, new_acc, update_cb, target_types)
     elif isinstance(m, tf.Module):
         items = vars(m)
-        if isinstance(m, tfp.bijectors.Bijector) and '_parameters' in items:
-            assert items['_parameters']['self'] is m
-            del items['_parameters']['self']  # avoid infinite recursion
-            del items['_parameters']  # fix other bug
+        if isinstance(m, tfp.bijectors.Bijector) and "_parameters" in items:
+            assert items["_parameters"]["self"] is m
+            del items["_parameters"]["self"]  # avoid infinite recursion
+            del items["_parameters"]  # fix other bug
         for name, submodule in vars(m).items():
             if name in tf.Module._TF_MODULE_IGNORED_PROPERTIES:
                 continue

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -406,19 +406,17 @@ def traverse_module(
     """
     path, state = acc
 
-    new_state = state
-
     if isinstance(m, target_types):
         return update_cb(m, path, state)
 
     if isinstance(m, (list, tuple)):
         for term_idx, subterm in enumerate(m):
-            new_acc = (f"{path}[{term_idx}]", new_state)
-            new_state = traverse_module(subterm, new_acc, update_cb, target_types)
+            new_acc = (f"{path}[{term_idx}]", state)
+            state = traverse_module(subterm, new_acc, update_cb, target_types)
     elif isinstance(m, dict):
         for term_idx, subterm in m.items():
-            new_acc = (f"{path}['{term_idx}']", new_state)
-            new_state = traverse_module(subterm, new_acc, update_cb, target_types)
+            new_acc = (f"{path}['{term_idx}']", state)
+            state = traverse_module(subterm, new_acc, update_cb, target_types)
     elif isinstance(m, tf.Module):
         module_vars = vars(m)
         if isinstance(m, tfp.bijectors.Bijector):
@@ -432,8 +430,8 @@ def traverse_module(
             if name in tf.Module._TF_MODULE_IGNORED_PROPERTIES:
                 continue
             new_acc = (f"{path}.{name}", new_state)
-            new_state = traverse_module(submodule, new_acc, update_cb, target_types)
-    return new_state
+            state = traverse_module(submodule, new_acc, update_cb, target_types)
+    return state
 
 
 @lru_cache()

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -420,6 +420,11 @@ def traverse_module(
             new_acc = (f"{path}['{term_idx}']", new_state)
             new_state = traverse_module(subterm, new_acc, update_cb, target_types)
     elif isinstance(m, tf.Module):
+        items = vars(m)
+        if isinstance(m, tfp.bijectors.Bijector) and '_parameters' in items:
+            assert items['_parameters']['self'] is m
+            del items['_parameters']['self']  # avoid infinite recursion
+            del items['_parameters']  # fix other bug
         for name, submodule in vars(m).items():
             if name in tf.Module._TF_MODULE_IGNORED_PROPERTIES:
                 continue

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -422,6 +422,11 @@ def traverse_module(
     elif isinstance(m, tf.Module):
         module_vars = vars(m)
         if isinstance(m, tfp.bijectors.Bijector):
+            # NOTE: tensorflow_probability 0.10 introduced a `_parameters`
+            # attribute that contains all arguments to a bijector, including
+            # "self", which naively leads to infinite recursion. We ignore the
+            # entire `_parameters` attribute, as they are also stored as
+            # explicit attributes in the bijector.
             module_vars = {name: module_vars[name] for name in module_vars if name != "_parameters"}
         for name, submodule in module_vars.items():
             if name in tf.Module._TF_MODULE_IGNORED_PROPERTIES:

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -420,12 +420,10 @@ def traverse_module(
             new_acc = (f"{path}['{term_idx}']", new_state)
             new_state = traverse_module(subterm, new_acc, update_cb, target_types)
     elif isinstance(m, tf.Module):
-        items = vars(m)
-        if isinstance(m, tfp.bijectors.Bijector) and "_parameters" in items:
-            assert items["_parameters"]["self"] is m
-            del items["_parameters"]["self"]  # avoid infinite recursion
-            del items["_parameters"]  # fix other bug
-        for name, submodule in vars(m).items():
+        module_vars = vars(m)
+        if isinstance(m, tfp.bijectors.Bijector):
+            module_vars = {name: module_vars[name] for name in module_vars if name != "_parameters"}
+        for name, submodule in module_vars.items():
             if name in tf.Module._TF_MODULE_IGNORED_PROPERTIES:
                 continue
             new_acc = (f"{path}.{name}", new_state)

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -406,17 +406,19 @@ def traverse_module(
     """
     path, state = acc
 
+    new_state = state
+
     if isinstance(m, target_types):
         return update_cb(m, path, state)
 
     if isinstance(m, (list, tuple)):
         for term_idx, subterm in enumerate(m):
-            new_acc = (f"{path}[{term_idx}]", state)
-            state = traverse_module(subterm, new_acc, update_cb, target_types)
+            new_acc = (f"{path}[{term_idx}]", new_state)
+            new_state = traverse_module(subterm, new_acc, update_cb, target_types)
     elif isinstance(m, dict):
         for term_idx, subterm in m.items():
-            new_acc = (f"{path}['{term_idx}']", state)
-            state = traverse_module(subterm, new_acc, update_cb, target_types)
+            new_acc = (f"{path}['{term_idx}']", new_state)
+            new_state = traverse_module(subterm, new_acc, update_cb, target_types)
     elif isinstance(m, tf.Module):
         module_vars = vars(m)
         if isinstance(m, tfp.bijectors.Bijector):
@@ -430,8 +432,8 @@ def traverse_module(
             if name in tf.Module._TF_MODULE_IGNORED_PROPERTIES:
                 continue
             new_acc = (f"{path}.{name}", new_state)
-            state = traverse_module(submodule, new_acc, update_cb, target_types)
-    return state
+            new_state = traverse_module(submodule, new_acc, update_cb, target_types)
+    return new_state
 
 
 @lru_cache()


### PR DESCRIPTION
This fixes a test failure in `test_freeze()` with tensorflow_probability==0.10. Note that this only showed up because of the test using a tf.Module() that *directly* contained a tfp.bijectors.Bijector instance - gpflow.Parameter instances that contain a bijector inside weren't affected as traverse_module() didn't try to peek inside their internals.

Looks like we'll need a 2.0.4 release next week...!
