### PR TITLE
Scipy optimize monitoring

### DIFF
--- a/doc/source/notebooks/basics/monitoring.pct.py
+++ b/doc/source/notebooks/basics/monitoring.pct.py
@@ -169,7 +169,7 @@ for i in tf.range(optimisation_steps):
 # %% [markdown]
 # ### Scipy Optimization monitoring
 #
-# Note that if you want to use the scipy optimizer, and want to monitor the training progress, then you need to simply replace 
+# Note that if you want to use the scipy optimizer, and want to monitor the training progress, then you need to simply replace
 # the optimization loop with a single call to SciPy's `minimize` and pass in the monitor as a `step_callback` keyword-argument:
 #
 

--- a/doc/source/notebooks/basics/monitoring.pct.py
+++ b/doc/source/notebooks/basics/monitoring.pct.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.4.0
+#       jupytext_version: 1.6.0
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -127,6 +127,21 @@ opt = tf.optimizers.Adam()
 for step in range(optimisation_steps):
     opt.minimize(training_loss, model.trainable_variables)
     monitor(step)  # <-- run the monitoring
+
+# %% [markdown]
+# ### Scipy Optimization monitoring
+#
+# Note that if you want to use the scipy optimizer, and want to monitor the training progress, then you need to do
+# something slightly different.
+#
+# ```
+# # define fast_tasks, slow_tasks, training_loss as in done in the previous 2 cells. Then,
+# from gpflow.monitor import ScipyMonitor
+# monitor = ScipyMonitor(fast_tasks, slow_tasks)
+#
+# opt = gpflow.optimizers.Scipy()
+# opt.minimize(training_loss, model.trainable_variables, step_callback=monitor)
+# ```
 
 # %% [markdown]
 # TensorBoard is accessible through the browser, after launching the server by running `tensorboard --logdir ${logdir}`.

--- a/gpflow/monitor/base.py
+++ b/gpflow/monitor/base.py
@@ -141,26 +141,3 @@ class Monitor:
     def __call__(self, step, **kwargs):
         for group in self.task_groups:
             group(step, **kwargs)
-
-
-class ScipyMonitor(Monitor):
-    r"""
-    Modifies Monitor class so that Scipy Optimization can be monitored
-    via tensorboard.
-
-    The Scipy Optimization behaves like one-step optimization for GPFlow, so a monitor instance
-    needs to be passed to be optimizer via the `step_callback` argument of the `minimize` function.
-    However, `minimize` expects to call the `step_callback` function with three arguments: step,
-    variables, and values. `Monitor`, however, only accepts one argument: step. To get around this,
-    this class implements a ScipyMonitor which can be called with step, variables, and values, but then
-    it calls the `Monitor` instance with just the step input.
-    """
-
-    def __init__(self, *task_groups: MonitorTaskGroup):
-        """
-        :param task_groups: a list of `MonitorTaskGroup`s to be executed.
-        """
-        super().__init__(*task_groups)
-
-    def __call__(self, step, variables, values, **kwargs):
-        super().__call__(step, **kwargs)

--- a/gpflow/monitor/base.py
+++ b/gpflow/monitor/base.py
@@ -141,3 +141,26 @@ class Monitor:
     def __call__(self, step, **kwargs):
         for group in self.task_groups:
             group(step, **kwargs)
+
+
+class ScipyMonitor(Monitor):
+    r"""
+    Modifies Monitor class so that Scipy Optimization can be monitored
+    via tensorboard.
+
+    The Scipy Optimization behaves like one-step optimization for GPFlow, so a monitor instance
+    needs to be passed to be optimizer via the `step_callback` argument of the `minimize` function.
+    However, `minimize` expects to call the `step_callback` function with three arguments: step,
+    variables, and values. `Monitor`, however, only accepts one argument: step. To get around this,
+    this class implements a ScipyMonitor which can be called with step, variables, and values, but then
+    it calls the `Monitor` instance with just the step input.
+    """
+
+    def __init__(self, *task_groups: MonitorTaskGroup):
+        """
+        :param task_groups: a list of `MonitorTaskGroup`s to be executed.
+        """
+        super().__init__(*task_groups)
+
+    def __call__(self, step, variables, values, **kwargs):
+        super().__call__(step, **kwargs)

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -82,7 +82,7 @@ class Scipy:
             if "callback" in scipy_kwargs:
                 raise ValueError("Callback passed both via `step_callback` and `callback`")
 
-            callback = self.callback_func(variables, step_callback)
+            callback = self.callback_func(step_callback)
             scipy_kwargs.update(dict(callback=callback))
 
         return scipy.optimize.minimize(
@@ -114,15 +114,12 @@ class Scipy:
         return _eval
 
     @classmethod
-    def callback_func(
-        cls, variables: Sequence[tf.Variable], step_callback: StepCallback
-    ) -> Callable[[np.ndarray], None]:
+    def callback_func(cls, step_callback: StepCallback) -> Callable[[np.ndarray], None]:
         step = 0  # type: int
 
-        def _callback(x: np.ndarray) -> None:
+        def _callback(_) -> None:
             nonlocal step
-            values = cls.unpack_tensors(variables, x)
-            step_callback(step, variables, values)
+            step_callback(step)
             step += 1
 
         return _callback

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -22,7 +22,7 @@ from scipy.optimize import OptimizeResult
 __all__ = ["Scipy"]
 
 Variables = Iterable[tf.Variable]  # deprecated
-StepCallback = Callable[[int, Sequence[tf.Variable], Sequence[tf.Tensor]], None]
+StepCallback = Callable[[int], None]
 LossClosure = Callable[[], tf.Tensor]
 
 
@@ -117,7 +117,7 @@ class Scipy:
     def callback_func(cls, step_callback: StepCallback) -> Callable[[np.ndarray], None]:
         step = 0  # type: int
 
-        def _callback(_) -> None:
+        def _callback(_: np.ndarray) -> None:
             nonlocal step
             step_callback(step)
             step += 1

--- a/tests/gpflow/test_monitor.py
+++ b/tests/gpflow/test_monitor.py
@@ -289,3 +289,9 @@ def test_compile_monitor(monitor, model):
 
     for step in tf.range(100):
         tf_func(step)
+
+
+def test_scipy_monitor(monitor, model):
+    opt = gpflow.optimizers.Scipy()
+
+    opt.minimize(model.training_loss, model.trainable_variables, step_callback=monitor)


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** enhancement + doc improvement

**Related issue(s)/PRs:** https://github.com/GPflow/GPflow/issues/1449, https://github.com/GPflow/GPflow/pull/1558

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
* The SciPy optimizer currently misbehaves when used with Monitoring objects. The changes removes the 'variables' and 'step' parameters from being used in SciPy. This should not be a problem as the variables being reported by the SciPy optimizer are just kernel hyperparameters/variational parameters which can be tracked using relevant Monitoring constructors. Additionally, there is also code that manages maintaining state of 'step'. So, both of these don't need to be passed into the scipy callback anyways.

**What alternatives have you considered?**
1) Having a separate monitoring class for SciPy as in https://github.com/GPflow/GPflow/pull/1558. After discussion with STJohn, it was decided that this is likely to cause confusion.

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

See `doc/source/notebooks/basics/monitoring.pct.py`

## PR checklist
<!-- tick off [X] as applicable -->
- [X] New features: code is well-documented
  - [X] detailed docstrings (API documentation)
  - [X] notebook examples (usage demonstration)
- [X] The bug case / new feature is covered by unit tests
- [X] Code has type annotations
- [X] I ran the black+isort formatter (`make format`)
- [X] I locally tested that the tests pass (`make check-all`)

### Release notes

<!-- leave blank if unsure -->

**Fully backwards compatible:** yes / no

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

**Commit message (for release notes):**

* ...
