### PR TITLE
MultivariateGPR interface prototype

### DIFF
--- a/gpflow/models/__init__.py
+++ b/gpflow/models/__init__.py
@@ -1,6 +1,6 @@
 from .gplvm import GPLVM, BayesianGPLVM
 from .gpmc import GPMC
-from .gpr import GPR
+from .gpr import GPR, MultivariateGPR
 from .model import BayesianModel, GPModel
 from .sgpmc import SGPMC
 from .sgpr import GPRFITC, SGPR

--- a/gpflow/models/gpr.py
+++ b/gpflow/models/gpr.py
@@ -24,7 +24,7 @@ from ..mean_functions import MeanFunction
 from .model import GPModel, InputData, MeanAndVariance, RegressionData
 from .training_mixins import InternalDataTrainingLossMixin
 from .util import data_input_to_tensor
-
+from ..config import default_jitter
 
 class GPR(GPModel, InternalDataTrainingLossMixin):
     r"""
@@ -112,3 +112,94 @@ class GPR(GPModel, InternalDataTrainingLossMixin):
         )  # [N, P], [N, P] or [P, N, N]
         f_mean = f_mean_zero + self.mean_function(Xnew)
         return f_mean, f_var
+
+class MultivariateGPR(GPModel, InternalDataTrainingLossMixin):
+    r"""
+    Multivariate extension of the vanilla Gaussian Process Regression.
+    """
+    def __init__(
+        self,
+        data: RegressionData,
+        kernel: Kernel,
+        mean_function: Optional[MeanFunction] = None,
+        noise_variance: float = 1.0,
+    ):
+        likelihood = gpflow.likelihoods.Gaussian(noise_variance)
+        _, Y_data = data
+        super().__init__(kernel, likelihood, mean_function, num_latent_gps=Y_data.shape[-1])
+        self.data = data_input_to_tensor(data)
+
+    def maximum_log_likelihood_objective(self) -> tf.Tensor:
+        return self.log_marginal_likelihood()
+
+    def log_marginal_likelihood(self) -> tf.Tensor:
+        r"""
+        Computes the log marginal likelihood.
+        .. math::
+            \log p(Y | \theta).
+        """
+        X, Y = self.data
+        m = self.mean_function(X) # [N, 1]
+        Kmm = self.kernel(X, full_cov = True, full_output_cov = True) # [M, P, M, P]
+
+        # reshape to be compatible with multi output
+        M, P = tf.shape(Y)[0], tf.shape(Y)[1]     
+        Y = tf.reshape(Y, shape = (M * P, 1)) # [M*P, 1]
+        m = tf.tile(m, (P, tf.constant(1))) # [M*P, 1]
+        Kmm = tf.reshape(Kmm, shape = (M * P, M * P)) # [M*P, M*P]
+        # add jitter to the diagional
+        Kmm += default_jitter() * tf.eye(M * P, dtype=Kmm.dtype)
+        Kmm += tf.linalg.diag(tf.fill([M * P], self.likelihood.variance)) # [M*P, M*P]
+        L = tf.linalg.cholesky(Kmm)  # [M*P, M*P]
+
+        # [R,] log-likelihoods for each independent dimension of Y
+        log_prob = multivariate_normal(Y, m, L)
+        return tf.reduce_sum(log_prob)
+    
+    def predict_f(
+        self, Xnew: InputData, full_cov: bool = False, full_output_cov: bool = False
+    ) -> MeanAndVariance:
+        r"""
+        This method computes predictions at X \in R^{N \x D} input points
+        .. math::
+            p(F* | Y)
+        where F* are points on the GP at new data points, Y are noisy observations at training data points.
+        """
+        X_data, Y_data = self.data
+        err = Y_data - self.mean_function(X_data)
+        
+        Kmm = self.kernel(X_data, full_cov = True, full_output_cov = True) # [M, P, M, P]
+        Knn = self.kernel(Xnew, full_cov=full_cov, full_output_cov = full_output_cov) # [N, P, N, P] or [N, N, P] or [P, N, N] or [N, P] 
+        Kmn = self.kernel(X_data, Xnew, full_cov = True, full_output_cov = True) # [M, P, N, P]
+
+        M, P, N, _ = tf.unstack(tf.shape(Kmn), num=Kmn.shape.ndims, axis=0)
+        Kmn = tf.reshape(Kmn, (M * P, N, P)) # [M*P, N, P]
+        err = tf.reshape(err, shape = (M * P, 1)) # [M*P, 1]
+        Kmm = tf.reshape(Kmm, (M * P, M * P)) # [M*P, M*P]
+        Kmm += tf.linalg.diag(tf.fill([M * P], self.likelihood.variance)) # [M*P, M*P]
+        # add jitter to the diagional
+        Kmm += default_jitter() * tf.eye(M * P, dtype=Kmm.dtype)
+        
+        M, N, P = tf.unstack(tf.shape(Kmn), num=Kmn.shape.ndims, axis=0)
+        Lm = tf.linalg.cholesky(Kmm) # [M*P, M*P]
+        Kmn = tf.reshape(Kmn, (M, N * P))  # [M*P, N*P]
+        A = tf.linalg.triangular_solve(Lm, Kmn, lower=True)  # [M*P, N*P]
+        Ar = tf.reshape(A, (M, N, P)) # [M*P, N, P]
+
+        # compute the covariance due to the conditioning
+        if full_cov and full_output_cov:
+            fvar = Knn - tf.tensordot(Ar, Ar, [[0], [0]])  # [N, P, N, P]
+        elif full_cov and not full_output_cov:
+            At = tf.transpose(Ar)  # [P, N, M*P]
+            fvar = Knn - tf.linalg.matmul(At, At, transpose_b=True)  # [P, N, N]
+        elif not full_cov and full_output_cov:
+            At = tf.transpose(Ar, [1, 0, 2])  # [N, M*P, P]
+            fvar = Knn - tf.linalg.matmul(At, At, transpose_a=True)  # [N, P, P]
+        elif not full_cov and not full_output_cov:
+            fvar = Knn - tf.reshape(tf.reduce_sum(tf.square(A), [0]), (N, P)) # [N, P]
+        
+        # another backsubstitution in the unwhitened case
+        A = tf.linalg.triangular_solve(tf.linalg.adjoint(Lm), A, lower=False)  # [M*P, N*P]
+        fmean_zero = tf.linalg.matmul(err, A, transpose_a=True)  # [1, N*P]
+        fmean_zero = tf.reshape(fmean_zero, (N, P))  # [N, P]
+        return fmean_zero + self.mean_function(Xnew), fvar


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** new feature

**Related issue(s)/PRs:** #1555, #1209, #1175

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->
Implementation of MultivariateGPR interface for multi-output regression with GPR model.

<!-- A clear and concise description of the contents of this pull request. -->
* MultivariateGPR prediction is based on the "inducing_point_conditional" implementation which can handle different covariance shapes based on the input arguments (full_cov = True, full_output_cov). 
* Added the jitter on the diagonal of the training covariance matrix.
* Tests are not implemented

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
No alternatives were considered, but I am wondering if the code in "inducing_point_conditional" could be somehow reused instead of rewriten in MultivariateGPR prediction.

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```python
import tensorflow as tf
import numpy as np
import gpflow
from gpflow.models import training_loss_closure
from gpflow.ci_utils import ci_niter
import matplotlib.pyplot as plt

def optimize_model_with_scipy(model):
    opt = gpflow.optimizers.Scipy()
    loss_closure = training_loss_closure(model, data, compile=True)   
    _ = opt.minimize(
        loss_closure,
        variables=model.trainable_variables,
        method="l-bfgs-b",
        options=dict(maxiter=ci_niter(10000)),
        compile=True
    )

def plot_model(model, lower=-8.0, upper=8.0, n=100):
    pX = np.linspace(lower, upper, n)[:, None]
    pY, pYv = model.predict_f(pX)
    pY, pYv = pY.numpy(), pYv.numpy()
    plt.plot(X, Y, "kx")
    plt.gca().set_prop_cycle(None)
    plt.plot(pX, pY, 'rx')
    for i in range(pY.shape[1]):
        top = pY[:, i] + 2.0 * pYv[:, i] ** 0.5
        bot = pY[:, i] - 2.0 * pYv[:, i] ** 0.5
        plt.fill_between(pX[:, 0], top, bot, alpha=0.3)
    plt.xlabel("X")
    plt.ylabel("f")
    
def generate_data(N=100):
    X = np.random.rand(N)[:, None] * 10 - 5  # Inputs = N x D
    G = np.hstack((0.5 * np.sin(3 * X) + X, 3.0 * np.cos(X) - X))  # G = N x L
    W = np.array([[0.5, -0.3, 1.5], [-0.4, 0.43, 0.0]])  # L x P
    F = np.matmul(G, W)  # N x P
    Y = F + np.random.randn(*F.shape) * [0.2, 0.2, 0.2]
    return X, Y

N = 100  # number of points
D = 1  # number of input dimensions
M = 15  # number of inducing points
L = 2  # number of latent GPs
P = 3  # number of observations = output dimensions
X, Y = data = generate_data(N)
Zinit = X.copy()

kern = gpflow.kernels.RBF()
kernel = gpflow.kernels.SharedIndependent(kern, output_dim = Y.shape[1])
model = gpflow.models.MultivariateGPR(kernel = kernel, data = data)
optimize_model_with_scipy(model)
pY, pYv = model.predict_f(X[:80, :], full_cov = True, full_output_cov = True)
print('full_cov = True,', 'full_output_cov = True', pY.shape, pYv.shape)
pY, pYv = model.predict_f(X[:80, :], full_cov = True, full_output_cov = False)
print('full_cov = True,', 'full_output_cov = False', pY.shape, pYv.shape)
pY, pYv = model.predict_f(X[:80, :], full_cov = False, full_output_cov = True)
print('full_cov = False,', 'full_output_cov = True', pY.shape, pYv.shape)
pY, pYv = model.predict_f(X[:80, :], full_cov = False, full_output_cov = False)
print('full_cov = False,', 'full_output_cov = False', pY.shape, pYv.shape)
plot_model(model)

kern_list = [gpflow.kernels.RBF() for _ in range(Y.shape[1])]
kernel = gpflow.kernels.SeparateIndependent(kern_list)
model = gpflow.models.MultivariateGPR(kernel=kernel, data = data)
optimize_model_with_scipy(model)
pY, pYv = model.predict_f(X[:80, :], full_cov = True, full_output_cov = True)
print('full_cov = True,', 'full_output_cov = True', pY.shape, pYv.shape)
pY, pYv = model.predict_f(X[:80, :], full_cov = True, full_output_cov = False)
print('full_cov = True,', 'full_output_cov = False', pY.shape, pYv.shape)
pY, pYv = model.predict_f(X[:80, :], full_cov = False, full_output_cov = True)
print('full_cov = False,', 'full_output_cov = True', pY.shape, pYv.shape)
pY, pYv = model.predict_f(X[:80, :], full_cov = False, full_output_cov = False)
print('full_cov = False,', 'full_output_cov = False', pY.shape, pYv.shape)
plot_model(model)

L = 2 
kern_list = [gpflow.kernels.RBF() for _ in range(L)]
kernel = gpflow.kernels.LinearCoregionalization(
    kern_list, W=np.random.randn(P, L)
)
model = gpflow.models.MultivariateGPR(kernel=kernel, data = data)
optimize_model_with_scipy(model)
pY, pYv = model.predict_f(X[:80, :], full_cov = True, full_output_cov = True)
print('full_cov = True,', 'full_output_cov = True', pY.shape, pYv.shape)
pY, pYv = model.predict_f(X[:80, :], full_cov = True, full_output_cov = False)
print('full_cov = True,', 'full_output_cov = False', pY.shape, pYv.shape)
pY, pYv = model.predict_f(X[:80, :], full_cov = False, full_output_cov = True)
print('full_cov = False,', 'full_output_cov = True', pY.shape, pYv.shape)
pY, pYv = model.predict_f(X[:80, :], full_cov = False, full_output_cov = False)
print('full_cov = False,', 'full_output_cov = False', pY.shape, pYv.shape)
plot_model(model)
```

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] I ran the black+isort formatter (`make format`)
- [ ] I locally tested that the tests pass (`make check-all`)

### Release notes

<!-- leave blank if unsure -->

**Fully backwards compatible:** yes 
