### PR TITLE
Doc requirements update

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,9 +1,7 @@
-gast==0.2.2
-ipython==7.8.0
-sphinx==2.2.0
-sphinx_autodoc_typehints==1.8.0
-sphinx_rtd_theme==0.4.3
-numpydoc==0.9.1
-nbsphinx==0.4.3
+ipython==7.18.1
+Sphinx==3.2.1
+sphinx-autodoc-typehints==1.11.0
+sphinx-rtd-theme==0.5.0
+numpydoc==1.1.0
+nbsphinx==0.7.1
 pandoc==1.0.2
-git+https://github.com/GPflow/GPflow.git@develop#egg=gpflow

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -84,8 +84,8 @@ master_doc = "index"
 
 # General information about the project.
 project = "GPflow"
-copyright = "2016-2020, James Hensman, Alexander G. de G. Matthews and the GPflow contributors"
-author = "James Hensman and Alexander G. de G. Matthews and others"
+copyright = "2016-2020 The GPflow Contributors"
+author = "James Hensman and Alexander G. de G. Matthews and many others"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
doc/requirements.txt specifies gpflow=develop from github - this won't work with building the "master" branch doc on readthedocs! Remove it here, and add it as a separate dependency in github.com/GPflow/docs/

Also, updating the versions as I can't get the docs to build locally with the previously pinned versions, whereas it's working with the updated versions.