### PR TITLE
Likelihood quadrature cleanup

### DIFF
--- a/doc/source/notebooks/advanced/heteroskedastic.pct.py
+++ b/doc/source/notebooks/advanced/heteroskedastic.pct.py
@@ -95,6 +95,7 @@ def plot_distribution(X, Y, loc, scale):
     plt.show()
     plt.close()
 
+
 plot_distribution(X, Y, loc, scale)
 
 
@@ -184,10 +185,12 @@ natgrad_opt = gpf.optimizers.NaturalGradient(gamma=0.1)
 adam_vars = model.trainable_variables
 adam_opt = tf.optimizers.Adam(0.01)
 
+
 @tf.function
 def optimisation_step():
     natgrad_opt.minimize(loss_fn, variational_vars)
     adam_opt.minimize(loss_fn, adam_vars)
+
 
 # %% [markdown]
 # # Run Optimization Loop

--- a/doc/source/notebooks/advanced/heteroskedastic.pct.py
+++ b/doc/source/notebooks/advanced/heteroskedastic.pct.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.4.2
+#       jupytext_version: 1.6.0
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -18,11 +18,11 @@
 
 # %% [markdown]
 # ## Standard (Homoskedastic) Regression
-# In standard GP Regression, the GP latent function is used to learn the location parameter of a likelihood distribution (usually a Gaussian) as a function of the input $x$, whereas the scale parameter is considered constant. This is a homoskedastic model, which is unable to capture variations of the noise distribution with the input $x$.
+# In standard GP regression, the GP latent function is used to learn the location parameter of a likelihood distribution (usually a Gaussian) as a function of the input $x$, whereas the scale parameter is considered constant. This is a homoskedastic model, which is unable to capture variations of the noise distribution with the input $x$.
 #
 #
 # ## Heteroskedastic Regression
-# This notebooks shows how to construct a model which uses multiple (2) GP latent functions to learn both the location and the scale of the Gaussian likelihood distribution. It does so by connecting a **Multi-Output Kernel**, which generates multiple GP latent functions, to a **Heteroskedastic Likelihood**, which maps the latent GPs into a single likelihood.
+# This notebooks shows how to construct a model which uses multiple (here two) GP latent functions to learn both the location and the scale of the Gaussian likelihood distribution. It does so by connecting a **Multi-Output Kernel**, which generates multiple GP latent functions, to a **Heteroskedastic Likelihood**, which maps the latent GPs into a single likelihood.
 #
 # The generative model is described as:
 #
@@ -30,28 +30,28 @@
 # $$ f_2(x) \sim \mathcal{GP}(0, k_2(\cdot, \cdot)) $$
 # $$ \text{loc}(x) = f_1(x) $$
 # $$ \text{scale}(x) = \text{transform}(f_2(x)) $$
-# $$ y_i|f_1, f_2, x_i \sim \mathcal{N}(\text{loc}(x_i),\;\text{scale}^2(x_i))$$
+# $$ y_i|f_1, f_2, x_i \sim \mathcal{N}(\text{loc}(x_i),\;\text{scale}(x_i)^2)$$
 #
-# Where the function $\text{transform}$ is used to map the GP $f_2$ to **positive-only values**, which is required as it represent the $\text{scale}$ of a Gaussian likelihood. In this notebook, the $\exp$ function will be used as the $\text{transform}$. An alternative would be the $\text{softplus}$ function.
+# The function $\text{transform}$ is used to map from the unconstrained GP $f_2$ to **positive-only values**, which is required as it represents the $\text{scale}$ of a Gaussian likelihood. In this notebook, the $\exp$ function will be used as the $\text{transform}$. Other positive transforms such as the $\text{softplus}$ function can also be used.
 
 # %%
+import matplotlib.pyplot as plt
 import numpy as np
-import gpflow as gpf
 import tensorflow as tf
 import tensorflow_probability as tfp
-import matplotlib.pyplot as plt
+import gpflow as gpf
 
 
 # %% [markdown]
 # # Data Generation
-# We generate some heteroskedastic data by substituting the random latent functions $f_1$ and $f_2$ of the generative model by deterministic $\sin$ and $\cos$ functions. The input $X$ is built with $N=1001$ uniformly spaced values in the interval $[0, 4\pi]$. The outputs $Y$ are still sampled from a Gaussian likelihood.
+# We generate heteroskedastic data by substituting the random latent functions $f_1$ and $f_2$ of the generative model by deterministic $\sin$ and $\cos$ functions. The input $X$ is built with $N=1001$ uniformly spaced values in the interval $[0, 4\pi]$. The outputs $Y$ are still sampled from a Gaussian likelihood.
 #
 # $$ x_i \in [0, 4\pi], \quad i = 1,\dots,N $$
 # $$ f_1(x) = \sin(x) $$
 # $$ f_2(x) = \cos(x) $$
 # $$ \text{loc}(x) = f_1(x) $$
 # $$ \text{scale}(x) = \exp(f_2(x)) $$
-# $$ y_i|x_i \sim \mathcal{N}(\text{loc}(x_i),\;\text{scale}^2(x_i))$$
+# $$ y_i|x_i \sim \mathcal{N}(\text{loc}(x_i),\;\text{scale}(x_i)^2)$$
 
 # %%
 N = 1001
@@ -71,29 +71,31 @@ transform = np.exp
 
 # Compute loc and scale as functions of input X
 loc = f1(X)
-variance = transform(f2(X))
-scale = variance ** 0.5
+scale = transform(f2(X))
 
 # Sample outputs Y from Gaussian Likelihood
 Y = np.random.normal(loc, scale)
 
 # %% [markdown]
 # # Plot Data
-# Note how the distribution density (shaded area) and the outputs $Y$ are more/less scatered depending on the input $X$.
+# Note how the distribution density (shaded area) and the outputs $Y$ both change depending on the input $X$.
 
 # %%
-plt.figure(figsize=(15, 5))
-for k in (1, 2):
+def plot_distribution(X, Y, loc, scale):
+    plt.figure(figsize=(15, 5))
     x = X.squeeze()
-    lb = (loc - k * scale).squeeze()
-    ub = (loc + k * scale).squeeze()
-    plt.fill_between(x, lb, ub, color="silver", alpha=1 - 0.05 * k ** 3)
-plt.plot(x, lb, color="silver")
-plt.plot(x, ub, color="silver")
-plt.plot(X, loc, color="black")
-plt.scatter(X, Y, color="gray", alpha=0.8)
-plt.show()
-plt.close()
+    for k in (1, 2):
+        lb = (loc - k * scale).squeeze()
+        ub = (loc + k * scale).squeeze()
+        plt.fill_between(x, lb, ub, color="silver", alpha=1 - 0.05 * k ** 3)
+    plt.plot(x, lb, color="silver")
+    plt.plot(x, ub, color="silver")
+    plt.plot(X, loc, color="black")
+    plt.scatter(X, Y, color="gray", alpha=0.8)
+    plt.show()
+    plt.close()
+
+plot_distribution(X, Y, loc, scale)
 
 
 # %% [markdown]
@@ -104,12 +106,12 @@ plt.close()
 # This implements the following part of the generative model:
 # $$ \text{loc}(x) = f_1(x) $$
 # $$ \text{scale}(x) = \text{transform}(f_2(x)) $$
-# $$ y_i|f_1, f_2, x_i \sim \mathcal{N}(\text{loc}(x_i),\;\text{scale}^2(x_i))$$
+# $$ y_i|f_1, f_2, x_i \sim \mathcal{N}(\text{loc}(x_i),\;\text{scale}(x_i)^2)$$
 
 # %%
 likelihood = gpf.likelihoods.HeteroskedasticTFPConditional(
     distribution_class=tfp.distributions.Normal,  # Gaussian Likelihood
-    transform=tfp.bijectors.Exp(),  # Exponential Transform
+    scale_transform=tfp.bijectors.Exp(),  # Exponential Transform
 )
 
 print(f"Likelihood's expected latent_dim: {likelihood.latent_dim}")
@@ -119,16 +121,16 @@ print(f"Likelihood's expected latent_dim: {likelihood.latent_dim}")
 # This implements the following part of the generative model:
 # $$ f_1(x) \sim \mathcal{GP}(0, k_1(\cdot, \cdot)) $$
 # $$ f_2(x) \sim \mathcal{GP}(0, k_2(\cdot, \cdot)) $$
-# with both kernels being modeled as separated and independent $\text{RBF}$ kernels.
+# with both kernels being modeled as separate and independent $\text{SquaredExponential}$ kernels.
 
 # %%
 kernel = gpf.kernels.SeparateIndependent(
     [
-        gpf.kernels.RBF(),  # This is k1, the kernel of f1
-        gpf.kernels.RBF(),  # this is k2, the kernel of f2
+        gpf.kernels.SquaredExponential(),  # This is k1, the kernel of f1
+        gpf.kernels.SquaredExponential(),  # this is k2, the kernel of f2
     ]
 )
-# The list contained in gpf.kernels.SeparateIndependent must be the same size of likelihood.latent_dim
+# The number of kernels contained in gpf.kernels.SeparateIndependent must be the same as likelihood.latent_dim
 
 # %% [markdown]
 # # Inducing Points
@@ -149,13 +151,12 @@ inducing_variable = gpf.inducing_variables.SeparateIndependentInducingVariables(
         gpf.inducing_variables.InducingPoints(Z),  # This is U2 = f2(Z2)
     ]
 )
-# The list contained in gpf.kernels.SeparateIndependent must be the same size of likelihood.latent_dim
 
 # %% [markdown]
 # ## SVGP Model
-# Build the **SVGP** model by composing composing the **Kernel**, the **Likelihood** and the **Inducing Variables**.
+# Build the **SVGP** model by composing the **Kernel**, the **Likelihood** and the **Inducing Variables**.
 #
-# Note that the model needs to be instructed about the number of latent GPs by passing `num_latent_gps=likelihood.latent_dim`
+# Note that the model needs to be instructed about the number of latent GPs by passing `num_latent_gps=likelihood.latent_dim`.
 
 # %%
 model = gpf.models.SVGP(
@@ -178,10 +179,15 @@ gpf.utilities.set_trainable(model.q_mu, False)
 gpf.utilities.set_trainable(model.q_sqrt, False)
 
 variational_vars = [(model.q_mu, model.q_sqrt)]
-natgrad_opt = gpf.optimizers.NaturalGradient(gamma=0.01)
+natgrad_opt = gpf.optimizers.NaturalGradient(gamma=0.1)
 
 adam_vars = model.trainable_variables
 adam_opt = tf.optimizers.Adam(0.01)
+
+@tf.function
+def optimisation_step():
+    natgrad_opt.minimize(loss_fn, variational_vars)
+    adam_opt.minimize(loss_fn, adam_vars)
 
 # %% [markdown]
 # # Run Optimization Loop
@@ -190,9 +196,8 @@ adam_opt = tf.optimizers.Adam(0.01)
 epochs = 100
 log_freq = 20
 
-for epoch in range(epochs + 1):
-    natgrad_opt.minimize(loss_fn, variational_vars)
-    adam_opt.minimize(loss_fn, adam_vars)
+for epoch in range(1, epochs + 1):
+    optimisation_step()
 
     # For every 'log_freq' epochs, print the epoch and plot the predictions against the data
     if epoch % log_freq == 0 and epoch > 0:
@@ -200,15 +205,6 @@ for epoch in range(epochs + 1):
         Ymean, Yvar = model.predict_y(X)
         Ymean = Ymean.numpy().squeeze()
         Ystd = tf.sqrt(Yvar).numpy().squeeze()
-        plt.figure(figsize=(15, 5))
-        for k in (1, 2):
-            x = X.squeeze()
-            lb = (Ymean - k * Ystd).squeeze()
-            ub = (Ymean + k * Ystd).squeeze()
-            plt.fill_between(x, lb, ub, color="silver", alpha=1 - 0.05 * k ** 3)
-        plt.plot(x, lb, color="silver")
-        plt.plot(x, ub, color="silver")
-        plt.plot(X, Ymean, color="black")
-        plt.scatter(X, Y, color="gray", alpha=0.8)
-        plt.show()
-        plt.close()
+        plot_distribution(X, Y, Ymean, Ystd)
+
+model

--- a/gpflow/kernels/stationaries.py
+++ b/gpflow/kernels/stationaries.py
@@ -46,7 +46,7 @@ class Stationary(Kernel):
         """
         for kwarg in kwargs:
             if kwarg not in {"name", "active_dims"}:
-                raise TypeError("Unknown keyword argument:", kwarg)
+                raise TypeError(f"Unknown keyword argument: {kwarg}")
 
         super().__init__(**kwargs)
         self.variance = Parameter(variance, transform=positive())

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -292,59 +292,67 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
 
 
 class QuadratureLikelihood(Likelihood):
-    def __init__(self, num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, latent_dim: int, observation_dim: int, *, num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS, **kwargs):
+        super().__init__(latent_dim=latent_dim, observation_dim=observation_dim, **kwargs)
         self.num_gauss_hermite_points = num_gauss_hermite_points
         self._quadrature = None
 
     @property
     def quadrature(self):
-        if self._quadrature is None:
-            if self.latent_dim is None:
-                raise Exception(
-                    "latent_dim not specified. "
-                    "Either set likelihood.latent_dim directly or "
-                    "call a method which passes data to have it inferred."
-                )
-            with tf.init_scope():
-                self._quadrature = NDiagGHQuadrature(self.latent_dim, self.num_gauss_hermite_points)
+        if self._quadrature is not None:
+            return self._quadrature
+
+        if self.latent_dim is None:
+            raise Exception(
+                "latent_dim not specified. Either set likelihood.latent_dim directly "
+                "or call a method which passes data to have it inferred."
+            )
+
+        with tf.init_scope():
+            self._quadrature = NDiagGHQuadrature(self.latent_dim, self.num_gauss_hermite_points)
         return self._quadrature
 
-    def _predict_mean_and_var(self, Fmu, Fvar):
-        r"""
-        :param Fmu: mean function evaluation Tensor, with shape [..., latent_dim]
-        :param Fvar: variance of function evaluation Tensor, with shape [..., latent_dim]
-        :returns: mean and variance, both with shape [..., observation_dim]
-        """
-
-        def conditional_y_squared(F):
-            return self.conditional_variance(F) + self.conditional_mean(F) ** 2
-
-        integrands = [self.conditional_mean, conditional_y_squared]
-        E_y, E_y2 = self.quadrature(integrands, Fmu, Fvar)
-        V_y = E_y2 - E_y ** 2
-        return E_y, V_y
-
     def _quadrature_log_prob(self, F, Y):
-        return tf.expand_dims(self.log_prob(F, Y), -1)
+        return tf.expand_dims(self.log_prob(F, Y), axis=-1)
+
+    def _quadrature_reduction(self, v):
+        return tf.squeeze(v, axis=-1)
 
     def _predict_log_density(self, Fmu, Fvar, Y):
         r"""
         :param Fmu: mean function evaluation Tensor, with shape [..., latent_dim]
         :param Fvar: variance of function evaluation Tensor, with shape [..., latent_dim]
         :param Y: observation Tensor, with shape [..., observation_dim]:
-        :returns: variational expectations, with shape [...]
+        :returns: log predictive density, with shape [...]
         """
-        return tf.squeeze(self.quadrature.logspace(self._quadrature_log_prob, Fmu, Fvar, Y), -1)
+        return self._quadrature_reduction(
+            self.quadrature.logspace(self._quadrature_log_prob, Fmu, Fvar, Y=Y)
+        )
 
     def _variational_expectations(self, Fmu, Fvar, Y):
         r"""
         :param Fmu: mean function evaluation Tensor, with shape [..., latent_dim]
         :param Fvar: variance of function evaluation Tensor, with shape [..., latent_dim]
         :param Y: observation Tensor, with shape [..., observation_dim]:
-        :returns: log predictive density, with shape [...]
+        :returns: variational expectations, with shape [...]
         """
-        return tf.squeeze(self.quadrature(self._quadrature_log_prob, Fmu, Fvar, Y), -1)
+        return self._quadrature_reduction(
+            self.quadrature(self._quadrature_log_prob, Fmu, Fvar, Y=Y)
+        )
+
+    def _predict_mean_and_var(self, Fmu, Fvar):
+        r"""
+        :param Fmu: mean function evaluation Tensor, with shape [..., latent_dim]
+        :param Fvar: variance of function evaluation Tensor, with shape [..., latent_dim]
+        :returns: mean and variance of Y, both with shape [..., observation_dim]
+        """
+
+        def conditional_y_squared(*F):
+            return self.conditional_variance(*F) + tf.square(self.conditional_mean(*F))
+
+        E_y, E_y2 = self.quadrature([self.conditional_mean, conditional_y_squared], Fmu, Fvar)
+        V_y = E_y2 - E_y ** 2
+        return E_y, V_y
 
 
 class ScalarLikelihood(Likelihood):

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -317,8 +317,9 @@ class QuadratureLikelihood(Likelihood):
 
     @num_gauss_hermite_points.setter
     def num_gauss_hermite_points(self, n_gh: int):
-        self._num_gauss_hermite_points = n_gh
-        self._set_quadrature()
+        if n_gh != self._num_gauss_hermite_points:
+            self._num_gauss_hermite_points = n_gh
+            self._set_quadrature()
 
     def _quadrature_log_prob(self, F, Y):
         return tf.expand_dims(self.log_prob(F, Y), axis=-1)
@@ -392,7 +393,6 @@ class ScalarLikelihood(QuadratureLikelihood):
 
     def __init__(self, **kwargs):
         super().__init__(latent_dim=None, observation_dim=None, **kwargs)
-        self.num_gauss_hermite_points = DEFAULT_NUM_GAUSS_HERMITE_POINTS
 
     @property
     def _quadrature_dim(self) -> int:

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -325,21 +325,27 @@ class QuadratureLikelihood(Likelihood):
 
     def _quadrature_log_prob(self, F, Y):
         """
+        Returns the appropriate log prob integrand for quadrature.
+
         Quadrature expects f(X), here logp(F), to return shape [N_quad_points]
         + batch_shape + [d']. Here d'=1, but log_prob() only returns
         [N_quad_points] + batch_shape, so we add an extra dimension.
+
         Also see _quadrature_reduction.
         """
         return tf.expand_dims(self.log_prob(F, Y), axis=-1)
 
-    def _quadrature_reduction(self, v):
+    def _quadrature_reduction(self, quadrature_result):
         """
+        Converts the quadrature integral appropriately.
+
         The return shape of quadrature is batch_shape + [d']. Here, d'=1, but
         we want predict_log_density and variational_expectations to return just
         batch_shape, so we squeeze out the extra dimension.
+
         Also see _quadrature_log_prob.
         """
-        return tf.squeeze(v, axis=-1)
+        return tf.squeeze(quadrature_result, axis=-1)
 
     def _predict_log_density(self, Fmu, Fvar, Y):
         r"""
@@ -467,22 +473,28 @@ class ScalarLikelihood(QuadratureLikelihood):
 
     def _quadrature_log_prob(self, F, Y):
         """
+        Returns the appropriate log prob integrand for quadrature.
+
         Quadrature expects f(X), here logp(F), to return shape [N_quad_points]
         + batch_shape + [d']. Here d' corresponds to the last dimension of both
         F and Y, and _scalar_log_prob simply broadcasts over this.
+
         Also see _quadrature_reduction.
         """
         return self._scalar_log_prob(F, Y)
 
-    def _quadrature_reduction(self, v):
+    def _quadrature_reduction(self, quadrature_result):
         """
+        Converts the quadrature integral appropriately.
+
         The return shape of quadrature is batch_shape + [d']. Here, d'
         corresponds to the last dimension of both F and Y, and we want to sum
         over the observations to obtain the overall predict_log_density or
         variational_expectations.
+
         Also see _quadrature_log_prob.
         """
-        return tf.reduce_sum(v, axis=-1)
+        return tf.reduce_sum(quadrature_result, axis=-1)
 
 
 class SwitchedLikelihood(ScalarLikelihood):

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -67,7 +67,7 @@ DEFAULT_NUM_GAUSS_HERMITE_POINTS = 20
 """
 The number of Gauss-Hermite points to use for quadrature (fallback when a
 likelihood method does not have an analytic method) if quadrature object is not
-explicitly given to likelihood constructoV
+explicitly passed to likelihood constructor.
 """
 
 

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -292,7 +292,14 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
 
 
 class QuadratureLikelihood(Likelihood):
-    def __init__(self, latent_dim: int, observation_dim: int, *, num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS, **kwargs):
+    def __init__(
+        self,
+        latent_dim: int,
+        observation_dim: int,
+        *,
+        num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS,
+        **kwargs,
+    ):
         super().__init__(latent_dim=latent_dim, observation_dim=observation_dim, **kwargs)
         self.num_gauss_hermite_points = num_gauss_hermite_points
         self._quadrature = None

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -63,6 +63,9 @@ from ..base import Module
 from ..quadrature import hermgauss, ndiag_mc, ndiagquad, NDiagGHQuadrature
 
 
+DEFAULT_NUM_GAUSS_HERMITE_POINTS = 20
+
+
 class Likelihood(Module, metaclass=abc.ABCMeta):
     def __init__(self, latent_dim: int, observation_dim: int):
         """
@@ -289,7 +292,7 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
 
 
 class QuadratureLikelihood(Likelihood):
-    def __init__(self, num_gauss_hermite_points: int = 20, **kwargs):
+    def __init__(self, num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS, **kwargs):
         super().__init__(**kwargs)
         self.num_gauss_hermite_points = num_gauss_hermite_points
         self._quadrature = None
@@ -366,7 +369,7 @@ class ScalarLikelihood(Likelihood):
 
     def __init__(self, **kwargs):
         super().__init__(latent_dim=None, observation_dim=None, **kwargs)
-        self.num_gauss_hermite_points = 20
+        self.num_gauss_hermite_points = DEFAULT_NUM_GAUSS_HERMITE_POINTS
 
     @property
     def num_gauss_hermite_points(self):

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -385,6 +385,11 @@ class ScalarLikelihood(QuadratureLikelihood):
 
     @property
     def num_gauss_hermite_points(self) -> int:
+        warnings.warn(
+            "The num_gauss_hermite_points property is deprecated; access through the `quadrature` attribute instead",
+            DeprecationWarning,
+        )
+
         if not isinstance(self.quadrature, NDiagGHQuadrature):
             raise TypeError(
                 "Can only query num_gauss_hermite_points if quadrature is a NDiagGHQuadrature instance"
@@ -394,12 +399,12 @@ class ScalarLikelihood(QuadratureLikelihood):
     @num_gauss_hermite_points.setter
     def num_gauss_hermite_points(self, n_gh: int):
         warnings.warn(
-            "The num_gauss_hermite_points setter is deprecated; assign a new GaussianQuadrature instance to the quadrature attribute instead",
+            "The num_gauss_hermite_points setter is deprecated; assign a new GaussianQuadrature instance to the `quadrature` attribute instead",
             DeprecationWarning,
         )
 
         if isinstance(self.quadrature, NDiagGHQuadrature) and n_gh == self.quadrature.n_gh:
-            return
+            return  # nothing to do here
 
         with tf.init_scope():
             self.quadrature = NDiagGHQuadrature(self._quadrature_dim, n_gh)

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -539,9 +539,12 @@ class MonteCarloLikelihood(Likelihood):
 
         Here, we implement a default Monte Carlo routine.
         """
-        integrand2 = lambda *X: self.conditional_variance(*X) + tf.square(self.conditional_mean(*X))
+
+        def conditional_y_squared(*F):
+            return self.conditional_variance(*F) + tf.square(self.conditional_mean(*F))
+
         E_y, E_y2 = self._mc_quadrature(
-            [self.conditional_mean, integrand2], Fmu, Fvar, epsilon=epsilon
+            [self.conditional_mean, conditional_y_squared], Fmu, Fvar, epsilon=epsilon
         )
         V_y = E_y2 - tf.square(E_y)
         return E_y, V_y  # [N, D]

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -298,11 +298,10 @@ class QuadratureLikelihood(Likelihood):
         observation_dim: int,
         *,
         num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS,
-        **kwargs,
     ):
-        super().__init__(latent_dim=latent_dim, observation_dim=observation_dim, **kwargs)
+        super().__init__(latent_dim=latent_dim, observation_dim=observation_dim)
         self.num_gauss_hermite_points = num_gauss_hermite_points
-        self._quadrature = None
+        self._quadrature: Optional[NDiagGHQuadrature] = None
 
     @property
     def quadrature(self):
@@ -394,11 +393,11 @@ class ScalarLikelihood(QuadratureLikelihood):
         self.num_gauss_hermite_points = DEFAULT_NUM_GAUSS_HERMITE_POINTS
 
     @property
-    def num_gauss_hermite_points(self):
+    def num_gauss_hermite_points(self) -> int:
         return self.quadrature.n_gh
 
     @num_gauss_hermite_points.setter
-    def num_gauss_hermite_points(self, n_gh):
+    def num_gauss_hermite_points(self, n_gh: int):
         self._quadrature = NDiagGHQuadrature(1, n_gh)
 
     def _check_last_dims_valid(self, F, Y):

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -302,7 +302,9 @@ class QuadratureLikelihood(Likelihood):
         super().__init__(latent_dim=latent_dim, observation_dim=observation_dim)
         if quadrature is None:
             with tf.init_scope():
-                quadrature = NDiagGHQuadrature(self._quadrature_dim, DEFAULT_NUM_GAUSS_HERMITE_POINTS)
+                quadrature = NDiagGHQuadrature(
+                    self._quadrature_dim, DEFAULT_NUM_GAUSS_HERMITE_POINTS
+                )
         self.quadrature = quadrature
 
     @property

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -394,7 +394,10 @@ class ScalarLikelihood(QuadratureLikelihood):
 
     @property
     def num_gauss_hermite_points(self) -> int:
-        return self.quadrature.n_gh
+        if self._quadrature is not None:
+            return self.quadrature.n_gh
+        else:
+            return None  # workaround for TensorFlow calling the getter when setting!
 
     @num_gauss_hermite_points.setter
     def num_gauss_hermite_points(self, n_gh: int):

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -60,7 +60,7 @@ import warnings
 from typing import Optional
 
 from ..base import Module
-from ..quadrature import hermgauss, ndiag_mc, ndiagquad, NDiagGHQuadrature
+from ..quadrature import ndiag_mc, GaussianQuadrature, NDiagGHQuadrature
 
 
 DEFAULT_NUM_GAUSS_HERMITE_POINTS = 20

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -64,6 +64,11 @@ from ..quadrature import ndiag_mc, GaussianQuadrature, NDiagGHQuadrature
 
 
 DEFAULT_NUM_GAUSS_HERMITE_POINTS = 20
+"""
+The number of Gauss-Hermite points to use for quadrature (fallback when a
+likelihood method does not have an analytic method) if quadrature object is not
+explicitly given to likelihood constructoV
+"""
 
 
 class Likelihood(Module, metaclass=abc.ABCMeta):

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 from ..utilities import positive
-from .base import QuadratureLikelihood
+from .base import QuadratureLikelihood, DEFAULT_NUM_GAUSS_HERMITE_POINTS
 
 
 # NOTE- in the following we're assuming outputs are independent, i.e. full_output_cov=False
@@ -31,7 +31,9 @@ class MultiLatentLikelihood(QuadratureLikelihood):
     by multiple latent GPs.
     """
 
-    def __init__(self, latent_dim: int, *, num_gauss_hermite_points: int = 21):
+    def __init__(
+        self, latent_dim: int, *, num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS
+    ):
         super().__init__(
             latent_dim=latent_dim,
             observation_dim=1,
@@ -49,7 +51,7 @@ class MultiLatentTFPConditional(MultiLatentLikelihood):
         self,
         latent_dim: int,
         conditional_distribution: Callable[..., tfp.distributions.Distribution],
-        num_gauss_hermite_points: int = 21,
+        num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS0,
     ):
         """
         :param latent_dim: number of arguments to the `conditional_distribution` callable
@@ -100,7 +102,7 @@ class HeteroskedasticTFPConditional(MultiLatentTFPConditional):
         self,
         distribution_class: Type[tfp.distributions.Distribution] = tfp.distributions.Normal,
         transform: tfp.bijectors.Bijector = positive(base="exp"),
-        num_gauss_hermite_points: int = 21,
+        num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS,
     ):
         """
         :param distribution_class: distribution class parameterized by `loc` and `scale`

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -97,20 +97,21 @@ class HeteroskedasticTFPConditional(MultiLatentTFPConditional):
     def __init__(
         self,
         distribution_class: Type[tfp.distributions.Distribution] = tfp.distributions.Normal,
-        transform: tfp.bijectors.Bijector = positive(base="exp"),
+        scale_transform: tfp.bijectors.Bijector = positive(base="exp"),
         **kwargs,
     ):
         """
         :param distribution_class: distribution class parameterized by `loc` and `scale`
-            as first and second argument, respectivily.
-        :param transform: callable applied to the variance GP to make it positive.
+            as first and second argument, respectively.
+        :param scale_transform: callable/bijector applied to the latent
+            function modelling the scale to ensure its positivity.
             Typically, `tf.exp` or `tf.softplus`, but can be any function f: R -> R^+.
         """
 
         def conditional_distribution(Fs) -> tfp.distributions.Distribution:
             tf.debugging.assert_equal(tf.shape(Fs)[-1], 2)
             loc = Fs[..., :1]
-            scale = transform(Fs[..., 1:])
+            scale = scale_transform(Fs[..., 1:])
             return distribution_class(loc, scale)
 
         super().__init__(

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -32,7 +32,7 @@ class MultiLatentLikelihood(QuadratureLikelihood):
     """
 
     def __init__(
-        self, latent_dim: int, *, num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS
+        self, latent_dim: int, *, num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS,
     ):
         super().__init__(
             latent_dim=latent_dim,
@@ -51,6 +51,7 @@ class MultiLatentTFPConditional(MultiLatentLikelihood):
         self,
         latent_dim: int,
         conditional_distribution: Callable[..., tfp.distributions.Distribution],
+        *,
         num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS0,
     ):
         """
@@ -102,6 +103,7 @@ class HeteroskedasticTFPConditional(MultiLatentTFPConditional):
         self,
         distribution_class: Type[tfp.distributions.Distribution] = tfp.distributions.Normal,
         transform: tfp.bijectors.Bijector = positive(base="exp"),
+        *,
         num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS,
     ):
         """

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 from ..utilities import positive
-from .base import QuadratureLikelihood, DEFAULT_NUM_GAUSS_HERMITE_POINTS
+from .base import QuadratureLikelihood
 
 
 class MultiLatentLikelihood(QuadratureLikelihood):

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -52,7 +52,7 @@ class MultiLatentTFPConditional(MultiLatentLikelihood):
         latent_dim: int,
         conditional_distribution: Callable[..., tfp.distributions.Distribution],
         *,
-        num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS0,
+        num_gauss_hermite_points: int = DEFAULT_NUM_GAUSS_HERMITE_POINTS,
     ):
         """
         :param latent_dim: number of arguments to the `conditional_distribution` callable

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -116,7 +116,7 @@ class HeteroskedasticTFPConditional(MultiLatentTFPConditional):
         def conditional_distribution(Fs) -> tfp.distributions.Distribution:
             tf.debugging.assert_equal(tf.shape(Fs)[-1], 2)
             loc = Fs[..., :1]
-            scale = transform(Fs[..., 1:] / 2)
+            scale = transform(Fs[..., 1:])
             return distribution_class(loc, scale)
 
         super().__init__(

--- a/gpflow/quadrature/deprecated.py
+++ b/gpflow/quadrature/deprecated.py
@@ -14,7 +14,7 @@
 
 import itertools
 from collections.abc import Iterable
-from warnings import DeprecationWarning
+import warnings
 
 import numpy as np
 import tensorflow as tf
@@ -120,9 +120,10 @@ def ndiagquad(funcs, H: int, Fmu, Fvar, logspace: bool = False, **Ys):
     Fmu, Fvar, Ys should all have same shape, with overall size `N`
     :return: shape is the same as that of the first Fmu
     """
-    raise DeprecationWarning(
+    warnings.warn(
         "Please use gpflow.quadrature.NDiagGHQuadrature instead "
-        "(note the changed convention of how multi-dimensional quadrature is handled)"
+        "(note the changed convention of how multi-dimensional quadrature is handled)",
+        DeprecationWarning,
     )
 
     n_gh = H

--- a/gpflow/quadrature/deprecated.py
+++ b/gpflow/quadrature/deprecated.py
@@ -14,6 +14,7 @@
 
 import itertools
 from collections.abc import Iterable
+from warnings import DeprecationWarning
 
 import numpy as np
 import tensorflow as tf
@@ -119,6 +120,11 @@ def ndiagquad(funcs, H: int, Fmu, Fvar, logspace: bool = False, **Ys):
     Fmu, Fvar, Ys should all have same shape, with overall size `N`
     :return: shape is the same as that of the first Fmu
     """
+    raise DeprecationWarning(
+        "Please use gpflow.quadrature.NDiagGHQuadrature instead "
+        "(note the changed convention of how multi-dimensional quadrature is handled)"
+    )
+
     n_gh = H
     if isinstance(Fmu, (tuple, list)):
         dim = len(Fmu)

--- a/gpflow/quadrature/gauss_hermite.py
+++ b/gpflow/quadrature/gauss_hermite.py
@@ -32,7 +32,7 @@ def gh_points_and_weights(n_gh: int):
     X ~ N(mean, stddev²)
     E[f(X)] = ∫f(x)p(x)dx = sum_{i=1}^{n_gh} f(mean + stddev*z_i)*dz_i
 
-    :param n_gh: Number of Gauss-Hermite points, integer
+    :param n_gh: Number of Gauss-Hermite points
     :returns: Points z and weights dz, both tensors with shape [n_gh],
         to compute uni-dimensional gaussian expectation
     """
@@ -75,8 +75,8 @@ def repeat_as_list(x: TensorType, n: int):
 
 def ndgh_points_and_weights(dim: int, n_gh: int):
     r"""
-    :param n_gh: number of Gauss-Hermite points, integer
-    :param dim: dimension of the multivariate normal, integer
+    :param dim: dimension of the multivariate normal
+    :param n_gh: number of Gauss-Hermite points per dimension
     :returns: points Z, Tensor with shape [n_gh**dim, dim],
         and weights dZ, Tensor with shape [n_gh**dim, 1]
     """
@@ -89,8 +89,8 @@ def ndgh_points_and_weights(dim: int, n_gh: int):
 class NDiagGHQuadrature(GaussianQuadrature):
     def __init__(self, dim: int, n_gh: int):
         """
-        :param n_gh: number of Gauss-Hermite points, integer
-        :param dim: dimension of the multivariate normal, integer
+        :param dim: dimension of the multivariate normal
+        :param n_gh: number of Gauss-Hermite points per dimension
         """
         self.dim = dim
         self.n_gh = n_gh

--- a/gpflow/quadrature/gauss_hermite.py
+++ b/gpflow/quadrature/gauss_hermite.py
@@ -30,7 +30,7 @@ def gh_points_and_weights(n_gh: int):
     uni-dimensional gaussian quadrature:
 
     X ~ N(mean, stddev²)
-    E[f(X)] = ∫f(x)p(x)dx = sum_{i=1}^{n_gh} f(mean + stddev*z_i)*dz_i
+    E[f(X)] = ∫ f(x) p(x) dx = \sum_{i=1}^{n_gh} f(mean + stddev*z_i) dz_i
 
     :param n_gh: Number of Gauss-Hermite points
     :returns: Points z and weights dz, both tensors with shape [n_gh],

--- a/tests/gpflow/likelihoods/test_heteroskedastic.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic.py
@@ -31,12 +31,7 @@ class Data:
     f_var = rng.randn(N, 2) ** 2
 
 
-@pytest.fixture
-def likelihood() -> HeteroskedasticTFPConditional:
-    return HeteroskedasticTFPConditional(num_gauss_hermite_points=20)
-
-
-def test_analytic_mean_and_var(likelihood):
+def test_analytic_mean_and_var():
     """
     Test that quadrature computation used in HeteroskedasticTFPConditional
     of the predictive mean and variance is close to the analytical version, 
@@ -44,8 +39,10 @@ def test_analytic_mean_and_var(likelihood):
     where f1, f2 ~ GP.
     """
     analytic_mean = Data.f_mean[:, [0]]
-    analytic_variance = np.exp(Data.f_mean[:, [1]] + Data.f_var[:, [1]] / 2.0) + Data.f_var[:, [0]]
+    analytic_variance = np.exp(Data.f_mean[:, [1]] + Data.f_var[:, [1]])**2 + Data.f_var[:, [0]]
 
+    likelihood = HeteroskedasticTFPConditional()
     y_mean, y_var = likelihood.predict_mean_and_var(Data.f_mean, Data.f_var)
-    np.testing.assert_array_almost_equal(y_mean, analytic_mean)
-    np.testing.assert_array_almost_equal(y_var, analytic_variance)
+
+    np.testing.assert_allclose(y_mean, analytic_mean)
+    np.testing.assert_allclose(y_var, analytic_variance, rtol=1.5e-6)

--- a/tests/gpflow/likelihoods/test_heteroskedastic.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic.py
@@ -35,7 +35,7 @@ def test_analytic_mean_and_var():
     """
     Test that quadrature computation used in HeteroskedasticTFPConditional
     of the predictive mean and variance is close to the analytical version, 
-    which can be computed for the special case of N(y | mean=f1, variance=exp(f2)),
+    which can be computed for the special case of N(y | mean=f1, scale=exp(f2)),
     where f1, f2 ~ GP.
     """
     analytic_mean = Data.f_mean[:, [0]]

--- a/tests/gpflow/likelihoods/test_heteroskedastic.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic.py
@@ -39,7 +39,7 @@ def test_analytic_mean_and_var():
     where f1, f2 ~ GP.
     """
     analytic_mean = Data.f_mean[:, [0]]
-    analytic_variance = np.exp(Data.f_mean[:, [1]] + Data.f_var[:, [1]])**2 + Data.f_var[:, [0]]
+    analytic_variance = np.exp(Data.f_mean[:, [1]] + Data.f_var[:, [1]]) ** 2 + Data.f_var[:, [0]]
 
     likelihood = HeteroskedasticTFPConditional()
     y_mean, y_var = likelihood.predict_mean_and_var(Data.f_mean, Data.f_var)

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -63,9 +63,7 @@ def _equivant_likelihoods_fixture(
     if request.param == "studentt":
         return (
             gpflow.likelihoods.StudentT(scale=Data.g_var ** 0.5, df=3.0),
-            HeteroskedasticTFPConditional(
-                distribution_class=student_t_class_factory(df=3), num_gauss_hermite_points=50
-            ),
+            HeteroskedasticTFPConditional(distribution_class=student_t_class_factory(df=3)),
         )
     elif request.param == "gaussian":
         return (

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -33,7 +33,7 @@ class Data:
     # single "GP" (for the mean):
     f_mean = rng.randn(N, 1)
     f_var = rng.randn(N, 1) ** 2  # ensure positivity
-    equivalent_f2 = np.log(g_var)
+    equivalent_f2 = np.log(g_var) / 2
     f2_mean = np.full((N, 1), equivalent_f2)
     f2_var = np.zeros((N, 1))
     F2_mean = np.c_[f_mean, f2_mean]

--- a/tests/gpflow/quadrature/test_quadrature.py
+++ b/tests/gpflow/quadrature/test_quadrature.py
@@ -74,10 +74,10 @@ def test_diagquad_with_kwarg(mu1, var1):
     assert_allclose(quad, expected)
 
 
-def test_ndiagqiuad_doesnot_throw_error():
+def test_ndiagquad_does_not_throw_error():
     """
     Check that the autograph=False for quadrature.ndiagquad does not throw an error.
-    Fix for https://github.com/GPflow/GPflow/issues/1547.
+    Regression test for https://github.com/GPflow/GPflow/issues/1547.
     """
 
     @tf.function(autograph=False)
@@ -95,7 +95,7 @@ def test_ndiagqiuad_doesnot_throw_error():
 def test_quadrature_autograph():
     """
     Check that the return value is equal with and without Autograph
-    Fix for https://github.com/GPflow/GPflow/issues/1547.
+    Regression test for https://github.com/GPflow/GPflow/issues/1547.
     """
 
     def compute(autograph):
@@ -108,8 +108,9 @@ def test_quadrature_autograph():
                 [lambda *X: tf.exp(X[0])], num_gauss_hermite_points, [mu], [var]
             )
 
-        return func()
+        (result,) = func()
+        return result.numpy()
 
-    np.testing.assert_allclose(
+    np.testing.assert_equal(
         compute(autograph=True), compute(autograph=False),
     )


### PR DESCRIPTION
**PR type:** cleanup

**Related issue(s)/PRs:** #1505, #1559, #1566

## Summary

**Proposed changes**

* Global constant for num_gauss_hermite_points default
* QuadratureLikelihood with dependency injection (in preparation for unifying with MonteCarloLikelihood)
* ScalarLikelihood as QuadratureLikelihood subclass (with _quadrature_dim/_quadrature_log_prob/_quadrature_reduction)
* HeteroskedasticTFPConditional: rename argument to `scale_transform` and remove undocumented scaling
* DeprecationWarning for deprecated code

## PR checklist
<!-- tick off [X] as applicable -->
- [X] Code has type annotations
- [X] I ran the black formatter (`make format`)
- [x] I locally tested that the tests pass (`make check-all`)

### Release notes

<!-- leave blank if unsure -->

**Fully backwards compatible:** yes / no

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

**Commit message (for release notes):**

* ...
