### PR TITLE
improve NaturalGradient optimizer documentation and add shape checks

### DIFF
--- a/doc/source/notebooks/advanced/natural_gradients.pct.py
+++ b/doc/source/notebooks/advanced/natural_gradients.pct.py
@@ -74,6 +74,7 @@ gpr.log_marginal_likelihood().numpy()
 
 # %%
 vgp = VGP(data, kernel=gpflow.kernels.Matern52(), likelihood=gpflow.likelihoods.Gaussian())
+# (Note that GPflow's NaturalGradient optimizer does not implement diagonal covariance parametrization, i.e., it does not work for `q_diag=True`.)
 
 # %% [markdown]
 # The log marginal likelihood lower bound (evidence lower bound or ELBO) of the approximate GP model is:


### PR DESCRIPTION
As discussed in #878, GPflow's NaturalGradient optimizer does not implement the diagonal covariance parametrization (`q_diag=True`). This PR clarifies this in the documentation and adds extra shape checks.