### PR TITLE
fix ModelToTensorBoard max_size = -1

### DIFF
--- a/gpflow/monitor/tensorboard.py
+++ b/gpflow/monitor/tensorboard.py
@@ -117,11 +117,9 @@ class ModelToTensorBoard(ToTensorBoard):
                 "run the monitor outside the `tf.function`."
             )
 
-        if size == 1:
-            tf.summary.scalar(name, param[0], step=self.current_step)
-        else:
-            for i in range(min(size, self.max_size)):
-                tf.summary.scalar(f"{name}[{i}]", param[i], step=self.current_step)
+        it = range(size) if self.max_size == -1 else range(min(size, self.max_size))
+        for i in it:
+            tf.summary.scalar(f"{name}[{i}]", param[i], step=self.current_step)
 
 
 class ScalarToTensorBoard(ToTensorBoard):

--- a/gpflow/monitor/tensorboard.py
+++ b/gpflow/monitor/tensorboard.py
@@ -116,10 +116,13 @@ class ModelToTensorBoard(ToTensorBoard):
                 "make sure the shape of all parameters is known beforehand. Otherwise, "
                 "run the monitor outside the `tf.function`."
             )
-
-        it = range(size) if self.max_size == -1 else range(min(size, self.max_size))
-        for i in it:
-            tf.summary.scalar(f"{name}[{i}]", param[i], step=self.current_step)
+        if size == 1:
+            # if there's only one element do not add a numbered suffix
+            tf.summary.scalar(name, param[0], step=self.current_step)
+        else:
+            it = range(size) if self.max_size == -1 else range(min(size, self.max_size))
+            for i in it:
+                tf.summary.scalar(f"{name}[{i}]", param[i], step=self.current_step)
 
 
 class ScalarToTensorBoard(ToTensorBoard):


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix

## Summary

Currently `ModelToTensorBoard` says in it's initialiser that passing -1 to max size will track all the parameters of a model, but currently this is not respected.

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```python
# Put your example code in here
```

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] I ran the black+isort formatter (`make format`)
- [ ] I locally tested that the tests pass (`make check-all`)

### Release notes

<!-- leave blank if unsure -->

**Fully backwards compatible:** yes

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

**Commit message (for release notes):**

* ...
