### PR TITLE
fix broken API docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs-performance-issues.md
+++ b/.github/ISSUE_TEMPLATE/bugs-performance-issues.md
@@ -2,7 +2,6 @@
 name: Bug report (including performance and build issues)
 about: Help us find mistakes in the GPflow code base
 labels: bug
-projects: 7
 ---
 
 <!-- Lines like this are comments and will be invisible -->

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -88,7 +88,7 @@ Citing GPflow
 
 To cite GPflow, please reference the `JMLR paper <http://www.jmlr.org/papers/volume18/16-537/16-537.pdf>`_. Sample BibTeX is given below:
 
-.. code-block:: bst
+.. code-block:: bib
 
     @ARTICLE{GPflow2017,
         author = {Matthews, Alexander G. de G. and {van der Wilk}, Mark and Nickson, Tom and Fujii, Keisuke. and {Boukouvalas}, Alexis and {Le{\'o}n-Villagr{\'a}}, Pablo and Ghahramani, Zoubin and Hensman, James},
@@ -107,7 +107,7 @@ with the framework for interdomain approximations and multioutput priors. We rev
 framework and describe the design in an `arXiv paper <https://arxiv.org/abs/2003.01115>`_
 which can be cited by users.
 
-.. code-block:: bst
+.. code-block:: bib
 
     @article{GPflow2020multioutput,
       author = {{van der Wilk}, Mark and Dutordoir, Vincent and John, ST and

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -245,34 +245,6 @@ def _get_leaf_components(input_module: tf.Module):
     return state
 
 
-if Version(tfp.__version__) >= Version("0.11.0"):
-    if hasattr(tfp.bijectors.Identity()._cache, "clear"):
-        # implementation in `master` branch (checked 29 Sep 2020) provides clear():
-
-        def _clear_bijector_cache(bijector: tfp.bijectors.Bijector):
-            bijector._cache.clear()
-
-    else:
-        # previous versions (including the versions 0.11.0 and 0.11.1 released as of 29 Sep 2020) provide reset(), but its implementation is broken
-
-        def _clear_bijector_cache(bijector: tfp.bijectors.Bijector):
-            # workaround for broken implementation of bijector._cache.reset():
-            cache = bijector._cache
-            cache_type = type(cache.forward)
-            assert type(cache.inverse) == cache_type
-            cache.__init__(cache.forward._func, cache.inverse._func, cache_type)
-
-
-else:
-    # fallback for backwards-compatibility with tensorflow_probability < 0.11.0
-
-    def _clear_bijector_cache(bijector: tfp.bijectors.Bijector):
-        # `_from_x` and `_from_y` are cache dictionaries for forward and inverse transformations
-        # in bijector class.
-        bijector._from_x.clear()
-        bijector._from_y.clear()
-
-
 def reset_cache_bijectors(input_module: tf.Module) -> tf.Module:
     """
     Recursively finds tfp.bijectors.Bijector-s inside the components of the tf.Module using `traverse_component`.
@@ -281,6 +253,33 @@ def reset_cache_bijectors(input_module: tf.Module) -> tf.Module:
     :param input_module: tf.Module including keras.Model, keras.layers.Layer and gpflow.Module.
     :return:
     """
+    if Version(tfp.__version__) >= Version("0.11.0"):
+        if hasattr(tfp.bijectors.Identity()._cache, "clear"):
+            # implementation in `master` branch (checked 29 Sep 2020) provides clear():
+
+            def _clear_bijector_cache(bijector: tfp.bijectors.Bijector):
+                bijector._cache.clear()
+
+        else:
+            # previous versions (including the versions 0.11.0 and 0.11.1 released as of 29 Sep 2020) provide reset(), but its implementation is broken
+
+            def _clear_bijector_cache(bijector: tfp.bijectors.Bijector):
+                # workaround for broken implementation of bijector._cache.reset():
+                cache = bijector._cache
+                cache_type = type(cache.forward)
+                assert type(cache.inverse) == cache_type
+                cache.__init__(cache.forward._func, cache.inverse._func, cache_type)
+
+
+    else:
+        # fallback for backwards-compatibility with tensorflow_probability < 0.11.0
+
+        def _clear_bijector_cache(bijector: tfp.bijectors.Bijector):
+            # `_from_x` and `_from_y` are cache dictionaries for forward and inverse transformations
+            bijector._from_x.clear()
+            bijector._from_y.clear()
+
+
     target_types = (tfp.bijectors.Bijector,)
     accumulator = ("", None)
 

--- a/gpflow/utilities/utilities.py
+++ b/gpflow/utilities/utilities.py
@@ -270,7 +270,6 @@ def reset_cache_bijectors(input_module: tf.Module) -> tf.Module:
                 assert type(cache.inverse) == cache_type
                 cache.__init__(cache.forward._func, cache.inverse._func, cache_type)
 
-
     else:
         # fallback for backwards-compatibility with tensorflow_probability < 0.11.0
 
@@ -278,7 +277,6 @@ def reset_cache_bijectors(input_module: tf.Module) -> tf.Module:
             # `_from_x` and `_from_y` are cache dictionaries for forward and inverse transformations
             bijector._from_x.clear()
             bijector._from_y.clear()
-
 
     target_types = (tfp.bijectors.Bijector,)
     accumulator = ("", None)

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,6 +1,6 @@
 mypy
 black==19.10b0
-isort
+isort>=5.1
 pytest>=3.5.0
 pytest-cov
 pytest-random-order


### PR DESCRIPTION
The recent PR for compatibility with multiple tfp versions (#1553, updated by #1574) broke our Sphinx build: we set `autodoc_mock_imports = ["tensorflow", "tensorflow_probability"]` in doc/source/conf.py; this means when building the documentation, `tfp` is a mock, and `tfp.__version__` cannot be parsed and `Version(tfp.__version__)` errors! This PR moves the version checks *inside* `reset_cache_bijectors`, so there won't be an import-time error anymore (and Sphinx does not actually execute the code).

A few minor fly-by changes that I uncovered in preparing this PR...