### PR TITLE
isort for consistent imports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,13 +66,13 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install Black
+          name: Install Black and Isort
           command: |
-            pip install black==19.10b0
+            pip install black==19.10b0 isort
       - run:
           name: Run format checker
           command: |
-            black --check -t py36 -l 100 gpflow tests doc setup.py
+            make format-check
 
   trigger-docs-generation:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,11 +66,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install Black and Isort
+          name: Install black and isort
           command: |
             pip install black==19.10b0 isort
       - run:
-          name: Run format checker
+          name: Run format check
           command: |
             make format-check
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,7 +39,7 @@ Please fill it in as far as possible; if anything about this template is unclear
   - [ ] notebook examples (usage demonstration)
 - [ ] The bug case / new feature is covered by unit tests
 - [ ] Code has type annotations
-- [ ] I ran the black formatter (`make format`)
+- [ ] I ran the black+isort formatter (`make format`)
 - [ ] I locally tested that the tests pass (`make check-all`)
 
 ### Release notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Variable names: scalars and vectors start lowercase, but following the notation 
 
 ### Formatting
 
-GPflow uses [black](https://github.com/psf/black) for formatting, calling it with `black -t py36 -l 100`. Simply run `make format` from the GPflow root directory.
+GPflow uses [black](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort/) for formatting. Simply run `make format` from the GPflow root directory (or check our Makefile for the appropriate command-line options).
 
 ## Pull requests
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 BLACK_CONFIG=-t py36 -l 100
 BLACK_TARGETS=gpflow tests doc setup.py
+ISORT_CONFIG=--atomic -l 100 --trailing-comma --remove-redundant-aliases --multi-line 3
+ISORT_TARGETS=gpflow tests setup.py
 
 .PHONY: help clean dev-install install package format format-check type-check test check-all
 
@@ -29,9 +31,11 @@ package:
 
 format:
 	black $(BLACK_CONFIG) $(BLACK_TARGETS)
+	isort $(ISORT_CONFIG) $(ISORT_TARGETS)
 
 format-check:
 	black --check $(BLACK_CONFIG) $(BLACK_TARGETS)
+	isort --check-only $(ISORT_CONFIG) $(ISORT_TARGETS)
 
 type-check:
 	mypy .

--- a/gpflow/__init__.py
+++ b/gpflow/__init__.py
@@ -14,9 +14,6 @@
 
 # flake8: noqa
 
-from .base import Module, Parameter
-from .config import default_int, default_float, default_jitter
-from .utilities import set_trainable
 from . import (
     conditionals,
     config,
@@ -35,6 +32,9 @@ from . import (
     quadrature,
     utilities,
 )
+from .base import Module, Parameter
+from .config import default_float, default_int, default_jitter
+from .utilities import set_trainable
 from .versions import __version__
 
 __all__ = [export for export in dir()]

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -14,7 +14,7 @@
 
 import functools
 from enum import Enum
-from typing import Any, List, Optional, Sequence, TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import tensorflow as tf

--- a/gpflow/ci_utils.py
+++ b/gpflow/ci_utils.py
@@ -15,7 +15,7 @@
 # pylint: skip-file
 
 import os
-from typing import Sequence, Type, Any, List, Iterable, TypeVar
+from typing import Any, Iterable, List, Sequence, Type, TypeVar
 
 
 def is_continuous_integration() -> bool:

--- a/gpflow/conditionals/__init__.py
+++ b/gpflow/conditionals/__init__.py
@@ -1,13 +1,6 @@
 # noqa: F401
 
+from . import conditionals, multioutput, sample_conditionals
 from .dispatch import conditional, sample_conditional
-
-from . import conditionals
-from . import sample_conditionals
-
-from . import multioutput
-
-
-from .util import base_conditional
-
 from .uncertain_conditionals import uncertain_conditional
+from .util import base_conditional

--- a/gpflow/conditionals/conditionals.py
+++ b/gpflow/conditionals/conditionals.py
@@ -14,11 +14,11 @@
 
 import tensorflow as tf
 
+from ..config import default_jitter
 from ..covariances import Kuf, Kuu
 from ..inducing_variables import InducingVariables
 from ..kernels import Kernel
 from ..utilities.ops import eye
-from ..config import default_jitter
 from .dispatch import conditional
 from .util import base_conditional, expand_independent_outputs
 

--- a/gpflow/conditionals/multioutput/__init__.py
+++ b/gpflow/conditionals/multioutput/__init__.py
@@ -1,2 +1,1 @@
-from . import sample_conditionals
-from . import conditionals
+from . import conditionals, sample_conditionals

--- a/gpflow/conditionals/multioutput/conditionals.py
+++ b/gpflow/conditionals/multioutput/conditionals.py
@@ -15,22 +15,22 @@
 import tensorflow as tf
 
 from ... import covariances
+from ...config import default_float, default_jitter
 from ...inducing_variables import (
-    InducingPoints,
-    FallbackSharedIndependentInducingVariables,
     FallbackSeparateIndependentInducingVariables,
-    SharedIndependentInducingVariables,
+    FallbackSharedIndependentInducingVariables,
+    InducingPoints,
     SeparateIndependentInducingVariables,
+    SharedIndependentInducingVariables,
 )
 from ...kernels import (
     Combination,
+    IndependentLatent,
+    LinearCoregionalization,
     MultioutputKernel,
     SeparateIndependent,
     SharedIndependent,
-    IndependentLatent,
-    LinearCoregionalization,
 )
-from ...config import default_float, default_jitter
 from ..dispatch import conditional
 from ..util import (
     base_conditional,

--- a/gpflow/conditionals/multioutput/sample_conditionals.py
+++ b/gpflow/conditionals/multioutput/sample_conditionals.py
@@ -18,9 +18,9 @@ from ...inducing_variables import (
     SeparateIndependentInducingVariables,
     SharedIndependentInducingVariables,
 )
-from ...kernels import SeparateIndependent, LinearCoregionalization
+from ...kernels import LinearCoregionalization, SeparateIndependent
 from ..dispatch import conditional, sample_conditional
-from ..util import sample_mvn, mix_latent_gp
+from ..util import mix_latent_gp, sample_mvn
 
 
 @sample_conditional.register(

--- a/gpflow/conditionals/uncertain_conditionals.py
+++ b/gpflow/conditionals/uncertain_conditionals.py
@@ -14,13 +14,12 @@
 
 import tensorflow as tf
 
-from .. import mean_functions
-from .. import covariances
+from .. import covariances, mean_functions
+from ..config import default_float, default_jitter
 from ..expectations import expectation
-from ..inducing_variables import InducingVariables, InducingPoints
+from ..inducing_variables import InducingPoints, InducingVariables
 from ..kernels import Kernel
 from ..probability_distributions import Gaussian
-from ..config import default_float, default_jitter
 
 
 def uncertain_conditional(

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import Optional
+
 import tensorflow as tf
 
 from ..config import default_float, default_jitter

--- a/gpflow/covariances/__init__.py
+++ b/gpflow/covariances/__init__.py
@@ -1,5 +1,2 @@
-from .dispatch import Kuf
-from .dispatch import Kuu
-
-from . import kufs, kuus
-from . import multioutput
+from . import kufs, kuus, multioutput
+from .dispatch import Kuf, Kuu

--- a/gpflow/covariances/kufs.py
+++ b/gpflow/covariances/kufs.py
@@ -15,8 +15,8 @@
 import tensorflow as tf
 
 from ..base import TensorLike
-from ..inducing_variables import InducingPoints, Multiscale, InducingPatches
-from ..kernels import Kernel, SquaredExponential, Convolutional
+from ..inducing_variables import InducingPatches, InducingPoints, Multiscale
+from ..kernels import Convolutional, Kernel, SquaredExponential
 from .dispatch import Kuf
 
 

--- a/gpflow/covariances/kuus.py
+++ b/gpflow/covariances/kuus.py
@@ -14,10 +14,10 @@
 
 import tensorflow as tf
 
-from ..inducing_variables import InducingPoints, Multiscale, InducingPatches
-from ..kernels import Kernel, SquaredExponential, Convolutional
-from .dispatch import Kuu
 from ..config import default_float
+from ..inducing_variables import InducingPatches, InducingPoints, Multiscale
+from ..kernels import Convolutional, Kernel, SquaredExponential
+from .dispatch import Kuu
 
 
 @Kuu.register(InducingPoints, Kernel)

--- a/gpflow/covariances/multioutput/kufs.py
+++ b/gpflow/covariances/multioutput/kufs.py
@@ -17,16 +17,16 @@ from typing import Union
 import tensorflow as tf
 
 from ...inducing_variables import (
-    InducingPoints,
-    FallbackSharedIndependentInducingVariables,
     FallbackSeparateIndependentInducingVariables,
-    SharedIndependentInducingVariables,
+    FallbackSharedIndependentInducingVariables,
+    InducingPoints,
     SeparateIndependentInducingVariables,
+    SharedIndependentInducingVariables,
 )
 from ...kernels import (
+    LinearCoregionalization,
     MultioutputKernel,
     SeparateIndependent,
-    LinearCoregionalization,
     SharedIndependent,
 )
 from ..dispatch import Kuf

--- a/gpflow/covariances/multioutput/kuus.py
+++ b/gpflow/covariances/multioutput/kuus.py
@@ -17,17 +17,17 @@ from typing import Union
 import tensorflow as tf
 
 from ...inducing_variables import (
-    InducingPoints,
-    FallbackSharedIndependentInducingVariables,
     FallbackSeparateIndependentInducingVariables,
+    FallbackSharedIndependentInducingVariables,
+    InducingPoints,
     SharedIndependentInducingVariables,
 )
 from ...kernels import (
+    IndependentLatent,
+    LinearCoregionalization,
     MultioutputKernel,
     SeparateIndependent,
-    LinearCoregionalization,
     SharedIndependent,
-    IndependentLatent,
 )
 from ..dispatch import Kuu
 

--- a/gpflow/expectations/__init__.py
+++ b/gpflow/expectations/__init__.py
@@ -1,5 +1,3 @@
-from .expectations import expectation, quadrature_expectation
-
 from . import (
     cross_kernels,
     linears,
@@ -10,5 +8,6 @@ from . import (
     squared_exponentials,
     sums,
 )
+from .expectations import expectation, quadrature_expectation
 
 __all__ = ["expectation", "quadrature_expectation"]

--- a/gpflow/expectations/cross_kernels.py
+++ b/gpflow/expectations/cross_kernels.py
@@ -14,10 +14,10 @@
 
 import tensorflow as tf
 
-from . import dispatch
 from .. import kernels
 from ..inducing_variables import InducingPoints
 from ..probability_distributions import DiagonalGaussian, Gaussian
+from . import dispatch
 from .expectations import expectation
 
 

--- a/gpflow/expectations/linears.py
+++ b/gpflow/expectations/linears.py
@@ -21,7 +21,6 @@ from ..probability_distributions import DiagonalGaussian, Gaussian, MarkovGaussi
 from . import dispatch
 from .expectations import expectation
 
-
 NoneType = type(None)
 
 

--- a/gpflow/expectations/misc.py
+++ b/gpflow/expectations/misc.py
@@ -16,11 +16,10 @@ import tensorflow as tf
 
 from .. import kernels
 from .. import mean_functions as mfn
-from ..inducing_variables import InducingVariables, InducingPoints
+from ..inducing_variables import InducingPoints, InducingVariables
 from ..probability_distributions import DiagonalGaussian, Gaussian, MarkovGaussian
 from . import dispatch
 from .expectations import expectation
-
 
 NoneType = type(None)
 

--- a/gpflow/inducing_variables/__init__.py
+++ b/gpflow/inducing_variables/__init__.py
@@ -1,10 +1,10 @@
-from .inducing_variables import InducingVariables, InducingPoints, Multiscale
-from .inducing_patch import InducingPatches
 from . import multioutput
+from .inducing_patch import InducingPatches
+from .inducing_variables import InducingPoints, InducingVariables, Multiscale
 from .multioutput import (
-    MultioutputInducingVariables,
-    FallbackSharedIndependentInducingVariables,
     FallbackSeparateIndependentInducingVariables,
-    SharedIndependentInducingVariables,
+    FallbackSharedIndependentInducingVariables,
+    MultioutputInducingVariables,
     SeparateIndependentInducingVariables,
+    SharedIndependentInducingVariables,
 )

--- a/gpflow/inducing_variables/multioutput/__init__.py
+++ b/gpflow/inducing_variables/multioutput/__init__.py
@@ -1,7 +1,7 @@
 from .inducing_variables import (
-    MultioutputInducingVariables,
-    FallbackSharedIndependentInducingVariables,
     FallbackSeparateIndependentInducingVariables,
-    SharedIndependentInducingVariables,
+    FallbackSharedIndependentInducingVariables,
+    MultioutputInducingVariables,
     SeparateIndependentInducingVariables,
+    SharedIndependentInducingVariables,
 )

--- a/gpflow/kernels/__init__.py
+++ b/gpflow/kernels/__init__.py
@@ -13,17 +13,20 @@ from .multioutput import (
 )
 from .periodic import Periodic
 from .statics import Constant, Static, White
-from .stationaries import (
+
+from .stationaries import (  # isort:skip
+    # base classes:
+    Stationary,
+    IsotropicStationary,
     AnisotropicStationary,
+    # actual kernel classes:
     Cosine,
     Exponential,
-    IsotropicStationary,
     Matern12,
     Matern32,
     Matern52,
     RationalQuadratic,
     SquaredExponential,
-    Stationary,
 )
 
 Bias = Constant

--- a/gpflow/kernels/__init__.py
+++ b/gpflow/kernels/__init__.py
@@ -1,30 +1,29 @@
+from . import multioutput
 from .base import Combination, Kernel, Product, Sum
-from .convolutional import Convolutional
 from .changepoints import ChangePoints
+from .convolutional import Convolutional
 from .linears import Linear, Polynomial
 from .misc import ArcCosine, Coregion
-from . import multioutput
-
 from .multioutput import (
+    IndependentLatent,
+    LinearCoregionalization,
     MultioutputKernel,
     SeparateIndependent,
     SharedIndependent,
-    IndependentLatent,
-    LinearCoregionalization,
 )
 from .periodic import Periodic
 from .statics import Constant, Static, White
 from .stationaries import (
-    SquaredExponential,
+    AnisotropicStationary,
     Cosine,
     Exponential,
+    IsotropicStationary,
     Matern12,
     Matern32,
     Matern52,
     RationalQuadratic,
+    SquaredExponential,
     Stationary,
-    IsotropicStationary,
-    AnisotropicStationary,
 )
 
 Bias = Constant

--- a/gpflow/kernels/convolutional.py
+++ b/gpflow/kernels/convolutional.py
@@ -15,10 +15,10 @@
 import numpy as np
 import tensorflow as tf
 
-from .base import Kernel
 from ..base import Parameter
 from ..config import default_float
 from ..utilities import to_default_float
+from .base import Kernel
 
 
 class Convolutional(Kernel):

--- a/gpflow/kernels/misc.py
+++ b/gpflow/kernels/misc.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 
 from ..base import Parameter
 from ..utilities import positive, to_default_float
-from .base import Kernel, ActiveDims
+from .base import ActiveDims, Kernel
 
 
 class ArcCosine(Kernel):

--- a/gpflow/kernels/multioutput/__init__.py
+++ b/gpflow/kernels/multioutput/__init__.py
@@ -1,7 +1,7 @@
 from .kernels import (
+    IndependentLatent,
+    LinearCoregionalization,
     MultioutputKernel,
     SeparateIndependent,
     SharedIndependent,
-    IndependentLatent,
-    LinearCoregionalization,
 )

--- a/gpflow/kernels/periodic.py
+++ b/gpflow/kernels/periodic.py
@@ -21,7 +21,7 @@ from ..base import Parameter
 from ..utilities import positive
 from ..utilities.ops import difference_matrix
 from .base import Kernel
-from .stationaries import Stationary, IsotropicStationary
+from .stationaries import IsotropicStationary, Stationary
 
 
 class Periodic(Kernel):

--- a/gpflow/kernels/stationaries.py
+++ b/gpflow/kernels/stationaries.py
@@ -17,7 +17,7 @@ import tensorflow as tf
 
 from ..base import Parameter
 from ..utilities import positive
-from ..utilities.ops import square_distance, difference_matrix
+from ..utilities.ops import difference_matrix, square_distance
 from .base import Kernel
 
 

--- a/gpflow/kullback_leiblers.py
+++ b/gpflow/kullback_leiblers.py
@@ -15,6 +15,7 @@
 # -*- coding: utf-8 -*-
 
 import tensorflow as tf
+
 from .config import default_float, default_jitter
 from .covariances.kuus import Kuu
 from .inducing_variables import InducingVariables

--- a/gpflow/likelihoods/__init__.py
+++ b/gpflow/likelihoods/__init__.py
@@ -14,32 +14,17 @@
 
 from .base import (
     Likelihood,
+    MonteCarloLikelihood,
     QuadratureLikelihood,
     ScalarLikelihood,
     SwitchedLikelihood,
-    MonteCarloLikelihood,
-)
-from .scalar_discrete import (
-    Bernoulli,
-    Ordinal,
-    Poisson,
-)
-from .scalar_continuous import (
-    Beta,
-    Exponential,
-    Gamma,
-    Gaussian,
-    StudentT,
 )
 from .misc import GaussianMC
-from .multiclass import (
-    MultiClass,
-    Softmax,
-    RobustMax,
-)
-
+from .multiclass import MultiClass, RobustMax, Softmax
 from .multilatent import (
+    HeteroskedasticTFPConditional,
     MultiLatentLikelihood,
     MultiLatentTFPConditional,
-    HeteroskedasticTFPConditional,
 )
+from .scalar_continuous import Beta, Exponential, Gamma, Gaussian, StudentT
+from .scalar_discrete import Bernoulli, Ordinal, Poisson

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -52,15 +52,15 @@ or 2D), if the new likelihood inherits from
 integration is done by sampling (can be more suitable when F is higher dimensional).
 """
 
-import numpy as np
-import tensorflow as tf
 import abc
 import warnings
-
 from typing import Optional
 
+import numpy as np
+import tensorflow as tf
+
 from ..base import Module
-from ..quadrature import hermgauss, ndiag_mc, ndiagquad, NDiagGHQuadrature
+from ..quadrature import NDiagGHQuadrature, hermgauss, ndiag_mc, ndiagquad
 
 
 class Likelihood(Module, metaclass=abc.ABCMeta):

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -62,7 +62,6 @@ import tensorflow as tf
 from ..base import Module
 from ..quadrature import GaussianQuadrature, NDiagGHQuadrature, ndiag_mc
 
-
 DEFAULT_NUM_GAUSS_HERMITE_POINTS = 20
 """
 The number of Gauss-Hermite points to use for quadrature (fallback when a

--- a/gpflow/likelihoods/multiclass.py
+++ b/gpflow/likelihoods/multiclass.py
@@ -18,8 +18,8 @@ import tensorflow_probability as tfp
 
 from ..base import Module, Parameter
 from ..config import default_float
-from ..utilities import to_default_float, to_default_int
 from ..quadrature import hermgauss
+from ..utilities import to_default_float, to_default_int
 from .base import Likelihood, MonteCarloLikelihood
 
 

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 import abc
-from typing import Callable, Type, Optional
+from typing import Callable, Optional, Type
 
 import tensorflow as tf
 import tensorflow_probability as tfp
 
 from ..utilities import positive
 from .base import QuadratureLikelihood
-
 
 # NOTE- in the following we're assuming outputs are independent, i.e. full_output_cov=False
 

--- a/gpflow/logdensities.py
+++ b/gpflow/logdensities.py
@@ -14,6 +14,7 @@
 
 import numpy as np
 import tensorflow as tf
+
 from .config import default_float
 from .utilities import to_default_float
 

--- a/gpflow/models/__init__.py
+++ b/gpflow/models/__init__.py
@@ -2,18 +2,9 @@ from .gplvm import GPLVM, BayesianGPLVM
 from .gpmc import GPMC
 from .gpr import GPR
 from .model import BayesianModel, GPModel
-from .training_mixins import (
-    ExternalDataTrainingLossMixin,
-    InternalDataTrainingLossMixin,
-)
-
-# from .gplvm import PCA_reduce
 from .sgpmc import SGPMC
 from .sgpr import GPRFITC, SGPR
 from .svgp import SVGP
+from .training_mixins import ExternalDataTrainingLossMixin, InternalDataTrainingLossMixin
+from .util import maximum_log_likelihood_objective, training_loss, training_loss_closure
 from .vgp import VGP, VGPOpperArchambeau
-from .util import (
-    training_loss,
-    training_loss_closure,
-    maximum_log_likelihood_objective,
-)

--- a/gpflow/models/gpmc.py
+++ b/gpflow/models/gpmc.py
@@ -25,7 +25,7 @@ from ..kernels import Kernel
 from ..likelihoods import Likelihood
 from ..mean_functions import MeanFunction
 from ..utilities import to_default_float
-from .model import InputData, RegressionData, MeanAndVariance, GPModel
+from .model import GPModel, InputData, MeanAndVariance, RegressionData
 from .training_mixins import InternalDataTrainingLossMixin
 from .util import data_input_to_tensor
 

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -17,13 +17,13 @@ from typing import Optional, Tuple
 
 import tensorflow as tf
 
-from .training_mixins import InputData, RegressionData
 from ..base import Module
 from ..conditionals.util import sample_mvn
 from ..kernels import Kernel, MultioutputKernel
 from ..likelihoods import Likelihood, SwitchedLikelihood
 from ..mean_functions import MeanFunction, Zero
 from ..utilities import to_default_float
+from .training_mixins import InputData, RegressionData
 
 MeanAndVariance = Tuple[tf.Tensor, tf.Tensor]
 

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -22,7 +22,7 @@ from ..base import Parameter
 from ..conditionals import conditional
 from ..config import default_float
 from ..utilities import positive, triangular
-from .model import GPModel, InputData, RegressionData, MeanAndVariance
+from .model import GPModel, InputData, MeanAndVariance, RegressionData
 from .training_mixins import ExternalDataTrainingLossMixin
 from .util import inducingpoint_wrapper
 

--- a/gpflow/models/training_mixins.py
+++ b/gpflow/models/training_mixins.py
@@ -33,10 +33,9 @@ to the objective function (ExternalDataTrainingLossMixin).
 import abc
 from typing import Callable, Iterator, Optional, Tuple, TypeVar, Union
 
+import numpy as np
 import tensorflow as tf
 from tensorflow.python.data.ops.iterator_ops import OwnedIterator as DatasetOwnedIterator
-import numpy as np
-
 
 InputData = Union[tf.Tensor]
 OutputData = Union[tf.Tensor]

--- a/gpflow/monitor/base.py
+++ b/gpflow/monitor/base.py
@@ -19,7 +19,6 @@ from typing import Callable, List, Union
 
 import tensorflow as tf
 
-
 __all__ = ["MonitorTask", "ExecuteCallback", "MonitorTaskGroup", "Monitor"]
 
 

--- a/gpflow/monitor/tensorboard.py
+++ b/gpflow/monitor/tensorboard.py
@@ -25,7 +25,6 @@ from ..models import BayesianModel
 from ..utilities import parameter_dict
 from .base import MonitorTask
 
-
 __all__ = ["ToTensorBoard", "ModelToTensorBoard", "ScalarToTensorBoard", "ImageToTensorBoard"]
 
 

--- a/gpflow/optimizers/__init__.py
+++ b/gpflow/optimizers/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=wildcard-import
 
 from . import natgrad
+from .mcmc import SamplingHelper
 from .natgrad import *
 from .scipy import Scipy
-from .mcmc import SamplingHelper

--- a/gpflow/optimizers/mcmc.py
+++ b/gpflow/optimizers/mcmc.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Sequence, Optional
+from typing import Callable, Optional, Sequence
 
 import tensorflow as tf
 

--- a/gpflow/quadrature/__init__.py
+++ b/gpflow/quadrature/__init__.py
@@ -1,3 +1,3 @@
 from .base import GaussianQuadrature
+from .deprecated import hermgauss, mvhermgauss, mvnquad, ndiag_mc, ndiagquad
 from .gauss_hermite import NDiagGHQuadrature
-from .deprecated import hermgauss, mvhermgauss, mvnquad, ndiagquad, ndiag_mc

--- a/gpflow/quadrature/base.py
+++ b/gpflow/quadrature/base.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Union, Iterable
-
 import abc
+from typing import Callable, Iterable, Union
+
 import tensorflow as tf
 
 from ..base import TensorType

--- a/gpflow/quadrature/deprecated.py
+++ b/gpflow/quadrature/deprecated.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import itertools
-from collections.abc import Iterable
 import warnings
+from collections.abc import Iterable
 
 import numpy as np
 import tensorflow as tf

--- a/gpflow/quadrature/deprecated.py
+++ b/gpflow/quadrature/deprecated.py
@@ -20,7 +20,6 @@ import tensorflow as tf
 
 from ..config import default_float
 from ..utilities import to_default_float
-
 from .gauss_hermite import NDiagGHQuadrature
 
 

--- a/gpflow/quadrature/gauss_hermite.py
+++ b/gpflow/quadrature/gauss_hermite.py
@@ -17,10 +17,9 @@ from typing import List
 import numpy as np
 import tensorflow as tf
 
-from .base import GaussianQuadrature
-from ..config import default_float
-
 from ..base import TensorType
+from ..config import default_float
+from .base import GaussianQuadrature
 
 
 def gh_points_and_weights(n_gh: int):

--- a/gpflow/utilities/bijectors.py
+++ b/gpflow/utilities/bijectors.py
@@ -19,7 +19,6 @@ import tensorflow_probability as tfp
 from .. import config
 from .utilities import to_default_float
 
-
 __all__ = ["positive", "triangular"]
 
 

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -15,10 +15,9 @@
 import copy
 from typing import List, Optional, Union
 
+import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
-import numpy as np
-
 
 EllipsisType = type(...)
 

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -15,17 +15,17 @@
 import copy
 import re
 from functools import lru_cache
-from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, Iterable
-from packaging.version import Version
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
+from packaging.version import Version
 from tabulate import tabulate
 
-from .ops import cast
 from ..base import Parameter
 from ..config import default_float, default_int, default_summary_fmt
+from .ops import cast
 
 __all__ = [
     "set_trainable",
@@ -155,7 +155,7 @@ def print_summary(module: tf.Module, fmt: str = None):
     """
     fmt = fmt if fmt is not None else default_summary_fmt()
     if fmt == "notebook":
-        from IPython.core.display import display, HTML
+        from IPython.core.display import HTML, display
 
         tab = tabulate_module_summary(module, "html")
         display(HTML(tab))

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ import sys
 
 from setuptools import find_packages, setup
 
-
 ##### Dependencies of GPflow
 
 # We do not want to install tensorflow in the readthedocs environment, where we

--- a/tests/gpflow/conditionals/test_broadcasted_conditionals.py
+++ b/tests/gpflow/conditionals/test_broadcasted_conditionals.py
@@ -27,7 +27,6 @@ import gpflow.kernels.multioutput as mk
 from gpflow.conditionals import sample_conditional
 from gpflow.conditionals.util import mix_latent_gp
 
-
 # ------------------------------------------
 # Data classes: storing constants
 # ------------------------------------------

--- a/tests/gpflow/conditionals/test_conditionals.py
+++ b/tests/gpflow/conditionals/test_conditionals.py
@@ -19,9 +19,9 @@ from numpy.testing import assert_allclose
 
 import gpflow
 from gpflow import Parameter
-from gpflow.utilities.bijectors import triangular
 from gpflow.conditionals import conditional
 from gpflow.config import default_float
+from gpflow.utilities.bijectors import triangular
 
 rng = np.random.RandomState(123)
 

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -6,18 +6,18 @@ import tensorflow as tf
 import gpflow
 import gpflow.inducing_variables.multioutput as mf
 import gpflow.kernels.multioutput as mk
+from gpflow import set_trainable
 from gpflow.conditionals import sample_conditional
 from gpflow.conditionals.util import (
     fully_correlated_conditional,
     fully_correlated_conditional_repeat,
     sample_mvn,
 )
+from gpflow.config import default_float, default_jitter
 from gpflow.inducing_variables import InducingPoints
 from gpflow.kernels import SquaredExponential
 from gpflow.likelihoods import Gaussian
 from gpflow.models import SVGP
-from gpflow.config import default_jitter, default_float
-from gpflow import set_trainable
 
 float_type = default_float()
 rng = np.random.RandomState(99201)

--- a/tests/gpflow/conditionals/test_uncertain_conditional.py
+++ b/tests/gpflow/conditionals/test_uncertain_conditional.py
@@ -20,12 +20,11 @@ import tensorflow as tf
 from numpy.testing import assert_allclose
 
 import gpflow
-from gpflow.mean_functions import Zero, Constant, Linear
-from gpflow.conditionals import conditional
-from gpflow.conditionals import uncertain_conditional
+from gpflow.conditionals import conditional, uncertain_conditional
+from gpflow.config import default_float
+from gpflow.mean_functions import Constant, Linear, Zero
 from gpflow.optimizers import Scipy
 from gpflow.quadrature import mvnquad
-from gpflow.config import default_float
 from gpflow.utilities import training_loop
 
 rng = np.random.RandomState(1)

--- a/tests/gpflow/config/test_config.py
+++ b/tests/gpflow/config/test_config.py
@@ -35,7 +35,6 @@ from gpflow.config import (
 )
 from gpflow.utilities import to_default_float, to_default_int
 
-
 _env_values = [
     ("int", "int16", np.int16),
     ("int", "int64", np.int64),

--- a/tests/gpflow/covariances/test_base_covariances.py
+++ b/tests/gpflow/covariances/test_base_covariances.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
 import pytest
+from numpy.testing import assert_allclose, assert_equal
+
 import gpflow
-from gpflow.inducing_variables import InducingPoints, Multiscale, InducingPatches
-from gpflow.covariances import Kuu, Kuf
 from gpflow.config import default_jitter
+from gpflow.covariances import Kuf, Kuu
+from gpflow.inducing_variables import InducingPatches, InducingPoints, Multiscale
 
 
 @pytest.mark.parametrize("N, D", [[17, 3], [10, 7]])

--- a/tests/gpflow/covariances/test_multioutput.py
+++ b/tests/gpflow/covariances/test_multioutput.py
@@ -5,7 +5,8 @@ import tensorflow as tf
 import gpflow
 import gpflow.inducing_variables.multioutput as mf
 import gpflow.kernels.multioutput as mk
-from gpflow.covariances.multioutput import kufs as mo_kufs, kuus as mo_kuus
+from gpflow.covariances.multioutput import kufs as mo_kufs
+from gpflow.covariances.multioutput import kuus as mo_kuus
 
 rng = np.random.RandomState(9911)
 

--- a/tests/gpflow/kernels/test_broadcasting.py
+++ b/tests/gpflow/kernels/test_broadcasting.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import tensorflow as tf
-
 import numpy as np
-from numpy.testing import assert_allclose
 import pytest
+import tensorflow as tf
+from numpy.testing import assert_allclose
 
 import gpflow
 import gpflow.ci_utils
 from gpflow import kernels
-
 
 KERNEL_CLASSES = [
     # Static kernels:

--- a/tests/gpflow/kernels/test_changepoints.py
+++ b/tests/gpflow/kernels/test_changepoints.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 import gpflow
 
 

--- a/tests/gpflow/kernels/test_coregion.py
+++ b/tests/gpflow/kernels/test_coregion.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy as np
+import tensorflow as tf
 from numpy.testing import assert_allclose
 
 import gpflow
-import tensorflow as tf
-from gpflow.mean_functions import Constant
 from gpflow import set_trainable
+from gpflow.mean_functions import Constant
 
 rng = np.random.RandomState(0)
 

--- a/tests/gpflow/kernels/test_kernels.py
+++ b/tests/gpflow/kernels/test_kernels.py
@@ -18,23 +18,18 @@ import tensorflow as tf
 from numpy.testing import assert_allclose
 
 import gpflow
+import gpflow.ci_utils
 from gpflow.config import default_float
 from gpflow.kernels import (
-    SquaredExponential,
     ArcCosine,
     Linear,
-    White,
+    LinearCoregionalization,
     SeparateIndependent,
     SharedIndependent,
-    LinearCoregionalization,
+    SquaredExponential,
+    White,
 )
-import gpflow.ci_utils
-from tests.gpflow.kernels.reference import (
-    ref_rbf_kernel,
-    ref_arccosine_kernel,
-    ref_periodic_kernel,
-)
-
+from tests.gpflow.kernels.reference import ref_arccosine_kernel, ref_periodic_kernel, ref_rbf_kernel
 
 rng = np.random.RandomState(1)
 

--- a/tests/gpflow/kernels/test_positive_semidefinite.py
+++ b/tests/gpflow/kernels/test_positive_semidefinite.py
@@ -17,8 +17,8 @@ import pytest
 import tensorflow as tf
 from numpy.testing import assert_array_less
 
-from gpflow import kernels
 import gpflow.ci_utils
+from gpflow import kernels
 
 KERNEL_CLASSES = [
     kernel

--- a/tests/gpflow/likelihoods/test_gaussian.py
+++ b/tests/gpflow/likelihoods/test_gaussian.py
@@ -1,4 +1,5 @@
 import pytest
+
 import gpflow
 
 

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Type, Tuple
+from typing import Tuple, Type
 
 import numpy as np
 import pytest

--- a/tests/gpflow/likelihoods/test_likelihoods.py
+++ b/tests/gpflow/likelihoods/test_likelihoods.py
@@ -18,28 +18,28 @@ import tensorflow as tf
 from numpy.testing import assert_allclose
 
 import gpflow
+import gpflow.ci_utils
+from gpflow.config import default_float, default_int
 from gpflow.likelihoods import (
-    QuadratureLikelihood,
-    ScalarLikelihood,
     Bernoulli,
     Beta,
     Exponential,
     Gamma,
     Gaussian,
     GaussianMC,
+    HeteroskedasticTFPConditional,
     Likelihood,
     MonteCarloLikelihood,
     MultiClass,
     MultiLatentLikelihood,
     MultiLatentTFPConditional,
-    HeteroskedasticTFPConditional,
     Ordinal,
     Poisson,
+    QuadratureLikelihood,
+    ScalarLikelihood,
     StudentT,
 )
 from gpflow.quadrature import ndiagquad
-from gpflow.config import default_float, default_int
-import gpflow.ci_utils
 
 tf.random.set_seed(99012)
 

--- a/tests/gpflow/likelihoods/test_likelihoods.py
+++ b/tests/gpflow/likelihoods/test_likelihoods.py
@@ -20,26 +20,29 @@ from numpy.testing import assert_allclose
 import gpflow
 import gpflow.ci_utils
 from gpflow.config import default_float, default_int
-from gpflow.likelihoods import (
+from gpflow.quadrature import ndiagquad
+
+from gpflow.likelihoods import (  # isort:skip
+    # classes we cannot test:
+    Likelihood,
+    QuadratureLikelihood,
+    ScalarLikelihood,
+    MonteCarloLikelihood,
+    MultiLatentLikelihood,
+    MultiLatentTFPConditional,
+    HeteroskedasticTFPConditional,
+    # classes we do test in this file:
     Bernoulli,
     Beta,
     Exponential,
     Gamma,
     Gaussian,
     GaussianMC,
-    HeteroskedasticTFPConditional,
-    Likelihood,
-    MonteCarloLikelihood,
     MultiClass,
-    MultiLatentLikelihood,
-    MultiLatentTFPConditional,
     Ordinal,
     Poisson,
-    QuadratureLikelihood,
-    ScalarLikelihood,
     StudentT,
 )
-from gpflow.quadrature import ndiagquad
 
 tf.random.set_seed(99012)
 

--- a/tests/gpflow/likelihoods/test_multiclass.py
+++ b/tests/gpflow/likelihoods/test_multiclass.py
@@ -18,13 +18,8 @@ import tensorflow as tf
 from numpy.testing import assert_allclose
 
 import gpflow
-from gpflow.likelihoods import (
-    Bernoulli,
-    MultiClass,
-    RobustMax,
-    Softmax,
-)
 from gpflow.config import default_float, default_int
+from gpflow.likelihoods import Bernoulli, MultiClass, RobustMax, Softmax
 from gpflow.utilities import to_default_float, to_default_int
 
 tf.random.set_seed(99012)

--- a/tests/gpflow/likelihoods/test_switched_likelihood.py
+++ b/tests/gpflow/likelihoods/test_switched_likelihood.py
@@ -20,7 +20,6 @@ from numpy.testing import assert_allclose
 import gpflow
 from gpflow.inducing_variables import InducingPoints
 from gpflow.likelihoods import Gaussian, StudentT, SwitchedLikelihood
-from gpflow.inducing_variables import InducingPoints
 
 
 @pytest.mark.parametrize("Y_list", [[tf.random.normal((i, 2)) for i in range(3, 6)]])

--- a/tests/gpflow/models/test_gplvm.py
+++ b/tests/gpflow/models/test_gplvm.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from typing import Optional
-import pytest
 
 import numpy as np
+import pytest
 import tensorflow as tf
 
 import gpflow

--- a/tests/gpflow/models/test_gpr.py
+++ b/tests/gpflow/models/test_gpr.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gpflow
 import numpy as np
 import pytest
 import tensorflow as tf
+
+import gpflow
 from gpflow import set_trainable
 
 rng = np.random.RandomState(0)

--- a/tests/gpflow/models/test_methods.py
+++ b/tests/gpflow/models/test_methods.py
@@ -22,7 +22,6 @@ from numpy.testing import assert_allclose, assert_array_equal, assert_array_less
 import gpflow
 from gpflow.config import default_float
 
-
 # ------------------------------------------
 # Data classes: storing constants
 # ------------------------------------------

--- a/tests/gpflow/models/test_svgp.py
+++ b/tests/gpflow/models/test_svgp.py
@@ -13,14 +13,15 @@
 # limitations under the License.
 
 from dataclasses import dataclass
+
 import numpy as np
 import pytest
 import tensorflow as tf
 from numpy.testing import assert_allclose, assert_array_equal, assert_array_less
 
 import gpflow
-from gpflow.config import default_float
 from gpflow import set_trainable
+from gpflow.config import default_float
 
 
 @dataclass(frozen=True)

--- a/tests/gpflow/models/test_training_mixins.py
+++ b/tests/gpflow/models/test_training_mixins.py
@@ -1,5 +1,6 @@
 import numpy as np
 import tensorflow as tf
+
 import gpflow
 
 

--- a/tests/gpflow/optimizers/test_mcmc.py
+++ b/tests/gpflow/optimizers/test_mcmc.py
@@ -2,14 +2,14 @@ import numpy as np
 import pytest
 import tensorflow as tf
 import tensorflow_probability as tfp
+from tensorflow_probability.python.bijectors import Exp
+from tensorflow_probability.python.distributions import Gamma, Uniform
 
 import gpflow
 from gpflow import default_float
 from gpflow.base import PriorOn
 from gpflow.config import set_default_float
 from gpflow.utilities import to_default_float
-from tensorflow_probability.python.bijectors import Exp
-from tensorflow_probability.python.distributions import Uniform, Gamma
 
 np.random.seed(1)
 

--- a/tests/gpflow/optimizers/test_natural_gradient.py
+++ b/tests/gpflow/optimizers/test_natural_gradient.py
@@ -1,12 +1,13 @@
 from typing import Optional
+
 import numpy as np
 import pytest
 import tensorflow as tf
 
 import gpflow
+from gpflow import set_trainable
 from gpflow.config import default_float
 from gpflow.optimizers import NaturalGradient
-from gpflow import set_trainable
 
 
 class Setup:

--- a/tests/gpflow/quadrature/test_quadrature_equivalence.py
+++ b/tests/gpflow/quadrature/test_quadrature_equivalence.py
@@ -15,10 +15,10 @@
 import numpy as np
 import pytest
 import tensorflow as tf
+from ndiagquad_old import ndiagquad as ndiagquad_old
 from numpy.testing import assert_allclose
 
 from gpflow.quadrature import ndiagquad
-from ndiagquad_old import ndiagquad as ndiagquad_old
 
 
 @pytest.mark.parametrize("mu", [np.array([1.0, 1.3])])

--- a/tests/gpflow/test_base.py
+++ b/tests/gpflow/test_base.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 
-import gpflow
+import tempfile
+
 import numpy as np
 import pytest
 import tensorflow as tf
-import tempfile
+
+import gpflow
 from gpflow.utilities import positive
 
 

--- a/tests/gpflow/test_base_prior.py
+++ b/tests/gpflow/test_base_prior.py
@@ -2,11 +2,11 @@ import numpy as np
 import pytest
 import tensorflow as tf
 import tensorflow_probability as tfp
-from gpflow.base import PriorOn
-from tensorflow_probability.python.distributions import Uniform
 from tensorflow_probability.python.bijectors import Exp
+from tensorflow_probability.python.distributions import Uniform
 
 import gpflow
+from gpflow.base import PriorOn
 from gpflow.config import set_default_float
 from gpflow.utilities import to_default_float
 

--- a/tests/gpflow/test_base_training.py
+++ b/tests/gpflow/test_base_training.py
@@ -13,16 +13,12 @@
 # limitations under the License.
 
 
-import gpflow
 import numpy as np
 import pytest
 import tensorflow as tf
-from gpflow.utilities import (
-    multiple_assign,
-    set_trainable,
-    leaf_components,
-    read_values,
-)
+
+import gpflow
+from gpflow.utilities import leaf_components, multiple_assign, read_values, set_trainable
 
 rng = np.random.RandomState(0)
 

--- a/tests/gpflow/test_kullback_leiblers.py
+++ b/tests/gpflow/test_kullback_leiblers.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 from numpy.testing import assert_allclose, assert_almost_equal
 
 import gpflow
-from gpflow import default_float, default_jitter, Parameter
+from gpflow import Parameter, default_float, default_jitter
 from gpflow.inducing_variables import InducingPoints
 from gpflow.kullback_leiblers import gauss_kl, prior_kl
 from gpflow.utilities.bijectors import triangular

--- a/tests/gpflow/test_logdensities.py
+++ b/tests/gpflow/test_logdensities.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 import numpy as np
-from numpy.random import randn
 import pytest
-import tensorflow as tf
-from gpflow import logdensities
-from gpflow import default_float
-from gpflow.utilities import to_default_float
 import scipy.stats
-from scipy.stats import multivariate_normal as mvn
+import tensorflow as tf
+from numpy.random import randn
 from numpy.testing import assert_allclose
+from scipy.stats import multivariate_normal as mvn
+
+from gpflow import default_float, logdensities
+from gpflow.utilities import to_default_float
 
 rng = np.random.RandomState(1)
 

--- a/tests/gpflow/test_mean_functions.py
+++ b/tests/gpflow/test_mean_functions.py
@@ -19,14 +19,7 @@ from numpy.testing import assert_allclose
 import gpflow
 from gpflow.config import default_int
 from gpflow.inducing_variables import InducingPoints
-from gpflow.mean_functions import (
-    Additive,
-    Constant,
-    Linear,
-    Product,
-    SwitchedMeanFunction,
-    Zero,
-)
+from gpflow.mean_functions import Additive, Constant, Linear, Product, SwitchedMeanFunction, Zero
 
 rng = np.random.RandomState(99021)
 

--- a/tests/gpflow/utilities/test_deepcopy.py
+++ b/tests/gpflow/utilities/test_deepcopy.py
@@ -1,10 +1,11 @@
 import copy
 import pickle
 
-import gpflow
 import pytest
 import tensorflow as tf
 import tensorflow_probability as tfp
+
+import gpflow
 
 
 class A(tf.Module):

--- a/tests/gpflow/utilities/test_multipledispatch.py
+++ b/tests/gpflow/utilities/test_multipledispatch.py
@@ -1,10 +1,10 @@
 import re
 import warnings
-from packaging.version import Version
 
 import multipledispatch
 import pytest
 import tensorflow as tf
+from packaging.version import Version
 
 import gpflow
 

--- a/tests/gpflow/utilities/test_ops.py
+++ b/tests/gpflow/utilities/test_ops.py
@@ -1,5 +1,5 @@
-import pytest
 import numpy as np
+import pytest
 import tensorflow as tf
 
 import gpflow

--- a/tests/gpflow/utilities/test_printing.py
+++ b/tests/gpflow/utilities/test_printing.py
@@ -19,10 +19,10 @@ import tensorflow as tf
 import gpflow
 from gpflow.config import Config, as_context
 from gpflow.utilities.utilities import (
-    leaf_components,
     _merge_leaf_components,
-    tabulate_module_summary,
+    leaf_components,
     set_trainable,
+    tabulate_module_summary,
 )
 
 rng = np.random.RandomState(0)

--- a/tests/integration/test_dynamic_shapes.py
+++ b/tests/integration/test_dynamic_shapes.py
@@ -18,7 +18,7 @@ import tensorflow as tf
 from numpy.testing import assert_allclose
 
 import gpflow
-from gpflow.config import default_jitter, default_float
+from gpflow.config import default_float, default_jitter
 from gpflow.mean_functions import Constant
 
 rng = np.random.RandomState(0)

--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -24,7 +24,6 @@ import pytest
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
 
-
 NOTEBOOK_DIR = "../../doc/source/notebooks"
 
 

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,5 +1,6 @@
 mypy
 black==19.10b0
+isort
 pytest>=3.5.0
 pytest-cov
 pytest-random-order


### PR DESCRIPTION
**PR type:** CI enhancement

## Summary

**Proposed changes**
* Add isort to `make format` / `make format-check` and run it as part of the format-checker test on CircleCI
* Except for `gpflow/models/__init__.py` where I removed a commented-out import to get black & isort to agree with each other, all code files (gpflow/, tests/, setup.py) were only edited by running `make format` locally.

**What alternatives have you considered?**
* Continue to manually clean up imports (or let them get messy)

## PR checklist
<!-- tick off [X] as applicable -->
- [x] New features: code is well-documented
- [x] I ran the black formatter (`make format`)
- [x] I locally tested that the tests pass (`make check-all`)

### Release notes

**Fully backwards compatible:** yes

**Commit message (for release notes):**

* GPflow now requires isort in its CI build. Run `make format` before opening PRs.
