### PR TITLE
Makefile quickfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+BLACK_CONFIG=-t py36 -l 100
+BLACK_TARGETS=gpflow tests doc setup.py
+
 .PHONY: help clean dev-install install package format test
 
 help:
@@ -21,10 +24,15 @@ package:
 	python setup.py bdist
 
 format:
-	black -t py36 -l 100 gpflow tests doc setup.py
+	black $(BLACK_CONFIG) $(BLACK_TARGETS)
+
+format-check:
+	black --check $(BLACK_CONFIG) $(BLACK_TARGETS)
 
 type-check:
-    mypy .
+	mypy .
 
-test:
+pytest:
 	pytest -v --durations=10 tests/
+
+test: format-check type-check pytest

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
 BLACK_CONFIG=-t py36 -l 100
 BLACK_TARGETS=gpflow tests doc setup.py
 
-.PHONY: help clean dev-install install package format test
+.PHONY: help clean dev-install install package format format-check type-check test check-all
 
 help:
 	@echo "The following make targets are available:"
 	@echo "	dev-install		install all dependencies for dev environment and sets a egg link to the project sources"
 	@echo "	install			install all dependencies and the project in the current environment"
 	@echo "	package			build pip package"
-	@echo "	test			run all tests in parallel"
 	@echo "	clean			removes package, build files and egg info"
+	@echo "	format			auto-format code"
+	@echo "	format-check		check that code has been formatted correctly"
+	@echo "	type-check		check that mypy is happy with type annotations"
+	@echo "	test			run all tests"
+	@echo "	check-all		run format-check, type-check, and test (as run by the continuous integration system)"
 
 clean:
 	rm -rf dist *.egg-info build
@@ -32,7 +36,7 @@ format-check:
 type-check:
 	mypy .
 
-pytest:
+test:
 	pytest -v --durations=10 tests/
 
-test: format-check type-check pytest
+check-all: format-check type-check test


### PR DESCRIPTION
#1471 unfortunately introduced a bug to the Makefile (spaces instead of tab for indenting) which makes it unusable. I've also added an extra test for formatting & turned `make test` into a target for all tests.