### PR TITLE
Replace len(inducing_variable) with inducing_variable.num inducing property

### DIFF
--- a/gpflow/covariances/kufs.py
+++ b/gpflow/covariances/kufs.py
@@ -37,8 +37,8 @@ def Kuf_sqexp_multiscale(inducing_variable: Multiscale, kernel: SquaredExponenti
 
 
 @Kuf.register(InducingPatches, Convolutional, object)
-def Kuf_conv_patch(feat, kern, Xnew):
-    Xp = kern.get_patches(Xnew)  # [N, num_patches, patch_len]
-    bigKzx = kern.base_kernel.K(feat.Z, Xp)  # [M, N, P] -- thanks to broadcasting of kernels
-    Kzx = tf.reduce_sum(bigKzx * kern.weights if hasattr(kern, "weights") else bigKzx, [2])
-    return Kzx / kern.num_patches
+def Kuf_conv_patch(inducing_variable, kernel, Xnew):
+    Xp = kernel.get_patches(Xnew)  # [N, num_patches, patch_len]
+    bigKzx = kernel.base_kernel.K(inducing_variable.Z, Xp)  # [M, N, P] -- thanks to broadcasting of kernels
+    Kzx = tf.reduce_sum(bigKzx * kernel.weights if hasattr(kernel, "weights") else bigKzx, [2])
+    return Kzx / kernel.num_patches

--- a/gpflow/covariances/kufs.py
+++ b/gpflow/covariances/kufs.py
@@ -39,6 +39,8 @@ def Kuf_sqexp_multiscale(inducing_variable: Multiscale, kernel: SquaredExponenti
 @Kuf.register(InducingPatches, Convolutional, object)
 def Kuf_conv_patch(inducing_variable, kernel, Xnew):
     Xp = kernel.get_patches(Xnew)  # [N, num_patches, patch_len]
-    bigKzx = kernel.base_kernel.K(inducing_variable.Z, Xp)  # [M, N, P] -- thanks to broadcasting of kernels
+    bigKzx = kernel.base_kernel.K(
+        inducing_variable.Z, Xp
+    )  # [M, N, P] -- thanks to broadcasting of kernels
     Kzx = tf.reduce_sum(bigKzx * kernel.weights if hasattr(kernel, "weights") else bigKzx, [2])
     return Kzx / kernel.num_patches

--- a/gpflow/covariances/kuus.py
+++ b/gpflow/covariances/kuus.py
@@ -23,7 +23,7 @@ from .dispatch import Kuu
 @Kuu.register(InducingPoints, Kernel)
 def Kuu_kernel_inducingpoints(inducing_variable: InducingPoints, kernel: Kernel, *, jitter=0.0):
     Kzz = kernel(inducing_variable.Z)
-    Kzz += jitter * tf.eye(len(inducing_variable), dtype=Kzz.dtype)
+    Kzz += jitter * tf.eye(inducing_variable.num_inducing, dtype=Kzz.dtype)
     return Kzz
 
 
@@ -36,10 +36,10 @@ def Kuu_sqexp_multiscale(inducing_variable: Multiscale, kernel: SquaredExponenti
     )
     d = inducing_variable._cust_square_dist(Zmu, Zmu, sc)
     Kzz = kernel.variance * tf.exp(-d / 2) * tf.reduce_prod(kernel.lengthscales / sc, 2)
-    Kzz += jitter * tf.eye(len(inducing_variable), dtype=Kzz.dtype)
+    Kzz += jitter * tf.eye(inducing_variable.num_inducing, dtype=Kzz.dtype)
     return Kzz
 
 
 @Kuu.register(InducingPatches, Convolutional)
-def Kuu_conv_patch(feat, kern, jitter=0.0):
-    return kern.base_kernel.K(feat.Z) + jitter * tf.eye(len(feat), dtype=default_float())
+def Kuu_conv_patch(inducing_variable, kernel, jitter=0.0):
+    return kernel.base_kernel.K(inducing_variable.Z) + jitter * tf.eye(inducing_variable.num_inducing, dtype=default_float())

--- a/gpflow/covariances/kuus.py
+++ b/gpflow/covariances/kuus.py
@@ -42,4 +42,6 @@ def Kuu_sqexp_multiscale(inducing_variable: Multiscale, kernel: SquaredExponenti
 
 @Kuu.register(InducingPatches, Convolutional)
 def Kuu_conv_patch(inducing_variable, kernel, jitter=0.0):
-    return kernel.base_kernel.K(inducing_variable.Z) + jitter * tf.eye(inducing_variable.num_inducing, dtype=default_float())
+    return kernel.base_kernel.K(inducing_variable.Z) + jitter * tf.eye(
+        inducing_variable.num_inducing, dtype=default_float()
+    )

--- a/gpflow/covariances/multioutput/kuus.py
+++ b/gpflow/covariances/multioutput/kuus.py
@@ -48,7 +48,7 @@ def _Kuu(
     jitter=0.0,
 ):
     Kmm = Kuu(inducing_variable.inducing_variable, kernel.kernel)  # [M, M]
-    jittermat = tf.eye(len(inducing_variable), dtype=Kmm.dtype) * jitter
+    jittermat = tf.eye(inducing_variable.num_inducing, dtype=Kmm.dtype) * jitter
     return Kmm + jittermat
 
 
@@ -62,7 +62,7 @@ def _Kuu(
     Kmm = tf.stack(
         [Kuu(inducing_variable.inducing_variable, k) for k in kernel.kernels], axis=0
     )  # [L, M, M]
-    jittermat = tf.eye(len(inducing_variable), dtype=Kmm.dtype)[None, :, :] * jitter
+    jittermat = tf.eye(inducing_variable.num_inducing, dtype=Kmm.dtype)[None, :, :] * jitter
     return Kmm + jittermat
 
 
@@ -76,7 +76,7 @@ def _Kuu(
     Kmm = tf.stack(
         [Kuu(f, kernel.kernel) for f in inducing_variable.inducing_variable_list], axis=0
     )  # [L, M, M]
-    jittermat = tf.eye(len(inducing_variable), dtype=Kmm.dtype)[None, :, :] * jitter
+    jittermat = tf.eye(inducing_variable.num_inducing, dtype=Kmm.dtype)[None, :, :] * jitter
     return Kmm + jittermat
 
 
@@ -91,5 +91,5 @@ def _Kuu(
 ):
     Kmms = [Kuu(f, k) for f, k in zip(inducing_variable.inducing_variable_list, kernel.kernels)]
     Kmm = tf.stack(Kmms, axis=0)  # [L, M, M]
-    jittermat = tf.eye(len(inducing_variable), dtype=Kmm.dtype)[None, :, :] * jitter
+    jittermat = tf.eye(inducing_variable.num_inducing, dtype=Kmm.dtype)[None, :, :] * jitter
     return Kmm + jittermat

--- a/gpflow/inducing_variables/inducing_variables.py
+++ b/gpflow/inducing_variables/inducing_variables.py
@@ -35,6 +35,10 @@ class InducingVariables(Module):
         """
         raise NotImplementedError
 
+    @property
+    def num_inducing(self) -> int:
+        return self.__len__()
+
 
 class InducingPointsBase(InducingVariables):
     def __init__(self, Z: TensorData, name: Optional[str] = None):

--- a/gpflow/inducing_variables/inducing_variables.py
+++ b/gpflow/inducing_variables/inducing_variables.py
@@ -16,6 +16,7 @@ import abc
 from typing import Optional
 
 import tensorflow as tf
+import tensorflow_probability as tfp
 
 from ..base import Module, Parameter, TensorData, TensorType
 from ..config import default_float
@@ -46,7 +47,9 @@ class InducingPointsBase(InducingVariables):
         :param Z: the initial positions of the inducing points, size [M, D]
         """
         super().__init__(name=name)
-        self.Z = Parameter(Z, dtype=default_float())
+        if not isinstance(Z, (tf.Variable, tfp.util.TransformedVariable)):
+            Z = Parameter(Z)
+        self.Z = Z
 
     def __len__(self) -> int:
         return tf.shape(self.Z)[0]

--- a/gpflow/inducing_variables/inducing_variables.py
+++ b/gpflow/inducing_variables/inducing_variables.py
@@ -49,7 +49,7 @@ class InducingPointsBase(InducingVariables):
         self.Z = Parameter(Z, dtype=default_float())
 
     def __len__(self) -> int:
-        return self.Z.shape[0]
+        return tf.shape(self.Z)[0]
 
 
 class InducingPoints(InducingPointsBase):

--- a/gpflow/inducing_variables/multioutput/inducing_variables.py
+++ b/gpflow/inducing_variables/multioutput/inducing_variables.py
@@ -67,7 +67,7 @@ class FallbackSharedIndependentInducingVariables(MultioutputInducingVariables):
         self.inducing_variable = inducing_variable
 
     def __len__(self) -> int:
-        return len(self.inducing_variable)
+        return self.inducing_variable.num_inducing
 
     @property
     def inducing_variables(self) -> Tuple[TensorType]:
@@ -108,7 +108,8 @@ class FallbackSeparateIndependentInducingVariables(MultioutputInducingVariables)
         self.inducing_variable_list = inducing_variable_list
 
     def __len__(self) -> int:
-        return len(self.inducing_variable_list[0])
+        # TODO(st--) we should check that they all have the same length...
+        return self.inducing_variable_list[0].num_inducing
 
     @property
     def inducing_variables(self) -> Tuple[TensorType, ...]:

--- a/gpflow/models/gplvm.py
+++ b/gpflow/models/gplvm.py
@@ -157,7 +157,7 @@ class BayesianGPLVM(GPModel, InternalDataTrainingLossMixin):
 
         pX = DiagonalGaussian(self.X_data_mean, self.X_data_var)
 
-        num_inducing = len(self.inducing_variable)
+        num_inducing = self.inducing_variable.num_inducing
         psi0 = tf.reduce_sum(expectation(pX, self.kernel))
         psi1 = expectation(pX, (self.kernel, self.inducing_variable))
         psi2 = tf.reduce_sum(
@@ -223,7 +223,7 @@ class BayesianGPLVM(GPModel, InternalDataTrainingLossMixin):
         pX = DiagonalGaussian(self.X_data_mean, self.X_data_var)
 
         Y_data = self.data
-        num_inducing = len(self.inducing_variable)
+        num_inducing = self.inducing_variable.num_inducing
         psi1 = expectation(pX, (self.kernel, self.inducing_variable))
         psi2 = tf.reduce_sum(
             expectation(

--- a/gpflow/models/sgpmc.py
+++ b/gpflow/models/sgpmc.py
@@ -83,7 +83,7 @@ class SGPMC(GPModel, InternalDataTrainingLossMixin):
         self.data = data_input_to_tensor(data)
         self.num_data = data[0].shape[0]
         self.inducing_variable = inducingpoint_wrapper(inducing_variable)
-        self.V = Parameter(np.zeros((len(self.inducing_variable), self.num_latent_gps)))
+        self.V = Parameter(np.zeros((self.inducing_variable.num_inducing, self.num_latent_gps)))
         self.V.prior = tfp.distributions.Normal(
             loc=to_default_float(0.0), scale=to_default_float(1.0)
         )

--- a/gpflow/models/sgpr.py
+++ b/gpflow/models/sgpr.py
@@ -92,7 +92,7 @@ class SGPRBase(GPModel, InternalDataTrainingLossMixin):
         The key quantity, the trace term, can be computed via
 
         >>> _, v = conditionals.conditional(X, model.inducing_variable.Z, model.kernel,
-        ...                                 np.zeros((len(model.inducing_variable), 1)))
+        ...                                 np.zeros((model.inducing_variable.num_inducing, 1)))
 
         which computes each individual element of the trace term.
         """
@@ -161,7 +161,7 @@ class SGPR(SGPRBase):
         """
         X_data, Y_data = self.data
 
-        num_inducing = len(self.inducing_variable)
+        num_inducing = self.inducing_variable.num_inducing
         num_data = to_default_float(tf.shape(Y_data)[0])
         output_dim = to_default_float(tf.shape(Y_data)[1])
 
@@ -198,7 +198,7 @@ class SGPR(SGPRBase):
         notebook.
         """
         X_data, Y_data = self.data
-        num_inducing = len(self.inducing_variable)
+        num_inducing = self.inducing_variable.num_inducing
         err = Y_data - self.mean_function(X_data)
         kuf = Kuf(self.inducing_variable, self.kernel, X_data)
         kuu = Kuu(self.inducing_variable, self.kernel, jitter=default_jitter())
@@ -282,7 +282,7 @@ class GPRFITC(SGPRBase):
 
     def common_terms(self):
         X_data, Y_data = self.data
-        num_inducing = len(self.inducing_variable)
+        num_inducing = self.inducing_variable.num_inducing
         err = Y_data - self.mean_function(X_data)  # size [N, R]
         Kdiag = self.kernel(X_data, full_cov=False)
         kuf = Kuf(self.inducing_variable, self.kernel, X_data)

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -75,7 +75,7 @@ class SVGP(GPModel, ExternalDataTrainingLossMixin):
         self.inducing_variable = inducingpoint_wrapper(inducing_variable)
 
         # init variational parameters
-        num_inducing = len(self.inducing_variable)
+        num_inducing = self.inducing_variable.num_inducing
         self._init_variational_parameters(num_inducing, q_mu, q_sqrt, q_diag)
 
     def _init_variational_parameters(self, num_inducing, q_mu, q_sqrt, q_diag):

--- a/tests/gpflow/test_inducing_variables.py
+++ b/tests/gpflow/test_inducing_variables.py
@@ -1,3 +1,17 @@
+# Copyright 2020 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import tensorflow as tf
 

--- a/tests/gpflow/test_inducing_variables.py
+++ b/tests/gpflow/test_inducing_variables.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 import gpflow
 
 
-def test_inducing_points_with_None_shape():
+def test_inducing_points_with_variable_shape():
     N, M1, D, P = 50, 13, 3, 1
     X, Y = np.random.randn(N, D), np.random.randn(N, P)
 
@@ -16,13 +16,17 @@ def test_inducing_points_with_None_shape():
 
     m = gpflow.models.SGPR(data=(X, Y), kernel=gpflow.kernels.Matern32(), inducing_variable=iv)
 
-    Z2 = np.random.randn(M1 + 1, D)
-    m.inducing_variable.Z.assign(Z2)
-
     opt = tf.optimizers.Adam()
 
     @tf.function
     def optimization_step():
         opt.minimize(m.training_loss, m.trainable_variables)
 
+    optimization_step()
+
+    # Check 1: that we can successfully assign a new Z with different number of inducing points!
+    Z2 = np.random.randn(M1 + 1, D)
+    m.inducing_variable.Z.assign(Z2)
+
+    # Check 2: that we can still optimize!
     optimization_step()

--- a/tests/gpflow/test_inducing_variables.py
+++ b/tests/gpflow/test_inducing_variables.py
@@ -30,6 +30,7 @@ def test_inducing_points_with_variable_shape():
 
     m = gpflow.models.SGPR(data=(X, Y), kernel=gpflow.kernels.Matern32(), inducing_variable=iv)
 
+    # Check 1: that we can still optimize with None shape
     opt = tf.optimizers.Adam()
 
     @tf.function
@@ -38,9 +39,9 @@ def test_inducing_points_with_variable_shape():
 
     optimization_step()
 
-    # Check 1: that we can successfully assign a new Z with different number of inducing points!
+    # Check 2: that we can successfully assign a new Z with different number of inducing points!
     Z2 = np.random.randn(M1 + 1, D)
     m.inducing_variable.Z.assign(Z2)
 
-    # Check 2: that we can still optimize!
+    # Check 3: that we can also optimize with changed Z tensor
     optimization_step()

--- a/tests/gpflow/test_inducing_variables.py
+++ b/tests/gpflow/test_inducing_variables.py
@@ -1,0 +1,28 @@
+import numpy as np
+import tensorflow as tf
+
+import gpflow
+
+
+def test_inducing_points_with_None_shape():
+    N, M1, D, P = 50, 13, 3, 1
+    X, Y = np.random.randn(N, D), np.random.randn(N, P)
+
+    Z1 = np.random.randn(M1, D)
+
+    iv = gpflow.inducing_variables.InducingPoints(Z1)
+    # overwrite Parameter with explicit tf.Variable with None shape:
+    iv.Z = tf.Variable(Z1, trainable=False, dtype=gpflow.default_float(), shape=(None, D))
+
+    m = gpflow.models.SGPR(data=(X, Y), kernel=gpflow.kernels.Matern32(), inducing_variable=iv)
+
+    Z2 = np.random.randn(M1 + 1, D)
+    m.inducing_variable.Z.assign(Z2)
+
+    opt = tf.optimizers.Adam()
+
+    @tf.function
+    def optimization_step():
+        opt.minimize(m.training_loss, m.trainable_variables)
+
+    optimization_step()

--- a/tests/gpflow/test_inducing_variables.py
+++ b/tests/gpflow/test_inducing_variables.py
@@ -24,9 +24,12 @@ def test_inducing_points_with_variable_shape():
 
     Z1 = np.random.randn(M1, D)
 
-    iv = gpflow.inducing_variables.InducingPoints(Z1)
-    # overwrite Parameter with explicit tf.Variable with None shape:
-    iv.Z = tf.Variable(Z1, trainable=False, dtype=gpflow.default_float(), shape=(None, D))
+    # use explicit tf.Variable with None shape:
+    iv = gpflow.inducing_variables.InducingPoints(
+        tf.Variable(Z1, trainable=False, dtype=gpflow.default_float(), shape=(None, D))
+    )
+    # Note that we cannot have Z be trainable if we want to be able to change its shape;
+    # TensorFlow optimizers expect shape to be known at construction time.
 
     m = gpflow.models.SGPR(data=(X, Y), kernel=gpflow.kernels.Matern32(), inducing_variable=iv)
 


### PR DESCRIPTION
**PR type:** bugfix / enhancement

**Related issue(s)/PRs:** Resolves #1578

## Summary

**Proposed changes**

Instead of calling `len(inducing_variable)`, make use of the new `inducing_variable.num_inducing` property (which calls `inducing_variable.__len__()` in the same way). This allows using a tf.Variable() with `None` shape as Z, as demonstrated in the added test.

### Minimal working example

See added test

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [X] The bug case / new feature is covered by unit tests
- [X] Code has type annotations
- [X] I ran the black+isort formatter (`make format`)
- [ ] I locally tested that the tests pass (`make check-all`)

### Release notes

<!-- leave blank if unsure -->

**Fully backwards compatible:** yes

**Commit message (for release notes):**

* Add support for inducing variables with dynamically changing shape. Use `inducing_variable.num_inducing` instead of `len(inducing_variable)`.
