### PR TITLE
Mypy build fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           command: pip install mypy
       - run:
           name: Run type checker
-          command: mypy .
+          command: mypy gpflow tests
 
   unit-test:
     <<: *runtest

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ format-check:
 	isort --check-only $(ISORT_CONFIG) $(ISORT_TARGETS)
 
 type-check:
-	mypy .
+	mypy gpflow tests
 
 test:
 	pytest -n auto --dist loadfile -v --durations=10 tests/


### PR DESCRIPTION
Mypy now recursively checks all directories. The notebooks do not pass
the type check (for one, they tend to redefine objects!), so we simply
restrict the type-checking to the gpflow source and tests explicitly.
