### PR TITLE
Fix tests for TF 2.4/TFP 0.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ if os.environ.get("READTHEDOCS") != "True":
     requirements = [
         "tensorflow>=2.1.0",
         "tensorflow-probability>0.10.0",  # tensorflow-probability==0.10.0 doesn't install correctly, https://github.com/tensorflow/probability/issues/991
+        # NOTE: once we require tensorflow-probability>=0.12, we can remove our custom deepcopy handling
         "setuptools>=41.0.0",  # to satisfy dependency constraints
     ]
 

--- a/tests/gpflow/optimizers/test_scipy.py
+++ b/tests/gpflow/optimizers/test_scipy.py
@@ -62,5 +62,5 @@ def test_scipy_jit():
 
     # The tolerance of the following test had to be loosened slightly from atol=1e-15
     # due to the changes introduced by PR #1213, which removed some implicit casts
-    # to float32.
-    np.testing.assert_allclose(get_values(m1), get_values(m2), rtol=1e-14, atol=1e-14)
+    # to float32. With TF 2.4 / TFP 0.12, we had to further increase atol from 1e-14.
+    np.testing.assert_allclose(get_values(m1), get_values(m2), rtol=1e-14, atol=2e-14)

--- a/tests/gpflow/utilities/test_deepcopy.py
+++ b/tests/gpflow/utilities/test_deepcopy.py
@@ -4,6 +4,7 @@ import pickle
 import pytest
 import tensorflow as tf
 import tensorflow_probability as tfp
+from packaging.version import Version
 
 import gpflow
 
@@ -53,9 +54,15 @@ def test_clears_bijector_cache_and_deepcopy(module):
     """
     input = 1.0
     _ = module(input)
-    with pytest.raises(TypeError):
-        copy.deepcopy(module)
-    module_copy = gpflow.utilities.deepcopy(module)
+
+    if Version(tfp.__version__) >= Version("0.12"):
+        module_copy = copy.deepcopy(module)
+    else:
+        # older versions of tensorflow_probability required us to maintain a workaround
+        with pytest.raises(TypeError):
+            copy.deepcopy(module)
+        module_copy = gpflow.utilities.deepcopy(module)
+
     assert module.var == module_copy.var
     assert module.var is not module_copy.var
     module_copy.var.assign([5.0])


### PR DESCRIPTION
Upstream changes made two tests fail, which are fixed by this PR:
- test_scipy: test_scipy_jit now has max absolute difference 2.13e-14 and max relative difference 3.99e-14. Not sure why this changed, not sure it's worth spending much time investigating. I've bumped the atol argument from 1e-14 to 2e-14; test now passes.
- test_deepcopy: with tensorflow_probability>=0.12, we no longer need to maintain our custom deepcopy workaround. I've added a version check to the tests and a note to the setup.py for when we drop support of tfp<0.12.