### PR TITLE
Alternative automatic API ref doc generation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -50,6 +50,8 @@ clean:
 
 .PHONY: html
 html:
+	rm -rf build
+	rm -rf source/_autosummary
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/doc/README.md
+++ b/doc/README.md
@@ -18,7 +18,7 @@ To compile the GPflow documentation locally:
 
 2. Install doc dependencies
    ```
-   pip install sphinx sphinx_rtd_theme numpydoc nbsphinx sphinx_autodoc_typehints ipython jupytext jupyter_client ipywidgets
+   pip install sphinx sphinx_rtd_theme numpydoc nbsphinx sphinx-autodoc-typehints sphinx-autopackagesummary ipython jupytext jupyter_client ipywidgets matplotlib sklearn tensorflow_datasets
    ```
 
 3. Install pandoc
@@ -27,9 +27,7 @@ To compile the GPflow documentation locally:
    ```
    If pandoc does not install via pip, or step 5 does not work, go to pandoc.org/installing.html (the PyPI package depends on the external system-wide installation of pandoc executables)
 
-4. Generate auto-generated files
-   * Notebooks (.ipynb): run `make -C source/notebooks -j 4` (here with 4 parallel threads)
-   * API documentation (.rst): run `python source/generate_module_rst.py`
+4. Generate Jupyter Notebooks (.ipynb): run `make -C source/notebooks -j 4` (here with 4 parallel threads)
 
 5. Compile the documentation
    ```
@@ -44,7 +42,6 @@ To compile the GPflow documentation locally:
 Upon each merge to the `develop` branch, this repository's [CircleCI configuration](../.circleci/config.yml) runs the `trigger-docs-generation` step
 which triggers a CircleCI build on the [GPflow/docs repository](https://github.com/GPflow/docs).
 This clones the latest GPflow develop branch and compiles all notebooks from jupytext to .ipynb
-(setting the `DOCS` environment variable so that notebook optimisations are run to convergence)
-and runs the `generate_module_rst.py` script as above to generate the .rst files for API documentation.
+(setting the `DOCS` environment variable so that notebook optimisations are run to convergence).
 (This script is run on CircleCI, instead of ReadTheDocs, as it requires gpflow and hence `tensorflow` and `tensorflow_probability` to be installed, but TensorFlow is too large to be installed inside the ReadTheDocs docker images.)
 ReadTheDocs then pulls in these auto-generated files as well as all other files within this doc/ directory to actually build the documentation using Sphinx.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,9 +1,11 @@
 gast==0.2.2
 ipython==7.8.0
-sphinx==2.2.0
-sphinx_autodoc_typehints==1.8.0
+sphinx==3.0.3
+sphinx-autodoc-typehints==1.10.3
+sphinx-autopackagesummary==1.3
+jupytext==1.4.2
 sphinx_rtd_theme==0.4.3
 numpydoc==0.9.1
-nbsphinx==0.4.3
+nbsphinx==0.7.0
 pandoc==1.0.2
 git+https://github.com/GPflow/GPflow.git@develop#egg=gpflow

--- a/doc/source/_templates/class.rst
+++ b/doc/source/_templates/class.rst
@@ -1,0 +1,39 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :inherited-members:
+   :show-inheritance:
+   {#:private-members:#}
+   {#:special-members:#}
+   {#:undoc-members:#}
+
+   {% block methods %}
+   {% if methods %}
+   .. rubric:: Class methods
+
+   .. autosummary::
+      :nosignatures:
+   {% for item in methods %}
+      {%- if not item.startswith('_') or item in ['__call__'] %}
+      ~{{ name }}.{{ item }}
+      {%- endif -%}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Class attributes
+
+   .. autosummary::
+      :nosignatures:
+   {% for item in attributes %}
+      {%- if not item.startswith('_') %}
+      ~{{ name }}.{{ item }}
+      {%- endif -%}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/doc/source/_templates/module.rst
+++ b/doc/source/_templates/module.rst
@@ -1,0 +1,51 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: Classes
+
+   .. autosummary::
+      :toctree: .
+      :nosignatures:
+      :template: class.rst
+   {% for item in classes %}
+      {%- if not item.startswith('_') %}
+      {{ item }}
+      {%- endif -%}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: Functions
+
+   .. autosummary::
+      :toctree: .
+      :nosignatures:
+   {% for item in functions %}
+      {#- if not item.startswith('_') #}
+      {{ item }}
+      {#- endif -#}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: Exceptions
+
+   .. autosummary::
+      :toctree: .
+      :nosignatures:
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   .. autopackagesummary:: {{ fullname }}
+      :toctree: .
+      :template: module.rst

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1,0 +1,10 @@
+API reference
+=============
+
+This table summarises the modules and subpackages in GPflow.
+
+To get started, check out the :class:`~gpflow.models.gpr.GPR` class.
+
+.. autopackagesummary:: gpflow
+   :toctree: _autosummary
+   :template: module.rst

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -24,8 +24,7 @@ GPflow Documentation
    derivations
 
 .. toctree::
-   :maxdepth: 3
-   :glob:
-   :caption: API:
+   :caption: API reference
+   :hidden:
 
-   gpflow/index
+   gpflow <api>


### PR DESCRIPTION
## Automatically generating API reference doc rather than using `generate_module_rst.py` file

### Description

Enhancement. There are pros and cos to this new method. See https://docs.google.com/document/d/1AIV8-nGOAzqzrzcA8mxpcgdGKDKyQ9wpjVweCyFbl1g/edit for a comparison with the current method.

### Minimal working example

To build the docs locally, don't run `generate_module_rst.py`. Instead, follow these instructions: https://github.com/JamesALeedham/GPflow/blob/33a89cb9b4ea23d57160492f27836d29691a4178/doc/README.md
