### PR TITLE
Heteroskedastic Gaussian Likelihood

### DIFF
--- a/gpflow/likelihoods/__init__.py
+++ b/gpflow/likelihoods/__init__.py
@@ -25,6 +25,7 @@ from .multilatent import (
     HeteroskedasticTFPConditional,
     MultiLatentLikelihood,
     MultiLatentTFPConditional,
+    HeteroskedasticGaussian,
 )
 from .scalar_continuous import Beta, Exponential, Gamma, Gaussian, StudentT
 from .scalar_discrete import Bernoulli, Ordinal, Poisson

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -54,6 +54,7 @@ class MultiLatentTFPConditional(MultiLatentLikelihood):
         :param conditional_distribution: function from Fs to a tfp Distribution,
             where Fs has shape [..., latent_dim]
         """
+        self._
         super().__init__(latent_dim, **kwargs)
         self.conditional_distribution = conditional_distribution
 
@@ -120,3 +121,86 @@ class HeteroskedasticTFPConditional(MultiLatentTFPConditional):
         super().__init__(
             latent_dim=2, conditional_distribution=conditional_distribution, **kwargs,
         )
+
+
+class HeteroskedasticGaussian(QuadratureLikelihood):
+    """
+    Analytical mplementation of the Heteroskedastic Gaussian Likelihood
+    with exponential function as the scale transform function.
+    The variational_expectations and predict_mean_and_var methods have analytical
+    expressions do not use quadrature.
+    The predict_log_density method is implemented with an analytical marginalization
+    of the location-modeling GP and uses a one-dimensional quadrature to marginalize 
+    the scale-modeling GP.
+    """
+
+    def __init__(self, quadrature=None):
+        # TODO: This should be tested whenever the quadrature attirbute is set.
+        # Maybe this should be done in the base class instead?
+        if quadrature and quadrature.dim != self._quadrature_dim:
+            raise Exception("If passing quadrature, quadrature.dim must be 1")
+
+        super().__init__(lobservation_dim=1, latent_dim=2, quadrature=quadrature)
+        self.scale_transform = tfp.bijectors.Exp()
+
+    @property
+    def _quadrature_dim(self) -> int:
+        """
+        By default, this returns self.latent_dim. However, in this class, the 
+        location-modeling GP's is marginalized analytically. Hence, this is overriden
+        to 1 as the quadrature only works with the scale-modeling GP.        
+        """
+        return 1
+
+    def _loc(self, F):
+        f = F[..., 0, None]
+        loc = f
+        return loc
+
+    def _scale(self, F):
+        g = F[..., 1, None]
+        scale = tf.exp(g)
+        return scale
+
+    def _split_mean_and_var(self, Fmu, Fvar):
+        m_f = Fmu[..., 0, None]
+        m_g = Fmu[..., 1, None]
+
+        k_f = Fvar[..., 0, None]
+        k_g = Fvar[..., 1, None]
+
+        return m_f, k_f, m_g, k_g
+
+    def _conditional_mean(self, F):
+        return self._loc(F)
+
+    def _conditional_variance(self, F):
+        return self._scale(F) ** 2
+
+    def _log_prob(self, F, Y):
+        y_given_fg = tfp.distributions.Normal(loc=self._loc(F), scale=self._scale(F))
+        return y_given_fg.log_prob(Y)
+
+    def _predict_mean_and_var(self, Fmu, Fvar):
+        m_f, k_f, m_g, k_g = self._split_mean_and_var(Fmu, Fvar)
+        Ymean = m_f
+        Yvar = k_f + tf.exp(2 * m_g + 2 * k_g)
+        return Ymean, Yvar
+
+    def _predict_log_density(self, Fmu, Fvar, Y):
+        m_f, k_f, m_g, k_g = self._split_mean_and_var(Fmu, Fvar)
+
+        def log_prob(g):
+            y_given_g = tfp.distributions.Normal(loc=m_f, scale=tf.sqrt(k_f + tf.exp(2 * g)))
+            return y_given_g.log_prob(Y)
+
+        result = self.quadrature(log_prob, m_g, k_g)
+        return tf.squeeze(result, axis=-1)
+
+    def _variational_expectations(self, Fmu, Fvar, Y):
+        m_f, k_f, m_g, k_g = self._split_mean_and_var(Fmu, Fvar)
+
+        result = -0.5 * (
+            np.log(2 * np.pi) + 2 * m_g + ((Y - m_f) ** 2 + k_f) * tf.exp(2 * k_g - 2 * m_g)
+        )
+        return tf.squeeze(result, axis=-1)


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** New Feature

**Related issue(s)/PRs:** #1559 

## Summary

**Proposed changes**
Analytical implementation of Heteroskedastic Gaussian Likelihood.

**Tests are not implemented yet:** I'm open to ideas about test cases and best file to place them. I thought about adding it to `tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py`, but couldn't figure out how to on my first try.

**What alternatives have you considered?**
This provides analytical expressions for the defaults of `MultiLatentTFPConditional` class as a separate `HeteroskedasticGaussian` class.
The other option would be to add multiple `if` 's to use analytical expressions when they are available, but I think it would cause more confusion than help.


### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```python
import numpy as np
import tensorflow as tf
import tensorflow_probability as tfp
import gpflow as gpf

N = 1001

np.random.seed(0)
tf.random.set_seed(0)

X = np.linspace(0, 4 * np.pi, N)[:, None]
f1 = np.sin
f2 = np.cos
transform = np.exp
loc = f1(X)
scale = transform(f2(X))
Y = np.random.normal(loc, scale)


### This is the analytical implementation
likelihood = gpf.likelihoods.HeteroskedasticGaussian()

## This is the non-analytical implementation, uncomment to check equivalence
# likelihood = gpf.likelihoods.HeteroskedasticTFPConditional(
#     distribution_class=tfp.distributions.Normal,
#     scale_transform=tfp.bijectors.Exp(),
# )


kernel = gpf.kernels.SeparateIndependent(
    [
        gpf.kernels.SquaredExponential(),
        gpf.kernels.SquaredExponential(),
    ]
)

M = 20
Z = np.linspace(X.min(), X.max(), M)[:, None]
inducing_variable = gpf.inducing_variables.SeparateIndependentInducingVariables(
    [
        gpf.inducing_variables.InducingPoints(Z),
        gpf.inducing_variables.InducingPoints(Z),
    ]
)
model = gpf.models.SVGP(
    kernel=kernel,
    likelihood=likelihood,
    inducing_variable=inducing_variable,
    num_latent_gps=likelihood.latent_dim,
)

data = (X, Y)
loss_fn = model.training_loss_closure(data)

gpf.utilities.set_trainable(model.q_mu, False)
gpf.utilities.set_trainable(model.q_sqrt, False)

variational_vars = [(model.q_mu, model.q_sqrt)]
natgrad_opt = gpf.optimizers.NaturalGradient(gamma=0.1)

adam_vars = model.trainable_variables
adam_opt = tf.optimizers.Adam(0.01)

@tf.function
def optimisation_step():
    natgrad_opt.minimize(loss_fn, variational_vars)
    adam_opt.minimize(loss_fn, adam_vars)

epochs = 100
log_freq = 20

for epoch in range(1, epochs + 1):
    optimisation_step()
    if epoch % log_freq == 0 and epoch > 0:
        print(f"Epoch {epoch} - Loss: {loss_fn().numpy() : .4f}")
```

## PR checklist
- [X] New features: code is well-documented
  - [X] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [X] I ran the black+isort formatter (`make format`)
- [ ] I locally tested that the tests pass (`make check-all`)

### Release notes
**Fully backwards compatible:** yes
