### PR TITLE
Make GPR work with SwitchedLikelihood

### DIFF
--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -191,7 +191,7 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
         """
         self._check_data_dims(Y)
         var_Y = self._data_variance(Y)
-        self._check_data_dims(var_Y)
+        tf.debugging.assert_equal(tf.shape(var_Y), tf.shape(Y)[:-1])
         return var_Y
 
     def _data_variance(self, Y):

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -181,6 +181,22 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
     def _conditional_variance(self, F):
         raise NotImplementedError
 
+    def data_variance(self, Y):
+        """
+        The conditional marginal variance of Y: [var(Y₁), ..., var(Yₖ)]
+        where K = observation_dim
+
+        :param Y: function evaluation Tensor, with shape [..., observation_dim]
+        :returns: variance [..., observation_dim]
+        """
+        self._check_data_dims(Y)
+        var_Y = self._data_variance(Y)
+        self._check_data_dims(var_Y)
+        return var_Y
+
+    def _data_variance(self, Y):
+        raise NotImplementedError
+
     def predict_mean_and_var(self, Fmu, Fvar):
         """
         Given a Normal distribution for the latent function,
@@ -560,6 +576,9 @@ class SwitchedLikelihood(ScalarLikelihood):
 
     def _conditional_variance(self, F):
         raise NotImplementedError
+
+    def _data_variance(self, Y):
+        return self._partition_and_stitch([Y], "data_variance")
 
 
 class MonteCarloLikelihood(Likelihood):

--- a/gpflow/likelihoods/scalar_continuous.py
+++ b/gpflow/likelihoods/scalar_continuous.py
@@ -60,6 +60,9 @@ class Gaussian(ScalarLikelihood):
     def _conditional_variance(self, F):
         return tf.fill(tf.shape(F), tf.squeeze(self.variance))
 
+    def _data_variance(self, Y):
+        return tf.fill(tf.shape(Y)[:-1], tf.squeeze(self.variance))
+
     def _predict_mean_and_var(self, Fmu, Fvar):
         return tf.identity(Fmu), Fvar + self.variance
 

--- a/tests/gpflow/likelihoods/test_switched_likelihood.py
+++ b/tests/gpflow/likelihoods/test_switched_likelihood.py
@@ -116,6 +116,23 @@ def test_switched_likelihood_with_vgp():
     opt.minimize(model.training_loss, model.trainable_variables, options=dict(maxiter=1))
 
 
+def test_switched_likelihood_with_gpr():
+    """
+    Test that SwitchedLikelihood works with basic GPR.
+    """
+    X = np.random.randn(12 + 15, 1)
+    Y = np.random.randn(12 + 15, 1)
+    idx = np.array([0] * 12 + [1] * 15)
+    Y_aug = np.c_[Y, idx]
+    assert Y_aug.shape == (12 + 15, 2)
+
+    kernel = gpflow.kernels.Matern32()
+    likelihood = gpflow.likelihoods.SwitchedLikelihood([Gaussian(), Gaussian()])
+    model = gpflow.models.GPR((X, Y_aug), kernel=kernel, likelihood=likelihood)
+    opt = gpflow.optimizers.Scipy()
+    opt.minimize(model.training_loss, model.trainable_variables, options=dict(maxiter=1))
+
+
 @pytest.mark.parametrize("num_latent_gps", [1, 2])
 def test_switched_likelihood_regression_valid_num_latent_gps(num_latent_gps):
     """


### PR DESCRIPTION
**PR type:** enhancement

**Related issue(s)/PRs:** maybe #896?

## Summary

**Proposed changes**

This PR makes minor modifications, so that a `models.GPR` is usable with a `SwitchedLikelihood` of `Gaussian`-s, i.e. a (somewhat limited) form of heteroscedastic noise.

This modification was very useful to me for specifying different kinds of linear observations with different noise level (but constant within their class). For my use-case I was additionally using an analogous *SwitchedKernel* that computes different covariances based on the classes of the input pairs, which I was using to condition on derivative observations simultaneously with direct observations - using different noise parameters for derivatives and data. (I could also provide a patch suggestion for that, if you're interested, but I'm not sure it's well-designed enough for your code).

I thought this might be useful to some others as well, but in any case it was easy enough to implement as short subclasses in my own code-base, so it's no problem for me either if it doesn't get merged. I'm waiting to add documentation or anything until I get a heads up that this would be considered for merging. In any case, many thanks for this wonderful package, I found it very well-designed and easy to adapt to my needs! :)

**What alternatives have you considered?**

I considered passing a non-scalar variance to `GPR(noise_variance=[...])`. This requires some changes in `GPR` and `Gaussian` as well because `GPR` assumes that `self.likelihood.variance` is a scalar and `Gaussian` always converts the variance to a `Parameter`. It will probably be somewhat ugly to get `Gaussian` to allow passing a variance that is a list of `Parameter` (to flexibly select a parameter for each component). Also, this removes from generality, because this will imply that `Gaussian.variance` has a fixed shape that doesn't easily adapt to points other than the input data.



### Minimal working example

See test:

```python
X = np.random.randn(12 + 15, 1)
Y = np.random.randn(12 + 15, 1)
idx = np.array([0] * 12 + [1] * 15)
Y_aug = np.c_[Y, idx]

kernel = gpflow.kernels.Matern32()
likelihood = gpflow.likelihoods.SwitchedLikelihood([Gaussian(), Gaussian()])
model = gpflow.models.GPR((X, Y_aug), kernel=kernel, likelihood=likelihood)

opt = gpflow.optimizers.Scipy()
opt.minimize(model.training_loss, model.trainable_variables, options=dict(maxiter=1))
```


## PR checklist

- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [x] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [x] I ran the black+isort formatter (`make format`) (**yes, and it reformatted many things other than the changed code)
- [x] I locally tested that the tests pass (`make check-all`) (**yes, it fails because of incorrect command line usage: `pytest: error: unrecognized arguments: -n --dist loadfile tests/`)

### Release notes

**Fully backwards compatible:** yes


**Commit message (for release notes):**

Support usage of SwitchedLikelihood with basic GPR