### PR TITLE
Allow users to pass an iterable to set_trainable

### DIFF
--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -1,7 +1,7 @@
 import copy
 import re
 from functools import lru_cache
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, Iterable
 
 import numpy as np
 import tensorflow as tf
@@ -44,12 +44,16 @@ def to_default_float(x):
     return cast(x, dtype=default_float())
 
 
-def set_trainable(model: tf.Module, flag: bool):
+def set_trainable(model: Union[tf.Module, Iterable[tf.Module]], flag: bool) -> None:
     """
-    Set trainable flag for all `tf.Variable`s and `gpflow.Parameter`s in a module.
+    Set trainable flag for all `tf.Variable`s and `gpflow.Parameter`s in a `tf.Module` or collection of
+    of `tf.Module`s.
     """
-    for variable in model.variables:
-        variable._trainable = flag
+    modules = [model] if isinstance(model, tf.Module) else model
+
+    for mod in modules:
+        for variable in mod.variables:
+            variable._trainable = flag
 
 
 def multiple_assign(module: tf.Module, parameters: Dict[str, tf.Tensor]):

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -46,7 +46,7 @@ def to_default_float(x):
 
 def set_trainable(model: Union[tf.Module, Iterable[tf.Module]], flag: bool) -> None:
     """
-    Set trainable flag for all `tf.Variable`s and `gpflow.Parameter`s in a `tf.Module` or collection of
+    Set trainable flag for all `tf.Variable`s and `gpflow.Parameter`s in a `tf.Module` or collection
     of `tf.Module`s.
     """
     modules = [model] if isinstance(model, tf.Module) else model

--- a/tests/gpflow/test_base_training.py
+++ b/tests/gpflow/test_base_training.py
@@ -102,17 +102,6 @@ def test_multiple_assign_fails_with_invalid_values(model, wrong_var_update_dict)
         multiple_assign(model, wrong_var_update_dict)
 
 
-def test_make_trainable(model):
-    """
-    Checks whether we `set_trainable()` can make parameters which are *not*
-    trainable trainable again.
-    """
-    set_trainable(model, False)
-    assert len(model.trainable_variables) == 0
-    set_trainable(model, True)
-    assert len(model.trainable_variables) == len(model.parameters)
-
-
 def test_dict_utilities(model):
     """
     Test both `parameter_dict()` and `read_values()`

--- a/tests/gpflow/utilities/test_set_trainable.py
+++ b/tests/gpflow/utilities/test_set_trainable.py
@@ -1,0 +1,42 @@
+import tensorflow as tf
+
+from gpflow import Parameter, set_trainable
+
+
+def _module() -> tf.Module:
+    class _Mod(tf.Module):
+        def __init__(self):
+            super().__init__()
+            self.var = tf.Variable(0.0)
+            self.param = Parameter(0.0)
+
+    assert len(_Mod().trainable_variables) == 2
+    assert len(_Mod().variables) == 2
+
+    return _Mod()
+
+
+def test_can_set_not_trainable():
+    module = _module()
+    set_trainable(module, False)
+    assert len(module.trainable_variables) == 0
+
+
+def test_can_set_not_trainable_then_trainable_again():
+    module = _module()
+    set_trainable(module, False)
+    set_trainable(module, True)
+    assert len(module.trainable_variables) == len(module.variables)
+
+
+def test_can_set_not_trainable_iterable():
+    modules = [_module(), _module(), _module()]
+    set_trainable(modules, False)
+    assert all(len(m.trainable_variables) == 0 for m in modules)
+
+
+def test_can_set_not_trainable_then_trainable_iterable():
+    modules = [_module(), _module(), _module()]
+    set_trainable(modules, False)
+    set_trainable(modules, True)
+    assert all(len(m.trainable_variables) == len(m.variables) for m in modules)

--- a/tests/gpflow/utilities/test_set_trainable.py
+++ b/tests/gpflow/utilities/test_set_trainable.py
@@ -10,10 +10,12 @@ def _module() -> tf.Module:
             self.var = tf.Variable(0.0)
             self.param = Parameter(0.0)
 
-    assert len(_Mod().trainable_variables) == 2
-    assert len(_Mod().variables) == 2
+    module = _Mod()
 
-    return _Mod()
+    assert len(module.trainable_variables) == 2
+    assert len(module.variables) == 2
+
+    return module
 
 
 def test_can_set_not_trainable():

--- a/tests/gpflow/utilities/test_utilities.py
+++ b/tests/gpflow/utilities/test_utilities.py
@@ -15,8 +15,8 @@ def _module() -> tf.Module:
     class _Mod(tf.Module):
         def __init__(self):
             super().__init__()
-            self.var = tf.Variable(0.)
-            self.param = Parameter(0.)
+            self.var = tf.Variable(0.0)
+            self.param = Parameter(0.0)
 
     assert len(_Mod().trainable_variables) == 2
     assert len(_Mod().variables) == 2

--- a/tests/gpflow/utilities/test_utilities.py
+++ b/tests/gpflow/utilities/test_utilities.py
@@ -4,50 +4,10 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 import gpflow
-from gpflow import Parameter
 from gpflow.config import Config, as_context
 from gpflow.models.util import data_input_to_tensor
-from gpflow.utilities import positive, triangular, set_trainable
+from gpflow.utilities import positive, triangular
 from gpflow.utilities.ops import difference_matrix
-
-
-def _module() -> tf.Module:
-    class _Mod(tf.Module):
-        def __init__(self):
-            super().__init__()
-            self.var = tf.Variable(0.0)
-            self.param = Parameter(0.0)
-
-    assert len(_Mod().trainable_variables) == 2
-    assert len(_Mod().variables) == 2
-
-    return _Mod()
-
-
-def test_can_set_not_trainable():
-    module = _module()
-    set_trainable(module, False)
-    assert len(module.trainable_variables) == 0
-
-
-def test_can_set_not_trainable_then_trainable_again():
-    module = _module()
-    set_trainable(module, False)
-    set_trainable(module, True)
-    assert len(module.trainable_variables) == len(module.variables)
-
-
-def test_can_set_not_trainable_iterable():
-    modules = [_module(), _module(), _module()]
-    set_trainable(modules, False)
-    assert all(len(m.trainable_variables) == 0 for m in modules)
-
-
-def test_can_set_not_trainable_then_trainable_iterable():
-    modules = [_module(), _module(), _module()]
-    set_trainable(modules, False)
-    set_trainable(modules, True)
-    assert all(len(m.trainable_variables) == len(m.variables) for m in modules)
 
 
 @pytest.mark.parametrize(

--- a/tests/gpflow/utilities/test_utilities.py
+++ b/tests/gpflow/utilities/test_utilities.py
@@ -13,15 +13,12 @@ from gpflow.utilities.ops import difference_matrix
 
 def _module() -> tf.Module:
     class _Mod(tf.Module):
-        class_var = tf.Variable(0.)
-        class_param = Parameter(1.)
-
         def __init__(self):
             super().__init__()
-            self.instance_var = tf.Variable(2.)
-            self.instance_param = Parameter(3.)
+            self.var = tf.Variable(0.)
+            self.param = Parameter(0.)
 
-    assert len(_Mod().trainable_variables) == 4
+    assert len(_Mod().trainable_variables) == 2
 
     return _Mod()
 
@@ -36,7 +33,7 @@ def test_can_set_not_trainable_then_trainable_again():
     module = _module()
     set_trainable(module, False)
     set_trainable(module, True)
-    assert len(module.trainable_variables) == 4
+    assert len(module.trainable_variables) == 2
 
 
 def test_can_set_not_trainable_iterable():
@@ -49,7 +46,7 @@ def test_can_set_not_trainable_then_trainable_iterable():
     modules = [_module(), _module(), _module()]
     set_trainable(modules, False)
     set_trainable(modules, True)
-    assert all(len(m.trainable_variables) == 4 for m in modules)
+    assert all(len(m.trainable_variables) == 2 for m in modules)
 
 
 @pytest.mark.parametrize(

--- a/tests/gpflow/utilities/test_utilities.py
+++ b/tests/gpflow/utilities/test_utilities.py
@@ -4,10 +4,52 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 import gpflow
+from gpflow import Parameter
 from gpflow.config import Config, as_context
 from gpflow.models.util import data_input_to_tensor
-from gpflow.utilities import positive, triangular
+from gpflow.utilities import positive, triangular, set_trainable
 from gpflow.utilities.ops import difference_matrix
+
+
+def _module() -> tf.Module:
+    class _Mod(tf.Module):
+        class_var = tf.Variable(0.)
+        class_param = Parameter(1.)
+
+        def __init__(self):
+            super().__init__()
+            self.instance_var = tf.Variable(2.)
+            self.instance_param = Parameter(3.)
+
+    assert len(_Mod().trainable_variables) == 4
+
+    return _Mod()
+
+
+def test_can_set_not_trainable():
+    module = _module()
+    set_trainable(module, False)
+    assert len(module.trainable_variables) == 0
+
+
+def test_can_set_not_trainable_then_trainable_again():
+    module = _module()
+    set_trainable(module, False)
+    set_trainable(module, True)
+    assert len(module.trainable_variables) == 4
+
+
+def test_can_set_not_trainable_iterable():
+    modules = [_module(), _module(), _module()]
+    set_trainable(modules, False)
+    assert all(len(m.trainable_variables) == 0 for m in modules)
+
+
+def test_can_set_not_trainable_then_trainable_iterable():
+    modules = [_module(), _module(), _module()]
+    set_trainable(modules, False)
+    set_trainable(modules, True)
+    assert all(len(m.trainable_variables) == 4 for m in modules)
 
 
 @pytest.mark.parametrize(

--- a/tests/gpflow/utilities/test_utilities.py
+++ b/tests/gpflow/utilities/test_utilities.py
@@ -19,6 +19,7 @@ def _module() -> tf.Module:
             self.param = Parameter(0.)
 
     assert len(_Mod().trainable_variables) == 2
+    assert len(_Mod().variables) == 2
 
     return _Mod()
 
@@ -33,7 +34,7 @@ def test_can_set_not_trainable_then_trainable_again():
     module = _module()
     set_trainable(module, False)
     set_trainable(module, True)
-    assert len(module.trainable_variables) == 2
+    assert len(module.trainable_variables) == len(module.variables)
 
 
 def test_can_set_not_trainable_iterable():
@@ -46,7 +47,7 @@ def test_can_set_not_trainable_then_trainable_iterable():
     modules = [_module(), _module(), _module()]
     set_trainable(modules, False)
     set_trainable(modules, True)
-    assert all(len(m.trainable_variables) == 2 for m in modules)
+    assert all(len(m.trainable_variables) == len(m.variables) for m in modules)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Allows users to specify an iterable of `tf.Module`s on which to set `tf.Variable`s as trainable, like
```python3
set_trainable([model.q_mu, model.q_sqrt], False)
```