### PR TITLE
HeteroskedasticTFPConditional should construct tensors at class-construction, not at module-import time

### DIFF
--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -97,7 +97,7 @@ class HeteroskedasticTFPConditional(MultiLatentTFPConditional):
     def __init__(
         self,
         distribution_class: Type[tfp.distributions.Distribution] = tfp.distributions.Normal,
-        scale_transform: tfp.bijectors.Bijector = positive(base="exp"),
+        scale_transform: Optional[tfp.bijectors.Bijector] = None,
         **kwargs,
     ):
         """
@@ -107,6 +107,8 @@ class HeteroskedasticTFPConditional(MultiLatentTFPConditional):
             function modelling the scale to ensure its positivity.
             Typically, `tf.exp` or `tf.softplus`, but can be any function f: R -> R^+.
         """
+        if scale_transform is None:
+            scale_transform = positive(base="exp")
 
         def conditional_distribution(Fs) -> tfp.distributions.Distribution:
             tf.debugging.assert_equal(tf.shape(Fs)[-1], 2)

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -109,11 +109,12 @@ class HeteroskedasticTFPConditional(MultiLatentTFPConditional):
         """
         if scale_transform is None:
             scale_transform = positive(base="exp")
+        self.scale_transform = scale_transform
 
         def conditional_distribution(Fs) -> tfp.distributions.Distribution:
             tf.debugging.assert_equal(tf.shape(Fs)[-1], 2)
             loc = Fs[..., :1]
-            scale = scale_transform(Fs[..., 1:])
+            scale = self.scale_transform(Fs[..., 1:])
             return distribution_class(loc, scale)
 
         super().__init__(

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -105,7 +105,7 @@ class HeteroskedasticTFPConditional(MultiLatentTFPConditional):
             as first and second argument, respectively.
         :param scale_transform: callable/bijector applied to the latent
             function modelling the scale to ensure its positivity.
-            Typically, `tf.exp` or `tf.softplus`, but can be any function f: R -> R^+. Defaults to `tf.exp` if not explicitly specified. 
+            Typically, `tf.exp` or `tf.softplus`, but can be any function f: R -> R^+. Defaults to exp if not explicitly specified. 
         """
         if scale_transform is None:
             scale_transform = positive(base="exp")

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -105,7 +105,7 @@ class HeteroskedasticTFPConditional(MultiLatentTFPConditional):
             as first and second argument, respectively.
         :param scale_transform: callable/bijector applied to the latent
             function modelling the scale to ensure its positivity.
-            Typically, `tf.exp` or `tf.softplus`, but can be any function f: R -> R^+.
+            Typically, `tf.exp` or `tf.softplus`, but can be any function f: R -> R^+. Defaults to `tf.exp` if not explicitly specified. 
         """
         if scale_transform is None:
             scale_transform = positive(base="exp")


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** enhancement

**Related issue(s)/PRs:** [discussion in gpflow slack, request-for-help, oct. 10]

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->
As discussed in the slack channel, `likelihoods.multilatent.HeteroskedasticTFPConditional` currently creates tensors at import time. This is due to the call of `positive(base="exp")` as a keyword argument default. This causes issues when gpflow is imported before the CUDA environment variable is set. Suggested improvements: 

<!-- A clear and concise description of the contents of this pull request. -->
* don't call positive at import time, i.e. new input is `scale_transform: Optional[tfp.bijectors.Bijector] = None`
* move this call into the `__init__` method instead 
* make` self.scale_transform = scale_transform` an attribute of `HeteroskedasticTFPConditional`

**What alternatives have you considered?**
Setting the CUDA environment variable before importing gpflow also works. 

### Minimal working example

```python
import os
import tensorflow as tf
import gpflow
os.environ["CUDA_VISIBLE_DEVICES"] = "0"
print('device is:', os.environ["CUDA_VISIBLE_DEVICES"])
print(tf.test.is_gpu_available())
```
<img width="1326" alt="cuda_error" src="https://user-images.githubusercontent.com/23448461/95840398-5c281500-0d44-11eb-9a74-53c26ae858fb.png">

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
- [ ] detailed docstrings (API documentation)
- [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [x] I ran the black+isort formatter (`make format`)
- [X] I locally tested that the tests pass (`make check-all`)

### Release notes

<!-- leave blank if unsure -->

**Fully backwards compatible:** 

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

**Commit message (for release notes):**
 change HeteroskedasticTFPConditional so it only constructs the tensor at class-construction, not at module-import time

