### PR TITLE
Temporary workaround for tensorflow_probability dependency issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     "multipledispatch>=0.6",
     "tabulate",
     "typing_extensions",
-    "cloudpickle==1.3.0",  # Temporary workaround for tensorflow/probability#991
+    "cloudpickle==1.3.0",  # temporary workaround for tensorflow/probability#991
 ]
 
 if sys.version_info < (3, 7):

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requirements = [
     "multipledispatch>=0.6",
     "tabulate",
     "typing_extensions",
+    "cloudpickle==1.3.0",  # temporary workaround for tensorflow/probability#991
 ]
 
 if sys.version_info < (3, 7):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     "multipledispatch>=0.6",
     "tabulate",
     "typing_extensions",
-    "cloudpickle==1.3.0",  # temporary workaround for tensorflow/probability#991
+    "cloudpickle==1.3.0",  # Temporary workaround for tensorflow/probability#991
 ]
 
 if sys.version_info < (3, 7):


### PR DESCRIPTION
**PR type:** Temporary bugfix

**Related issue(s)/PRs:** tensorflow/probability#991 tensorflow/probability#993

## Summary

cloudpickle changed their namespacing in the latest, recently released 1.5.0 version, which is no longer compatible with tensorflow_probability. This is a temporary fix to get our build running again, until tfp publishes their next release.

**What alternatives have you considered?**
Pausing all PR activity until the next tfp release...

## PR checklist
- [X] I ran the black formatter (`make format`)

### Release notes
Should be reverted before the next release.