### PR TITLE
Clean up broadcasting conditionals

### DIFF
--- a/gpflow/conditionals/multioutput/conditionals.py
+++ b/gpflow/conditionals/multioutput/conditionals.py
@@ -131,7 +131,9 @@ def separate_independent_conditional(
     Knns = tf.stack([k.K(Xnew) if full_cov else k.K_diag(Xnew) for k in kernels], axis=0)
     # [P, 1, M, M]  or  [P, M, 1]
 
-    fmu, fvar = broadcasting_base_conditional(Kmns, Kmms, Knns, f, full_cov=full_cov, q_sqrt=q_sqrt, white=white)
+    fmu, fvar = broadcasting_base_conditional(
+        Kmns, Kmms, Knns, f, full_cov=full_cov, q_sqrt=q_sqrt, white=white
+    )
     return fmu, expand_independent_outputs(fvar, full_cov, full_output_cov)
 
 

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
 import warnings
+from typing import Optional
 
 import tensorflow as tf
 
@@ -36,7 +36,10 @@ def base_conditional(
     #    Knn = Knn[..., None, :, :]
     # else:
     #    Knn = Knn[..., None, :]
-    warnings.warn("base_conditional is deprecated, use broadcasting_base_conditional instead", DeprecationWarning)
+    warnings.warn(
+        "base_conditional is deprecated, use broadcasting_base_conditional instead",
+        DeprecationWarning,
+    )
     return broadcasting_base_conditional(
         Kmn[None, ...],
         Kmm[None, ...],
@@ -58,7 +61,10 @@ def base_conditional_with_lm(
     q_sqrt: Optional[tf.Tensor] = None,
     white=False,
 ):
-    warnings.warn("base_conditional_with_lm is deprecated, use broadcasting_base_conditional instead", DeprecationWarning)
+    warnings.warn(
+        "base_conditional_with_lm is deprecated, use broadcasting_base_conditional instead",
+        DeprecationWarning,
+    )
     return broadcasting_base_conditional_with_lm(
         Kmn[None, ...],
         Lm[None, ...],

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -166,8 +166,8 @@ def base_conditional_with_lm(
     # A
 
 
-    #f_reordered = tf.einsum("...mr->...rm", f)[..., None]  # [..., R, M, 1]
-    #fmean = tf.linalg.matmul(A, f_reordered, transpose_a=True)
+    f_reordered = tf.einsum("...mr->...rm", f)[..., None]  # [..., R, M, 1]
+    fmean = tf.linalg.matmul(A, f_reordered, transpose_a=True)
     fmean = tf.einsum("...rm->...mr", tf.squeeze(fmean, axis=-1))
 
     if q_sqrt is not None:

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from typing import Optional
+import warnings
 
 import tensorflow as tf
 
@@ -35,9 +36,32 @@ def base_conditional(
     #    Knn = Knn[..., None, :, :]
     # else:
     #    Knn = Knn[..., None, :]
+    warnings.warn("base_conditional is deprecated, use broadcasting_base_conditional instead", DeprecationWarning)
     return broadcasting_base_conditional(
         Kmn[None, ...],
         Kmm[None, ...],
+        Knn[None, ...],
+        f,
+        full_cov=full_cov,
+        q_sqrt=q_sqrt,
+        white=white,
+    )
+
+
+def base_conditional_with_lm(
+    Kmn: tf.Tensor,
+    Lm: tf.Tensor,
+    Knn: tf.Tensor,
+    f: tf.Tensor,
+    *,
+    full_cov=False,
+    q_sqrt: Optional[tf.Tensor] = None,
+    white=False,
+):
+    warnings.warn("base_conditional_with_lm is deprecated, use broadcasting_base_conditional instead", DeprecationWarning)
+    return broadcasting_base_conditional_with_lm(
+        Kmn[None, ...],
+        Lm[None, ...],
         Knn[None, ...],
         f,
         full_cov=full_cov,
@@ -80,12 +104,12 @@ def broadcasting_base_conditional(
     :return: [N, R]  or [R, N, N]
     """
     Lm = tf.linalg.cholesky(Kmm)
-    return base_conditional_with_lm(
+    return broadcasting_base_conditional_with_lm(
         Kmn=Kmn, Lm=Lm, Knn=Knn, f=f, full_cov=full_cov, q_sqrt=q_sqrt, white=white
     )
 
 
-def base_conditional_with_lm(
+def broadcasting_base_conditional_with_lm(
     Kmn: tf.Tensor,
     Lm: tf.Tensor,
     Knn: tf.Tensor,

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -30,6 +30,24 @@ def base_conditional(
     q_sqrt: Optional[tf.Tensor] = None,
     white=False,
 ):
+    # Kmn [M, ..., N] -> [1, M, ..., N]
+    #if full_cov:
+    #    Knn = Knn[..., None, :, :]
+    #else:
+    #    Knn = Knn[..., None, :]
+    return broadcasting_base_conditional(Kmn[None, ...], Kmm[None, ...], Knn[None, ...], f,
+            full_cov=full_cov, q_sqrt=q_sqrt, white=white)
+
+def broadcasting_base_conditional(
+    Kmn: tf.Tensor,
+    Kmm: tf.Tensor,
+    Knn: tf.Tensor,
+    f: tf.Tensor,
+    *,
+    full_cov=False,
+    q_sqrt: Optional[tf.Tensor] = None,
+    white=False,
+):
     r"""
     Given a g1 and g2, and distribution p and q such that
       p(g2) = N(g2; 0, Kmm)
@@ -43,9 +61,9 @@ def base_conditional(
     This method computes the mean and (co)variance of
       q(g1) = ∫ q(g2) p(g1 | g2)
 
-    :param Kmn: [M, ..., N]
-    :param Kmm: [M, M]
-    :param Knn: [..., N, N]  or  N
+    :param Kmn: [R, M, ..., N]
+    :param Kmm: [R, M, M]
+    :param Knn: [R, ..., N, N]  or  [R, ..., N] if not full_cov
     :param f: [M, R]
     :param full_cov: bool
     :param q_sqrt: If this is a Tensor, it must have shape [R, M, M] (lower
@@ -82,21 +100,23 @@ def base_conditional_with_lm(
 
     # get the leading dims in Kmn to the front of the tensor
     # if Kmn has rank two, i.e. [M, N], this is the identity op.
-    K = tf.rank(Kmn)
-    perm = tf.concat(
-        [
-            tf.reshape(tf.range(1, K - 1), [K - 2]),  # leading dims (...)
-            tf.reshape(0, [1]),  # [M]
-            tf.reshape(K - 1, [1]),
-        ],
-        0,
-    )  # [N]
-    Kmn = tf.transpose(Kmn, perm)  # [..., M, N]
+    origKmn = Kmn
+    Kmn = tf.einsum("rm...n->...rmn", Kmn)
+    #K = tf.rank(Kmn)
+    #perm = tf.concat(
+    #    [
+    #        tf.reshape(tf.range(1, K - 1), [K - 2]),  # leading dims (...)
+    #        tf.reshape(0, [1]),  # [M]
+    #        tf.reshape(K - 1, [1]),
+    #    ],
+    #    0,
+    #)  # [N]
+    #Kmn = tf.transpose(Kmn, perm)  # [..., M, N]
 
     shape_constraints = [
-        (Kmn, [..., "M", "N"]),
-        (Lm, ["M", "M"]),
-        (Knn, [..., "N", "N"] if full_cov else [..., "N"]),
+        #(Kmn, [..., "R/1", "M", "N"]),
+        #(Lm, ["R/1", "M", "M"]),
+        #(Knn, ["R/1", ..., "N", "N"] if full_cov else ["R/1", ..., "N"]),
         (f, ["M", "R"]),
     ]
     if q_sqrt is not None:
@@ -111,30 +131,44 @@ def base_conditional_with_lm(
         "shape.]",
     )
 
-    leading_dims = tf.shape(Kmn)[:-2]
+    #leading_dims = tf.shape(Kmn)[:-3]
 
     # Compute the projection matrix A
-    Lm = tf.broadcast_to(Lm, tf.concat([leading_dims, tf.shape(Lm)], 0))  # [..., M, M]
-    A = tf.linalg.triangular_solve(Lm, Kmn, lower=True)  # [..., M, N]
+    #Lm = tf.broadcast_to(Lm, tf.concat([leading_dims, tf.shape(Lm)], 0))  # [..., R, M, M]
+    A = tf.linalg.triangular_solve(Lm, Kmn, lower=True)  # [..., R, M, N]
 
     # compute the covariance due to the conditioning
+    origKnn = Knn
     if full_cov:
-        fvar = Knn - tf.linalg.matmul(A, A, transpose_a=True)  # [..., N, N]
-        cov_shape = tf.concat([leading_dims, [num_func, N, N]], 0)
-        fvar = tf.broadcast_to(tf.expand_dims(fvar, -3), cov_shape)  # [..., R, N, N]
+        Knn = tf.einsum("r...nm->...rnm", Knn)
+        fvar = Knn - tf.linalg.matmul(A, A, transpose_a=True)  # [..., R, N, N]
+        #cov_shape = tf.concat([leading_dims, [num_func, N, N]], 0)
+        #fvar = tf.broadcast_to(tf.expand_dims(fvar, -3), cov_shape)  # [..., R, N, N]
     else:
-        fvar = Knn - tf.reduce_sum(tf.square(A), -2)  # [..., N]
-        cov_shape = tf.concat([leading_dims, [num_func, N]], 0)  # [..., R, N]
-        fvar = tf.broadcast_to(tf.expand_dims(fvar, -2), cov_shape)  # [..., R, N]
+        Knn = tf.einsum("r...n->...rn", Knn)
+        fvar = Knn - tf.reduce_sum(tf.square(A), -2)  # [..., R, N]
+        #cov_shape = tf.concat([leading_dims, [num_func, N]], 0)  # [..., R, N]
+        #fvar = tf.broadcast_to(tf.expand_dims(fvar, -2), cov_shape)  # [..., R, N]
 
     # another backsubstitution in the unwhitened case
     if not white:
         A = tf.linalg.triangular_solve(tf.linalg.adjoint(Lm), A, lower=False)
 
     # construct the conditional mean
-    f_shape = tf.concat([leading_dims, [M, num_func]], 0)  # [..., M, R]
-    f = tf.broadcast_to(f, f_shape)  # [..., M, R]
-    fmean = tf.linalg.matmul(A, f, transpose_a=True)  # [..., N, R]
+    #f_shape = tf.concat([leading_dims, [M, num_func]], 0)  # [..., M, R]
+    #f = tf.broadcast_to(f, f_shape)  # [..., M, R]
+    # A: [..., 1, M, N]
+    # f: [..., M, 5]
+    # [1, N, R]
+    #fmean = tf.linalg.matmul(A, f, transpose_a=True)  # [..., N, R]
+    #fmean = tf.einsum("...rmn,mr->...nr", A, f)  # sum over m, broadcast over r
+    #fmean = tf.einsum("...rmn,mrd->...nr", A, f[..., None])  # sum over m, broadcast over r
+    # A
+
+
+    #f_reordered = tf.einsum("...mr->...rm", f)[..., None]  # [..., R, M, 1]
+    #fmean = tf.linalg.matmul(A, f_reordered, transpose_a=True)
+    fmean = tf.einsum("...rm->...mr", tf.squeeze(fmean, axis=-1))
 
     if q_sqrt is not None:
         q_sqrt_dims = q_sqrt.shape.ndims
@@ -143,10 +177,11 @@ def base_conditional_with_lm(
         elif q_sqrt_dims == 3:
             L = tf.linalg.band_part(q_sqrt, -1, 0)  # force lower triangle # [R, M, M]
             L_shape = tf.shape(L)
-            L = tf.broadcast_to(L, tf.concat([leading_dims, L_shape], 0))
+            #L = tf.broadcast_to(L, tf.concat([leading_dims, L_shape], 0))
 
-            shape = tf.concat([leading_dims, [num_func, M, N]], axis=0)
-            A_tiled = tf.broadcast_to(tf.expand_dims(A, -3), shape)
+            #shape = tf.concat([leading_dims, [num_func, M, N]], axis=0)
+            #A_tiled = tf.broadcast_to(tf.expand_dims(A, -3), shape)
+            A_tiled = A
             LTA = tf.linalg.matmul(L, A_tiled, transpose_a=True)  # [R, M, N]
         else:  # pragma: no cover
             raise ValueError("Bad dimension for q_sqrt: %s" % str(q_sqrt.shape.ndims))
@@ -158,6 +193,7 @@ def base_conditional_with_lm(
 
     if not full_cov:
         fvar = tf.linalg.adjoint(fvar)  # [N, R]
+        fvar = tf.broadcast_to(fvar, tf.shape(fmean))  # TODO: can we reuse the broadcast_to further up instead?
 
     shape_constraints = [
         (Kmn, [..., "M", "N"]),  # tensor included again for N dimension

--- a/tests/gpflow/conditionals/test_broadcasted_conditionals.py
+++ b/tests/gpflow/conditionals/test_broadcasted_conditionals.py
@@ -35,14 +35,14 @@ from gpflow.conditionals.util import mix_latent_gp
 class Data:
     S1, S2, N, M = (
         7,  # num samples 1
-        6,  # num samples 2
-        4,  # num datapoints
-        3,  # num inducing
+        11,  # num samples 2
+        23,  # num datapoints
+        17,  # num inducing
     )
     Dx, Dy, L = (
         2,  # input dim
         5,  # output dim
-        4,  # num latent GPs
+        3,  # num latent GPs
     )
     W = np.random.randn(Dy, L)  # mixing matrix
 

--- a/tests/gpflow/conditionals/test_conditionals.py
+++ b/tests/gpflow/conditionals/test_conditionals.py
@@ -25,9 +25,9 @@ from gpflow.utilities.bijectors import triangular
 
 rng = np.random.RandomState(123)
 
-Ln = 2
-Nn = 10
-Mn = 20
+Ln = 3
+Nn = 11
+Mn = 23
 
 
 @pytest.fixture(scope="module")
@@ -74,7 +74,7 @@ def test_diag(Xdata, Xnew, kernel, mu, sqrt, chol, white):
     assert_allclose(var_diff, 0)
 
 
-def test_whiten(Xdata, Xnew, kernel, mu, sqrt):
+def test_whiten(Xdata, Xnew, kernel, mu):
     """
     Make sure that predicting using the whitened representation is the
     sameas the non-whitened one.

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -163,9 +163,7 @@ class DataMixedKernelWithEye(Data):
     assert L == Data.P
     W = np.eye(L)
 
-    G = np.hstack(
-        [0.5 * np.sin(3 * Data.X) + Data.X, 3.0 * np.cos(Data.X) - Data.X, 1.0 + Data.X]
-    )
+    G = np.hstack([0.5 * np.sin(3 * Data.X) + Data.X, 3.0 * np.cos(Data.X) - Data.X, 1.0 + Data.X])
     assert G.shape == (Data.N, Data.P)
 
     mu_data = tf.random.uniform((M, L), dtype=tf.float64)
@@ -174,9 +172,9 @@ class DataMixedKernelWithEye(Data):
     assert sqrt_data.shape == (L, M, M)
 
     mu_data_full = tf.reshape(mu_data @ W, [-1, 1])
-    assert mu_data_full.shape == (L*M, 1)
+    assert mu_data_full.shape == (L * M, 1)
     sqrt_data_full = expand_cov(sqrt_data, W)
-    assert sqrt_data_full.shape == (1, L*M, L*M)
+    assert sqrt_data_full.shape == (1, L * M, L * M)
 
     Y = tf.convert_to_tensor(G @ W)
     W = tf.convert_to_tensor(W)

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -132,9 +132,9 @@ def create_q_sqrt(M, L):
 
 
 class Data:
-    N, Ntest = 20, 5
+    N, Ntest = 23, 5
     D = 1  # input dimension
-    M = 3  # inducing points
+    M = 7  # inducing points
     L = 2  # latent gps
     P = 3  # output dimension
     MAXITER = int(15e2)


### PR DESCRIPTION
**PR type:** enhancement

## Summary

The independent separate multi-output conditional relied on tf.map_fn and a lot of reshaping. This PR makes the base_conditional broadcast over independent Kuu etc, which allows us to delete most of the code in independent separate multi-output conditional.

Note that this PR currently is in *draft* mode; there may be a bunch of unnecessary transposes, and we haven't yet checked whether this degrades accuracy in any way.

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] The bug case / new feature is covered by unit tests
- [X] Code has type annotations
- [X] I ran the black+isort formatter (`make format`)
- [x] I locally tested that the tests pass (`make check-all`)

### Release notes

**Fully backwards compatible:** yes

**Commit message (for release notes):**

* Clean up conditional internals