### PR TITLE
Ensure the plots appear in the generated VFF documentation

### DIFF
--- a/doc/source/notebooks/advanced/variational_fourier_features.pct.py
+++ b/doc/source/notebooks/advanced/variational_fourier_features.pct.py
@@ -42,7 +42,7 @@ LowRank = tf.linalg.LinearOperatorLowRankUpdate
 # %%
 import matplotlib.pyplot as plt
 
-# %matplotlib notebook
+# %matplotlib inline
 
 # %% [markdown]
 # The VFF inducing variables are defined as a projection $u_m = \mathcal{P}_{\phi_m}(f)$ (eq. (59)) of the GP $f(\cdot)$ onto a truncated Fourier basis, $\phi_m = [1, \cos(\omega_1(x-a)),\dots,\cos(\omega_M(x-a)),\sin(\omega_1(x-a)),\dots,\sin(\omega_M(x-a))]$ (eq. (47)). To represent this we define a new inducing variables class that derives from the `InducingVariables` base class.


### PR DESCRIPTION
The generated documentation for the VFF model does not have show any of the plots. This is due to a difference between Jupyter notebooks and the Sphinx-generated documents. 

In a Jupyter notebook the following magic function call declares that the plots appear in an interactive cell:
`# %matplotlib notebook` 
and the following declares that the plots are static:
`# %matplotlib inline`.

Unfortunately the Sphinx documentation does not support the interactive plotting, and so the default behaviour is to ignore the plots completely.

This PR replaces the first matplotlib function call with the second.