### PR TITLE
Extend SVGP predict_f() and predict_y() to support predictions with samples from the inducing point distribution

### DIFF
--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -215,13 +215,13 @@ class SVGP(GPModel, ExternalDataTrainingLossMixin):
             q_mu = self.q_mu
             q_sqrt = self.q_sqrt
             mu, var = conditional(Xnew,
-                                    self.inducing_variable,
-                                    self.kernel,
-                                    q_mu,
-                                    q_sqrt=q_sqrt,
-                                    full_cov=full_cov,
-                                    white=self.whiten,
-                                    full_output_cov=full_output_cov)
+                                  self.inducing_variable,
+                                  self.kernel,
+                                  q_mu,
+                                  q_sqrt=q_sqrt,
+                                  full_cov=full_cov,
+                                  white=self.whiten,
+                                  full_output_cov=full_output_cov)
         else:
             q_mu = self.sample_inducing_points(num_inducing_samples)
             q_sqrt = None
@@ -229,19 +229,20 @@ class SVGP(GPModel, ExternalDataTrainingLossMixin):
             @tf.function
             def single_sample_conditional(q_mu):
                 return conditional(Xnew,
-                                    self.inducing_variable,
-                                    self.kernel,
-                                    q_mu,
-                                    q_sqrt=q_sqrt,
-                                    full_cov=full_cov,
-                                    white=self.whiten,
-                                    full_output_cov=full_output_cov)
+                                   self.inducing_variable,
+                                   self.kernel,
+                                   q_mu,
+                                   q_sqrt=q_sqrt,
+                                   full_cov=full_cov,
+                                   white=self.whiten,
+                                   full_output_cov=full_output_cov)
 
             # map each inducing point sample through the standard GP conditional
             mu, var = tf.map_fn(single_sample_conditional,
                                 q_mu,
                                 dtype=(default_float(), default_float()))
-            return mu + self.mean_function(Xnew), var
+        return mu + self.mean_function(Xnew), var
+
     def predict_y(self,
                   Xnew: InputData,
                   num_inducing_samples: int = None,

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -16,6 +16,7 @@ from typing import Tuple
 
 import numpy as np
 import tensorflow as tf
+import tensorflow_probability as tfp
 
 from .. import kullback_leiblers
 from ..base import Parameter

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -242,3 +242,15 @@ class SVGP(GPModel, ExternalDataTrainingLossMixin):
                                 q_mu,
                                 dtype=(default_float(), default_float()))
             return mu + self.mean_function(Xnew), var
+    def predict_y(self,
+                  Xnew: InputData,
+                  num_inducing_samples: int = None,
+                  full_cov: bool = False,
+                  full_output_cov: bool = False) -> MeanAndVariance:
+        """Compute mean and variance at Xnew."""
+        f_mean, f_var = self.predict_f(
+            Xnew,
+            num_inducing_samples=num_inducing_samples,
+            full_cov=full_cov,
+            full_output_cov=full_output_cov)
+        return self.likelihood.predict_mean_and_var(f_mean, f_var)


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** enhancement / new feature

**Related issue(s)/PRs:** GitHub issue number, #1608

## Summary
It would be useful for me (and I assume others) if the functionality of `SVGP.predict_f` and `SVGP.predict_y` could be extended to draw samples from the inducing point variational distribution and call the standard GP conditional with these samples. Currently these methods analytically marginalise the inducing points (Gaussian convolution).

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->

I propose to add an extra argument (`num_inducing_samples`) to `predict_f` and `predict_y` that allows the behaviour to be switched.

1. If `num_inducing_samples=None` then the original behaviour is achieved (inducing points are analytically marginalised),
2. If `num_inducing_samples=N` then N samples are drawn from N(q_mu, q_sqrt q_sqrt.T) and the standard GP conditional is called for each sample (with `q_sqrt=None`). The predictions for each sample are then stacked on the leading dimension of the returned mean and (co)variance.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
I have implemented this functionality in a class that inherits `SVGP` but I think other people could benefit from the `SVGP` class being extended with this functionality.

If this is functionality that GPflow does want then I am happy to keep working on the PR.

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```python
#!/usr/bin/env python3
import numpy as np
import gpflow as gpf
from gpflow.models import SVGP

num_data = 200
num_test = 50
input_dim = 1
num_inducing = 30
num_inducing_samples = 10

X = np.linspace(0, 2, num_data*input_dim).reshape([num_data, input_dim])
Y = np.sin(X).reshape([num_data, 1])

idx = np.random.choice(range(num_data), size=num_inducing, replace=False)
inducing_inputs = X[idx, ...].reshape(-1, input_dim)
inducing_variable = gpf.inducing_variables.InducingPoints(inducing_inputs)

mean_function = gpf.mean_functions.Constant()
likelihood = gpf.likelihoods.Gaussian()
kernel = gpf.kernels.RBF()

model = SVGP(kernel,
             likelihood,
             mean_function=mean_function,
             inducing_variable=inducing_variable)

Xnew = np.linspace(-1, 3, num_test).reshape([num_test, input_dim])

f_mu, f_var = model.predict_f(Xnew)
y_mu, y_var = model.predict_y(Xnew)
print('Normal prediction - inducing points analytically marginalised')
print(f_mu.shape)
print(f_var.shape)

f_mu, f_var = model.predict_f(Xnew, num_inducing_samples=num_inducing_samples)
y_mu, y_var = model.predict_y(Xnew, num_inducing_samples=num_inducing_samples)
print('Predictions with sampled inducing points')
print(f_mu.shape)
print(f_var.shape)
```

## PR checklist
<!-- tick off [X] as applicable -->
- [X] New features: code is well-documented
  - [X] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [X] Code has type annotations
- [X] I ran the black+isort formatter (`make format`)
- [X] I locally tested that the tests pass (`make check-all`)

### Release notes

<!-- leave blank if unsure -->

**Fully backwards compatible:** yes

**Commit message (for release notes):**
