### PR TITLE
Adding heteroskedastic tests

### DIFF
--- a/doc/source/notebooks/advanced/heteroskedastic.pct.py
+++ b/doc/source/notebooks/advanced/heteroskedastic.pct.py
@@ -22,7 +22,7 @@
 #
 #
 # ## Heteroskedastic Regression
-# This notebooks shows how to construct a model which uses multiple (2) GP latent functions to learn both the location and the scale and of the Gaussian likelihood distribution. It does so by connecting a **Multi-Output Kernel**, which generates multiple GP latent functions, to a **Heteroskedastic Likelihood**, which maps the latent GPs into a single likelihood.
+# This notebooks shows how to construct a model which uses multiple (2) GP latent functions to learn both the location and the scale of the Gaussian likelihood distribution. It does so by connecting a **Multi-Output Kernel**, which generates multiple GP latent functions, to a **Heteroskedastic Likelihood**, which maps the latent GPs into a single likelihood.
 #
 # The generative model is described as:
 #

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -72,7 +72,7 @@ def test_predict_mean_and_var():
     )
 
 
-@pytest.skip("Conditional mean is not implemented in heteroskedastic likelihood")
+@pytest.mark.skip("Conditional mean is not implemented in heteroskedastic likelihood")
 def test_conditional_mean():
     l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
@@ -82,7 +82,7 @@ def test_conditional_mean():
     )
 
 
-@pytest.skip("Conditional variance is not implemented in heteroskedastic likelihood")
+@pytest.mark.skip("Conditional variance is not implemented in heteroskedastic likelihood")
 def test_conditional_variance():
     l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
@@ -92,7 +92,7 @@ def test_conditional_variance():
     )
 
 
-@pytest.skip("Currently broken as it returns the sum over outputs when given multiple outputs")
+@pytest.mark.skip("Currently broken as it returns the sum over outputs when given multiple outputs")
 def test_predict_log_density():
     l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import numpy as np
+import pytest
 import tensorflow as tf
 import tensorflow_probability as tfp
 
@@ -71,6 +72,7 @@ def test_predict_mean_and_var():
     )
 
 
+@pytest.skip("Conditional mean is not implemented in heteroskedastic likelihood")
 def test_conditional_mean():
     l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
@@ -80,6 +82,7 @@ def test_conditional_mean():
     )
 
 
+@pytest.skip("Conditional variance is not implemented in heteroskedastic likelihood")
 def test_conditional_variance():
     l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
@@ -89,6 +92,7 @@ def test_conditional_variance():
     )
 
 
+@pytest.skip("Currently broken as it returns the sum over outputs when given multiple outputs")
 def test_predict_log_density():
     l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -25,23 +25,22 @@ tf.random.set_seed(99012)
 
 class Data:
     g_var = 0.345
-    # toData.Y data: shape [N, 1]
-    Y = np.c_[0.5, 0.4, 1.0].T
-    N, _ = Y.shape
+    rng = np.random.RandomState(123)
+    N = 5
+    Y = rng.randn(N, 1)
     # single "GP" (for the mean):
-    f_mean = np.c_[0.4, 0.7, 0.9].T
-    f_var = np.c_[0.7, 0.2, 1.3].T
+    f_mean = rng.randn(N, 1)
+    f_var = rng.uniform(0.1, 1.0, (N, 1))  # must be positive
     equivalent_f2 = np.log(np.sqrt(g_var))
-    F2_mean = np.full((N, 1), equivalent_f2)
+    f2_mean = np.full((N, 1), equivalent_f2)
     f2_var = np.zeros((N, 1))
-    # stacked N x 2 arraData.Ys
-    F2_mean = np.c_[f_mean, F2_mean]
+    F2_mean = np.c_[f_mean, f2_mean]
     F2_var = np.c_[f_var, f2_var]
 
 
 def test_log_prob():
     """
-    heteroskedastic likelihood where the variance parameter is alwaData.Ys constant
+    heteroskedastic likelihood where the variance parameter is always constant
      giving the same answers for variational_expectations, predict_mean_and_var,
       etc as the regular Gaussian  likelihood
     """

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -84,8 +84,8 @@ def test_conditional_variance():
     l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
     np.testing.assert_allclose(
-        l1.conditional_mean(Data.f_mean),
-        l2.conditional_mean(Data.F2_mean),
+        l1.conditional_variance(Data.f_mean),
+        l2.conditional_variance(Data.F2_mean),
     )
 
 

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -31,7 +31,7 @@ class Data:
     # single "GP" (for the mean):
     f_mean = np.c_[0.4, 0.7, 0.9].T
     f_var = np.c_[0.7, 0.2, 1.3].T
-    equivalent_f2 = np.log(np.sqrt(0.345))
+    equivalent_f2 = np.log(np.sqrt(g_var))
     F2_mean = np.full((N, 1), equivalent_f2)
     f2_var = np.zeros((N, 1))
     # stacked N x 2 arraData.Ys

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -21,75 +21,78 @@ from gpflow.likelihoods.heteroskedastic import HeteroskedasticTFPDistribution
 
 tf.random.set_seed(99012)
 
-# toy data: shape [N, 1]
-Y = np.c_[0.5, 0.4, 1.0].T
-N, _ = Y.shape
-# single "GP" (for the mean):
-f_mean = np.c_[0.4, 0.7, 0.9].T
-f_var = np.c_[0.7, 0.2, 1.3].T
-equivalent_f2 = np.log(np.sqrt(0.345))
-f2_mean = np.full((N, 1), equivalent_f2)
-f2_var = np.zeros((N, 1))
-# stacked N x 2 arrays
-F2_mean = np.c_[f_mean, f2_mean]
-F2_var = np.c_[f_var, f2_var]
+
+class Data:
+    g_var = 0.345
+    # toData.Y data: shape [N, 1]
+    Y = np.c_[0.5, 0.4, 1.0].T
+    N, _ = Y.shape
+    # single "GP" (for the mean):
+    f_mean = np.c_[0.4, 0.7, 0.9].T
+    f_var = np.c_[0.7, 0.2, 1.3].T
+    equivalent_f2 = np.log(np.sqrt(0.345))
+    F2_mean = np.full((N, 1), equivalent_f2)
+    f2_var = np.zeros((N, 1))
+    # stacked N x 2 arraData.Ys
+    F2_mean = np.c_[f_mean, F2_mean]
+    F2_var = np.c_[f_var, f2_var]
 
 
 def test_log_prob():
     """
-    heteroskedastic likelihood where the variance parameter is always constant
+    heteroskedastic likelihood where the variance parameter is alwaData.Ys constant
      giving the same answers for variational_expectations, predict_mean_and_var,
       etc as the regular Gaussian  likelihood
     """
-    l1 = gpflow.likelihoods.Gaussian(variance=0.345)
+    l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
     np.testing.assert_allclose(
-        l1.log_prob(f_mean, Y),
-        l2.log_prob(F2_mean, Y),
+        l1.log_prob(Data.f_mean, Data.Y),
+        l2.log_prob(Data.F2_mean, Data.Y),
     )
 
 
 def test_variational_expectations():
     # Create likelihoods
-    l1 = gpflow.likelihoods.Gaussian(variance=0.345)
+    l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
     np.testing.assert_allclose(
-        l1.variational_expectations(f_mean, f_var, Y),
-        l2.variational_expectations(F2_mean, F2_var, Y),
+        l1.variational_expectations(Data.f_mean, Data.f_var, Data.Y),
+        l2.variational_expectations(Data.F2_mean, Data.F2_var, Data.Y),
     )
 
 
 def test_predict_mean_and_var():
-    l1 = gpflow.likelihoods.Gaussian(variance=0.345)
+    l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
     np.testing.assert_allclose(
-        l1.predict_mean_and_var(f_mean, f_var),
-        l2.predict_mean_and_var(F2_mean, F2_var),
+        l1.predict_mean_and_var(Data.f_mean, Data.f_var),
+        l2.predict_mean_and_var(Data.F2_mean, Data.F2_var),
     )
 
 
 def test_conditional_mean():
-    l1 = gpflow.likelihoods.Gaussian(variance=0.345)
+    l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
     np.testing.assert_allclose(
-        l1.conditional_mean(f_mean),
-        l2.conditional_mean(F2_mean),
+        l1.conditional_mean(Data.f_mean),
+        l2.conditional_mean(Data.F2_mean),
     )
 
 
 def test_conditional_variance():
-    l1 = gpflow.likelihoods.Gaussian(variance=0.345)
+    l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
     np.testing.assert_allclose(
-        l1.conditional_mean(f_mean),
-        l2.conditional_mean(F2_mean),
+        l1.conditional_mean(Data.f_mean),
+        l2.conditional_mean(Data.F2_mean),
     )
 
 
 def test_predict_log_density():
-    l1 = gpflow.likelihoods.Gaussian(variance=0.345)
+    l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
     np.testing.assert_allclose(
-        l1.predict_log_density(f_mean, f_var, Y),
-        l2.predict_log_density(F2_mean, f2_var, Y),
+        l1.predict_log_density(Data.f_mean, Data.f_var, Data.Y),
+        l2.predict_log_density(Data.F2_mean, Data.f2_var, Data.Y),
     )

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -47,8 +47,7 @@ def test_log_prob():
     l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
     np.testing.assert_allclose(
-        l1.log_prob(Data.f_mean, Data.Y),
-        l2.log_prob(Data.F2_mean, Data.Y),
+        l1.log_prob(Data.f_mean, Data.Y), l2.log_prob(Data.F2_mean, Data.Y),
     )
 
 
@@ -76,8 +75,7 @@ def test_conditional_mean():
     l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
     np.testing.assert_allclose(
-        l1.conditional_mean(Data.f_mean),
-        l2.conditional_mean(Data.F2_mean),
+        l1.conditional_mean(Data.f_mean), l2.conditional_mean(Data.F2_mean),
     )
 
 
@@ -86,8 +84,7 @@ def test_conditional_variance():
     l1 = gpflow.likelihoods.Gaussian(variance=Data.g_var)
     l2 = HeteroskedasticTFPDistribution(tfp.distributions.Normal)
     np.testing.assert_allclose(
-        l1.conditional_variance(Data.f_mean),
-        l2.conditional_variance(Data.F2_mean),
+        l1.conditional_variance(Data.f_mean), l2.conditional_variance(Data.F2_mean),
     )
 
 


### PR DESCRIPTION
This adds some tests to @st-- 's heteroskedastic branch.
These tests ensure that heteroskedastic likelihood with a constant variance, will give the same results as a Gaussian likelihood with the same variance.

3 of these tests are failing and currently skipped.
- `conditional_mean()` and `conditional_variance()` tests are skipped because they are not implemented in Heteroskedastic likelihood, which cause the tests to fail. I've [asked in GPFlow slack](https://gpflow.slack.com/archives/C0118UMH14N/p1591888632015800) as to whether anyone uses these directly.
- `predict_log_density()` test is skipped because it does not return the same result, as it returns the sum over outputs when given multiple outputs. I have also [asked about this in GPFlow slack](https://gpflow.slack.com/archives/C0118UMH14N/p1592230688019100).
