### PR TITLE
Fix API for using SciPy optimizer with monitoring.

### DIFF
--- a/doc/source/notebooks/basics/monitoring.pct.py
+++ b/doc/source/notebooks/basics/monitoring.pct.py
@@ -134,14 +134,16 @@ for step in range(optimisation_steps):
 
 
 # %% [markdown]
-# For optimal performance, we can also wrap the monitor call inside `tf.function`:
+# ### For optimal performance, we can also wrap the monitor call inside `tf.function`:
 
 # %%
 opt = tf.optimizers.Adam()
 
-log_dir = f"{log_dir}/compiled"
-model_task = ModelToTensorBoard(log_dir, model)
-lml_task = ScalarToTensorBoard(log_dir, lambda: model.training_loss(), "training_objective")
+log_dir_compiled = f"{log_dir}/compiled"
+model_task = ModelToTensorBoard(log_dir_compiled, model)
+lml_task = ScalarToTensorBoard(
+    log_dir_compiled, lambda: model.training_loss(), "training_objective"
+)
 # Note that the `ImageToTensorBoard` task cannot be compiled, and is omitted from the monitoring
 monitor = Monitor(MonitorTaskGroup([model_task, lml_task]))
 
@@ -163,3 +165,27 @@ for i in tf.range(optimisation_steps):
 
 # %% [markdown]
 # When opening TensorBoard, you may need to use the command `tensorboard --logdir . --reload_multifile=true`, as multiple `FileWriter` objects are used.
+
+# %% [markdown]
+# ### Scipy Optimization monitoring
+#
+# Note that if you want to use the `Scipy` optimizer provided by GPflow, and want to monitor the training progress, then you need to simply replace
+# the optimization loop with a single call to its `minimize` method and pass in the monitor as a `step_callback` keyword argument:
+#
+
+# %%
+opt = gpflow.optimizers.Scipy()
+
+log_dir_scipy = f"{log_dir}/scipy"
+model_task = ModelToTensorBoard(log_dir_scipy, model)
+lml_task = ScalarToTensorBoard(log_dir_scipy, lambda: model.training_loss(), "training_objective")
+image_task = ImageToTensorBoard(log_dir_scipy, plot_prediction, "image_samples")
+
+monitor = Monitor(
+    MonitorTaskGroup([model_task, lml_task], period=1), MonitorTaskGroup(image_task, period=5)
+)
+
+# %%
+opt.minimize(training_loss, model.trainable_variables, step_callback=monitor)
+
+# %%


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** enhancement + doc improvement

**Related issue(s)/PRs:** https://github.com/GPflow/GPflow/issues/1449, https://github.com/GPflow/GPflow/pull/1558

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
* The SciPy optimizer currently misbehaves when used with Monitoring objects. The changes remove the 'variables' and 'step' parameters from being used in SciPy with this object. I tried to remove these parameters completely, but it seems they are being used for custom callback objects being used in other parts of the code.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
Having a separate monitoring class for SciPy as in #1558. After discussion with STJohn, it was decided that this is likely to cause confusion.

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

See `doc/source/notebooks/basics/monitoring.pct.py`

## PR checklist
<!-- tick off [X] as applicable -->
- [X] New features: code is well-documented
  - [X] detailed docstrings (API documentation)
  - [X] notebook examples (usage demonstration)
- [X] The bug case / new feature is covered by unit tests
- [X] Code has type annotations
- [X] I ran the black+isort formatter (`make format`)
- [X] I locally tested that the tests pass (`make check-all`)

### Release notes

