### PR TITLE
Allow conditionals to be computed based on pre-computed Kmm and Lm

### DIFF
--- a/gpflow/conditionals/conditionals.py
+++ b/gpflow/conditionals/conditionals.py
@@ -23,7 +23,7 @@ def _conditional(
     q_sqrt=None,
     white=False,
     Kmm=None,
-    Lm=None
+    Lm=None,
 ):
     """
     Single-output GP conditional.
@@ -82,7 +82,7 @@ def _conditional(
     q_sqrt=None,
     white=False,
     Kmm=None,
-    Lm=None
+    Lm=None,
 ):
     """
     Given f, representing the GP at the points X, produce the mean and
@@ -126,7 +126,8 @@ def _conditional(
         Kmm = kernel(X) + eye(tf.shape(X)[-2], value=default_jitter(), dtype=X.dtype)  # [..., M, M]
     Kmn = kernel(X, Xnew)  # [M, ..., N]
     Knn = kernel(Xnew, full_cov=full_cov)  # [..., N] (full_cov = False) or [..., N, N] (True)
-    mean, var = base_conditional(Kmn, Kmm, Knn, f, full_cov=full_cov, q_sqrt=q_sqrt,
-                                 white=white, Lm=Lm)
+    mean, var = base_conditional(
+        Kmn, Kmm, Knn, f, full_cov=full_cov, q_sqrt=q_sqrt, white=white, Lm=Lm
+    )
 
     return mean, var  # [N, R], [N, R] or [R, N, N]

--- a/gpflow/conditionals/multioutput/conditionals.py
+++ b/gpflow/conditionals/multioutput/conditionals.py
@@ -135,12 +135,14 @@ def separate_independent_conditional(
 
     def single_gp_conditional(t):
         Kmm, Kmn, Knn, f, q_sqrt, Lm = t
-        return base_conditional(Kmn, Kmm, Knn, f, full_cov=full_cov, q_sqrt=q_sqrt, white=white,
-                                Lm=Lm)
+        return base_conditional(
+            Kmn, Kmm, Knn, f, full_cov=full_cov, q_sqrt=q_sqrt, white=white, Lm=Lm
+        )
 
     rmu, rvar = tf.map_fn(
-        single_gp_conditional, (Kmms, Kmns, Knns, fs, q_sqrts, Lms),
-        (default_float(), default_float())
+        single_gp_conditional,
+        (Kmms, Kmns, Knns, fs, q_sqrts, Lms),
+        (default_float(), default_float()),
     )  # [P, N, 1], [P, 1, N, N] or [P, N, 1]
 
     fmu = rollaxis_left(tf.squeeze(rmu, axis=-1), 1)  # [N, P]
@@ -202,7 +204,7 @@ def fallback_independent_latent_conditional(
         full_output_cov=full_output_cov,
         q_sqrt=q_sqrt,
         white=white,
-        Lm=Lm
+        Lm=Lm,
     )
 
 

--- a/gpflow/conditionals/multioutput/sample_conditionals.py
+++ b/gpflow/conditionals/multioutput/sample_conditionals.py
@@ -23,6 +23,8 @@ def _sample_conditional(
     q_sqrt=None,
     white=False,
     num_samples=None,
+    Kmm=None,
+    Lm=None,
 ):
     """
     `sample_conditional` will return a sample from the conditinoal distribution.
@@ -41,7 +43,7 @@ def _sample_conditional(
         object, SeparateIndependentInducingVariables, SeparateIndependent, object
     )
     g_mu, g_var = ind_conditional(
-        Xnew, inducing_variable, kernel, f, white=white, q_sqrt=q_sqrt
+        Xnew, inducing_variable, kernel, f, white=white, q_sqrt=q_sqrt, Kmm=Kmm, Lm=Lm
     )  # [..., N, L], [..., N, L]
     g_sample = sample_mvn(g_mu, g_var, full_cov, num_samples=num_samples)  # [..., (S), N, L]
     f_mu, f_var = mix_latent_gp(kernel.W, g_mu, g_var, full_cov, full_output_cov)

--- a/gpflow/conditionals/sample_conditionals.py
+++ b/gpflow/conditionals/sample_conditionals.py
@@ -19,6 +19,8 @@ def _sample_conditional(
     q_sqrt=None,
     white=False,
     num_samples=None,
+    Kmm=None,
+    Lm=None,
 ):
     """
     `sample_conditional` will return a sample from the conditional distribution.
@@ -44,6 +46,8 @@ def _sample_conditional(
         white=white,
         full_cov=full_cov,
         full_output_cov=full_output_cov,
+        Kmm=Kmm,
+        Lm=Lm
     )
     if full_cov:
         # mean: [..., N, P]

--- a/gpflow/conditionals/sample_conditionals.py
+++ b/gpflow/conditionals/sample_conditionals.py
@@ -47,7 +47,7 @@ def _sample_conditional(
         full_cov=full_cov,
         full_output_cov=full_output_cov,
         Kmm=Kmm,
-        Lm=Lm
+        Lm=Lm,
     )
     if full_cov:
         # mean: [..., N, P]

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -14,6 +14,7 @@ def base_conditional(
     full_cov=False,
     q_sqrt: Optional[tf.Tensor] = None,
     white=False,
+    Lm=None
 ):
     r"""
     Given a g1 and g2, and distribution p and q such that
@@ -36,6 +37,8 @@ def base_conditional(
     :param q_sqrt: If this is a Tensor, it must have shape [R, M, M] (lower
         triangular) or [M, R] (diagonal)
     :param white: bool
+    :param Lm: The cholesky decomposition of `Kmm`, of shape[M, M]. If this is not provided then
+    it is computed within this function. Passing this in may improve performance.
     :return: [N, R]  or [R, N, N]
     """
     # compute kernel stuff
@@ -75,7 +78,8 @@ def base_conditional(
     )
 
     leading_dims = tf.shape(Kmn)[:-2]
-    Lm = tf.linalg.cholesky(Kmm)  # [M, M]
+    if Lm is None:
+        Lm = tf.linalg.cholesky(Kmm)  # [M, M]
 
     # Compute the projection matrix A
     Lm = tf.broadcast_to(Lm, tf.concat([leading_dims, tf.shape(Lm)], 0))  # [..., M, M]

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -334,7 +334,7 @@ def fully_correlated_conditional(
         full_output_cov=full_output_cov,
         q_sqrt=q_sqrt,
         white=white,
-        Lm=Lm
+        Lm=Lm,
     )
     return tf.squeeze(mean, axis=0), tf.squeeze(var, axis=0)
 

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -14,7 +14,7 @@ def base_conditional(
     full_cov=False,
     q_sqrt: Optional[tf.Tensor] = None,
     white=False,
-    Lm=None
+    Lm=None,
 ):
     r"""
     Given a g1 and g2, and distribution p and q such that


### PR DESCRIPTION
## PR content:

* [Title](#title)
* [Description](#description)

### Title

Allow conditionals to be computed based on pre-computed `Kmm` and `Lm`

### Description

This PR allows conditionals to be computed based on pre-computed values for `Kmm` and `Lm`. This allows the performance of, for example, prediction to be improved by passing these pre-computed values into the conditionals calculation, instead of calculating these each time. 

I can add some tests if you think this is a reasonable approach.