### PR TITLE
One backprop step for Natgrad & Adam

### DIFF
--- a/doc/source/notebooks/advanced/natgrad_and_adam.pct.py
+++ b/doc/source/notebooks/advanced/natgrad_and_adam.pct.py
@@ -1,0 +1,197 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,.pct.py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.10.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# This notebook compares performance and time for a SVGP model trained on a simple 1-D periodic dataset for 3 optimizers:
+#
+# 1. Adam only
+# 2. Adam and Natgrad separately
+# 3. (New optimizer) Adam+NatGrad combined
+#
+# Results show that 2) and 3) achieve better ELBO than 1). Additionally, 1) takes ~20s, 2) takes ~30s, and 3) takes ~23s for 20k iterations on this dataset.
+
+# %%
+# %matplotlib inline
+import itertools
+import numpy as np
+import time
+import gpflow
+import tensorflow as tf
+import matplotlib.pyplot as plt
+
+from gpflow.optimizers import JointNaturalGradientAndAdam
+
+plt.style.use("ggplot")
+
+# for reproducibility of this notebook:
+rng = np.random.RandomState(123)
+tf.random.set_seed(42)
+
+
+# %%
+def func(x):
+    return np.sin(x * 3 * 3.14) + 0.3 * np.cos(x * 9 * 3.14) + 0.5 * np.sin(x * 7 * 3.14)
+
+
+N = 10000  # Number of training observations
+
+X = rng.rand(N, 1) * 2 - 1  # X values
+Y = func(X) + 0.2 * rng.randn(N, 1)  # Noisy Y values
+data = (X, Y)
+
+plt.plot(X, Y, "x", alpha=0.2)
+Xt = np.linspace(-1.1, 1.1, 1000)[:, None]
+Yt = func(Xt)
+_ = plt.plot(Xt, Yt, c="k")
+
+
+# %%
+def get_model_and_loss(minibatch_size=100, M=50):
+    """
+    :param M: number of inducing point locations
+    """
+    Z = X[:M, :].copy()  # Initialize inducing locations to the first M inputs in the dataset
+
+    kernel = gpflow.kernels.SquaredExponential()
+    model = gpflow.models.SVGP(kernel, gpflow.likelihoods.Gaussian(), Z, num_data=N)
+
+    train_dataset = (
+        tf.data.Dataset.from_tensor_slices((X, Y))
+        .repeat()
+        .shuffle(N)
+        .batch(minibatch_size, drop_remainder=True)
+    )
+    training_loss = model.training_loss_closure(iter(train_dataset), compile=True)
+
+    return model, training_loss
+
+
+# %% [markdown]
+# # ADAM
+
+# %%
+num_iterations = 20000
+
+optimizer = tf.optimizers.Adam()
+
+model, training_loss = get_model_and_loss()
+
+
+@tf.function
+def optimization_step():
+    optimizer.minimize(training_loss, model.trainable_variables)
+
+
+logf = []
+# Time the training loop
+d = time.time()
+
+for step in range(num_iterations):
+    optimization_step()
+    if step % 10 == 0:
+        elbo = -training_loss().numpy()
+        logf.append(elbo)
+
+print(f"Time taken {time.time() - d}s.")
+
+plt.plot(np.arange(num_iterations)[::10], logf)
+plt.xlabel("iteration")
+_ = plt.ylabel("ELBO")
+
+# %% [markdown]
+# # ADAM, NatGrad separately
+
+# %%
+num_iterations = 20000
+
+adam_opt = tf.optimizers.Adam()
+natgrad_opt = gpflow.optimizers.NaturalGradient(gamma=0.1)
+
+model, training_loss = get_model_and_loss()
+
+# Get variational/nonvariational params.
+# Run Adam on nonvariational, NatGrad on variational.
+"""
+TODO: Code below fails to work. Make it work.
+variational_params = [(model.q_mu, model.q_sqrt)]
+non_variational_params = [p for p in model.trainable_parameters if p not in variational_params
+"""
+variational_params = [(model.q_mu, model.q_sqrt)]
+[gpflow.set_trainable(vp, False) for vp in variational_params]
+non_variational_params = model.trainable_variables
+
+
+@tf.function
+def optimization_step():
+    # TODO: this rolls the data because of iterator?!?!
+    adam_opt.minimize(training_loss, non_variational_params)
+    natgrad_opt.minimize(training_loss, variational_params)
+
+
+logf = []
+# Time the training loop
+d = time.time()
+
+for step in range(num_iterations):
+    optimization_step()
+    if step % 10 == 0:
+        elbo = -training_loss().numpy()
+        logf.append(elbo)
+
+print(f"Time taken {time.time() - d}s.")
+
+plt.plot(np.arange(num_iterations)[::10], logf)
+plt.xlabel("iteration")
+_ = plt.ylabel("ELBO")
+
+# %% [markdown]
+# # ADAM + NatGrad combined
+
+# %%
+num_iterations = 20000
+
+optimizer = JointNaturalGradientAndAdam(gamma=0.1, adam_lr=0.001)
+
+model, training_loss = get_model_and_loss()
+
+# Get variational/nonvariational params.
+variational_params = [(model.q_mu, model.q_sqrt)]
+[gpflow.set_trainable(vp, False) for vp in variational_params]
+non_variational_params = model.trainable_variables
+
+
+@tf.function
+def optimization_step():
+    optimizer.minimize(training_loss, variational_params, non_variational_params)
+
+
+logf = []
+
+# Time the training loop
+d = time.time()
+
+for step in range(num_iterations):
+    optimization_step()
+    if step % 10 == 0:
+        elbo = -training_loss().numpy()
+        logf.append(elbo)
+
+print(f"Time taken {time.time() - d}s.")
+
+plt.plot(np.arange(num_iterations)[::10], logf)
+plt.xlabel("iteration")
+_ = plt.ylabel("ELBO")
+
+# %%

--- a/gpflow/optimizers/__init__.py
+++ b/gpflow/optimizers/__init__.py
@@ -1,6 +1,7 @@
 # pylint: disable=wildcard-import
 
-from . import natgrad
+from . import natgrad, natgrad_and_adam
 from .mcmc import SamplingHelper
 from .natgrad import *
+from .natgrad_and_adam import *
 from .scipy import Scipy

--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -120,6 +120,107 @@ class XiSqrtMeanVar(XiTransform):
         return natural_to_meanvarsqrt(nat1, nat2)
 
 
+def _assert_shapes(q_mu, q_sqrt):
+    tf.debugging.assert_shapes(
+        [(q_mu, ["M", "L"]), (q_sqrt, ["L", "M", "M"]),]
+    )
+
+
+def natgrad_apply_gradients(
+    gamma: Scalar,
+    q_mu_grad: tf.Tensor,
+    q_sqrt_grad: tf.Tensor,
+    q_mu: Parameter,
+    q_sqrt: Parameter,
+    xi_transform: XiTransform,
+):
+    """
+    This function does the backward step on the q_mu and q_sqrt parameters,
+    given the gradients of the loss function with respect to their unconstrained
+    variables. I.e., it expects the arguments to come from
+
+        with tf.GradientTape() as tape:
+            loss = loss_function()
+        q_mu_grad, q_mu_sqrt = tape.gradient(loss, [q_mu, q_sqrt])
+
+    (Note that tape.gradient() returns the gradients in *unconstrained* space!)
+
+    Implements equation [10] from
+
+    @inproceedings{salimbeni18,
+        title={Natural Gradients in Practice: Non-Conjugate Variational Inference in Gaussian Process Models},
+        author={Salimbeni, Hugh and Eleftheriadis, Stefanos and Hensman, James},
+        booktitle={AISTATS},
+        year={2018}
+
+    In addition, for convenience with the rest of GPflow, this code computes ∂L/∂η using
+    the chain rule (the following assumes a numerator layout where the gradient is a row
+    vector; note that TensorFlow actually returns a column vector), where L is the loss:
+
+    ∂L/∂η = (∂L / ∂[q_mu, q_sqrt])(∂[q_mu, q_sqrt] / ∂η)
+
+    In total there are three derivative calculations:
+    natgrad of L w.r.t ξ  = (∂ξ / ∂θ) [(∂L / ∂[q_mu, q_sqrt]) (∂[q_mu, q_sqrt] / ∂η)]ᵀ
+
+    Note that if ξ = θ (i.e. [q_mu, q_sqrt]) some of these calculations are the identity.
+    In the code η = eta, ξ = xi, θ = nat.
+
+    :param q_mu_grad: gradient of loss w.r.t. q_mu (in unconstrained space)
+    :param q_sqrt_grad: gradient of loss w.r.t. q_sqrt (in unconstrained space)
+    :param q_mu: parameter for the mean of q(u) with shape [M, L]
+    :param q_sqrt: parameter for the square root of the covariance of q(u)
+        with shape [L, M, M] (the diagonal parametrization, q_diag=True, is NOT supported)
+    :param xi_transform: the ξ transform to use (self.xi_transform if not specified)
+    """
+    _assert_shapes(q_mu, q_sqrt)
+
+    # 1) the ordinary gpflow gradient
+    dL_dmean = _to_constrained(q_mu_grad, q_mu.transform)
+    dL_dvarsqrt = _to_constrained(q_sqrt_grad, q_sqrt.transform)
+
+    with tf.GradientTape(persistent=True, watch_accessed_variables=False) as tape:
+        tape.watch([q_mu.unconstrained_variable, q_sqrt.unconstrained_variable])
+
+        # the three parameterizations as functions of [q_mu, q_sqrt]
+        eta1, eta2 = meanvarsqrt_to_expectation(q_mu, q_sqrt)
+        # we need these to calculate the relevant gradients
+        meanvarsqrt = expectation_to_meanvarsqrt(eta1, eta2)
+
+        if not isinstance(xi_transform, XiNat):
+            nat1, nat2 = meanvarsqrt_to_natural(q_mu, q_sqrt)
+            xi1_nat, xi2_nat = xi_transform.naturals_to_xi(nat1, nat2)
+            dummy_tensors = tf.ones_like(xi1_nat), tf.ones_like(xi2_nat)
+            with tf.GradientTape(watch_accessed_variables=False) as forward_tape:
+                forward_tape.watch(dummy_tensors)
+                dummy_gradients = tape.gradient(
+                    [xi1_nat, xi2_nat], [nat1, nat2], output_gradients=dummy_tensors
+                )
+
+    # 2) the chain rule to get ∂L/∂η, where η (eta) are the expectation parameters
+    dL_deta1, dL_deta2 = tape.gradient(
+        meanvarsqrt, [eta1, eta2], output_gradients=[dL_dmean, dL_dvarsqrt]
+    )
+
+    if not isinstance(xi_transform, XiNat):
+        nat_dL_xi1, nat_dL_xi2 = forward_tape.gradient(
+            dummy_gradients, dummy_tensors, output_gradients=[dL_deta1, dL_deta2]
+        )
+    else:
+        nat_dL_xi1, nat_dL_xi2 = dL_deta1, dL_deta2
+
+    del tape  # Remove "persistent" tape
+
+    xi1, xi2 = xi_transform.meanvarsqrt_to_xi(q_mu, q_sqrt)
+    xi1_new = xi1 - gamma * nat_dL_xi1
+    xi2_new = xi2 - gamma * nat_dL_xi2
+
+    # Transform back to the model parameters [q_mu, q_sqrt]
+    mean_new, varsqrt_new = xi_transform.xi_to_meanvarsqrt(xi1_new, xi2_new)
+
+    q_mu.assign(mean_new)
+    q_sqrt.assign(varsqrt_new)
+
+
 class NaturalGradient(tf.optimizers.Optimizer):
     """
     Implements a natural gradient descent optimizer for variational models
@@ -209,109 +310,12 @@ class NaturalGradient(tf.optimizers.Optimizer):
             for q_mu_grad, q_sqrt_grad, q_mu, q_sqrt, xi_transform in zip(
                 q_mu_grads, q_sqrt_grads, q_mus, q_sqrts, xis
             ):
-                self._natgrad_apply_gradients(q_mu_grad, q_sqrt_grad, q_mu, q_sqrt, xi_transform)
+                if xi_transform is None:
+                    xi_transform = self.xi_transform
 
-    def _assert_shapes(self, q_mu, q_sqrt):
-        tf.debugging.assert_shapes(
-            [(q_mu, ["M", "L"]), (q_sqrt, ["L", "M", "M"]),]
-        )
-
-    def _natgrad_apply_gradients(
-        self,
-        q_mu_grad: tf.Tensor,
-        q_sqrt_grad: tf.Tensor,
-        q_mu: Parameter,
-        q_sqrt: Parameter,
-        xi_transform: Optional[XiTransform] = None,
-    ):
-        """
-        This function does the backward step on the q_mu and q_sqrt parameters,
-        given the gradients of the loss function with respect to their unconstrained
-        variables. I.e., it expects the arguments to come from
-
-            with tf.GradientTape() as tape:
-                loss = loss_function()
-            q_mu_grad, q_mu_sqrt = tape.gradient(loss, [q_mu, q_sqrt])
-
-        (Note that tape.gradient() returns the gradients in *unconstrained* space!)
-
-        Implements equation [10] from
-
-        @inproceedings{salimbeni18,
-            title={Natural Gradients in Practice: Non-Conjugate Variational Inference in Gaussian Process Models},
-            author={Salimbeni, Hugh and Eleftheriadis, Stefanos and Hensman, James},
-            booktitle={AISTATS},
-            year={2018}
-
-        In addition, for convenience with the rest of GPflow, this code computes ∂L/∂η using
-        the chain rule (the following assumes a numerator layout where the gradient is a row
-        vector; note that TensorFlow actually returns a column vector), where L is the loss:
-
-        ∂L/∂η = (∂L / ∂[q_mu, q_sqrt])(∂[q_mu, q_sqrt] / ∂η)
-
-        In total there are three derivative calculations:
-        natgrad of L w.r.t ξ  = (∂ξ / ∂θ) [(∂L / ∂[q_mu, q_sqrt]) (∂[q_mu, q_sqrt] / ∂η)]ᵀ
-
-        Note that if ξ = θ (i.e. [q_mu, q_sqrt]) some of these calculations are the identity.
-        In the code η = eta, ξ = xi, θ = nat.
-
-        :param q_mu_grad: gradient of loss w.r.t. q_mu (in unconstrained space)
-        :param q_sqrt_grad: gradient of loss w.r.t. q_sqrt (in unconstrained space)
-        :param q_mu: parameter for the mean of q(u) with shape [M, L]
-        :param q_sqrt: parameter for the square root of the covariance of q(u)
-            with shape [L, M, M] (the diagonal parametrization, q_diag=True, is NOT supported)
-        :param xi_transform: the ξ transform to use (self.xi_transform if not specified)
-        """
-        self._assert_shapes(q_mu, q_sqrt)
-
-        if xi_transform is None:
-            xi_transform = self.xi_transform
-
-        # 1) the ordinary gpflow gradient
-        dL_dmean = _to_constrained(q_mu_grad, q_mu.transform)
-        dL_dvarsqrt = _to_constrained(q_sqrt_grad, q_sqrt.transform)
-
-        with tf.GradientTape(persistent=True, watch_accessed_variables=False) as tape:
-            tape.watch([q_mu.unconstrained_variable, q_sqrt.unconstrained_variable])
-
-            # the three parameterizations as functions of [q_mu, q_sqrt]
-            eta1, eta2 = meanvarsqrt_to_expectation(q_mu, q_sqrt)
-            # we need these to calculate the relevant gradients
-            meanvarsqrt = expectation_to_meanvarsqrt(eta1, eta2)
-
-            if not isinstance(xi_transform, XiNat):
-                nat1, nat2 = meanvarsqrt_to_natural(q_mu, q_sqrt)
-                xi1_nat, xi2_nat = xi_transform.naturals_to_xi(nat1, nat2)
-                dummy_tensors = tf.ones_like(xi1_nat), tf.ones_like(xi2_nat)
-                with tf.GradientTape(watch_accessed_variables=False) as forward_tape:
-                    forward_tape.watch(dummy_tensors)
-                    dummy_gradients = tape.gradient(
-                        [xi1_nat, xi2_nat], [nat1, nat2], output_gradients=dummy_tensors
-                    )
-
-        # 2) the chain rule to get ∂L/∂η, where η (eta) are the expectation parameters
-        dL_deta1, dL_deta2 = tape.gradient(
-            meanvarsqrt, [eta1, eta2], output_gradients=[dL_dmean, dL_dvarsqrt]
-        )
-
-        if not isinstance(xi_transform, XiNat):
-            nat_dL_xi1, nat_dL_xi2 = forward_tape.gradient(
-                dummy_gradients, dummy_tensors, output_gradients=[dL_deta1, dL_deta2]
-            )
-        else:
-            nat_dL_xi1, nat_dL_xi2 = dL_deta1, dL_deta2
-
-        del tape  # Remove "persistent" tape
-
-        xi1, xi2 = xi_transform.meanvarsqrt_to_xi(q_mu, q_sqrt)
-        xi1_new = xi1 - self.gamma * nat_dL_xi1
-        xi2_new = xi2 - self.gamma * nat_dL_xi2
-
-        # Transform back to the model parameters [q_mu, q_sqrt]
-        mean_new, varsqrt_new = xi_transform.xi_to_meanvarsqrt(xi1_new, xi2_new)
-
-        q_mu.assign(mean_new)
-        q_sqrt.assign(varsqrt_new)
+                natgrad_apply_gradients(
+                    self.gamma, q_mu_grad, q_sqrt_grad, q_mu, q_sqrt, xi_transform
+                )
 
     def get_config(self):
         config = super().get_config()

--- a/gpflow/optimizers/natgrad_and_adam.py
+++ b/gpflow/optimizers/natgrad_and_adam.py
@@ -1,0 +1,149 @@
+# Copyright 2018-2021 The GPflow Contributors, Amazon.com. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Sequence, Tuple, Union
+
+import tensorflow as tf
+
+from gpflow.base import Parameter
+
+from .natgrad import LossClosure, NatGradParameters, Scalar, XiNat, natgrad_apply_gradients
+
+TensorflowLearningRate = Union[
+    Scalar, tf.Tensor, tf.keras.optimizers.schedules.LearningRateSchedule, Callable[[], Scalar]
+]
+
+__all__ = [
+    "JointNaturalGradientAndAdam",
+]
+
+
+class JointNaturalGradientAndAdam(tf.optimizers.Optimizer):
+    """
+    Implements a combined Natural Gradient and Adam optimizer. This calculates
+    gradients for variational parameters as well as non-variational parameters in a single
+    backwards pass (as opposed to using two backward passes for NatGrad and Adam separately).
+    Then, it applies the NatGrad update on the variational parameters, and the Adam update on the
+    non-variational parameters.
+
+    Note that the behaviour of this optimizer is slightly different to the usual NatGrad+Adam behaviour
+    when done in two different steps. With this optimizer, taking a NatGrad step of gamma=1.0 for the Gaussian
+    likelihood case will not lead to the optimal inducing locations as the kernel hyperparameters would've
+    changed. However, any other potential effects on convergence will need to be evaluated empirically.
+
+    Note that this optimizer does not implement the standard API of
+    tf.optimizers.Optimizer. Its only public method is minimize(), which has
+    a custom signature (var_list needs to be a list of (q_mu, q_sqrt) tuples,
+    where q_mu and q_sqrt are gpflow.Parameter instances, not tf.Variable).
+
+    Note furthermore that the natural gradients are implemented only for the
+    full covariance case (i.e., q_diag=True is NOT supported).
+
+    When using in your work, please cite
+        @inproceedings{salimbeni18,
+            title={Natural Gradients in Practice: Non-Conjugate Variational Inference in Gaussian Process Models},
+            author={Salimbeni, Hugh and Eleftheriadis, Stefanos and Hensman, James},
+            booktitle={AISTATS},
+            year={2018}
+    """
+
+    def __init__(self, gamma: Scalar, adam_lr: TensorflowLearningRate, name=None):
+        """
+        :param gamma: natgrad step length
+        :param adam_lr: adam learning rate
+        """
+        name = self.__class__.__name__ if name is None else name
+        super().__init__(name)
+        self.gamma = gamma
+        self.xi_transform = XiNat()
+
+        self.adam_lr = adam_lr
+        self.adam_optimizer = tf.optimizers.Adam(learning_rate=self.adam_lr)
+
+    def minimize(
+        self,
+        loss_fn: LossClosure,
+        variational_var_list: Sequence[NatGradParameters],
+        non_variational_var_list: Sequence[Parameter],
+    ):
+        """
+        Minimizes objective function of the model.
+        Natural Gradient optimizer works with variational parameters only.
+
+        :param loss_fn: Loss function.
+        :param variational_var_list: List of pair tuples of variational parameters or
+            triplet tuple with variational parameters. These parameters will be optimized
+            using NatGrad.
+
+            For example, `var_list` could be
+            ```
+            var_list = [
+                (q_mu1, q_sqrt1),
+                (q_mu2, q_sqrt2)
+            ]
+            ```
+        :param non_variational_var_list: List of non-variational parameters to be optimized
+            using Adam.
+        """
+        variational_parameters = [(v[0], v[1]) for v in variational_var_list]
+        self._natgrad_steps(loss_fn, variational_parameters, non_variational_var_list)
+
+    def _natgrad_steps(
+        self,
+        loss_fn: LossClosure,
+        variational_parameters: Sequence[Tuple[Parameter, Parameter]],
+        non_variational_var_list: Sequence[Parameter],
+    ):
+        """
+        Computes gradients of loss_fn() w.r.t. variational parameters and
+        nonvariational parameters in a single backward pass. Then, it updates
+        the variational parameters using natgrad, and the non-variational parameters
+        using Adam.
+
+        :param loss_fn: Loss function.
+        :param variational_parameters: List of tuples (q_mu, q_sqrt)
+        :param non_variational_var_list: List of non-variational parameters to be optimized
+            using Adam.
+        """
+        q_mus, q_sqrts = zip(*variational_parameters)
+        q_mu_vars = [p.unconstrained_variable for p in q_mus]
+        q_sqrt_vars = [p.unconstrained_variable for p in q_sqrts]
+
+        # Calculate loss whilst doing backprop on both variational and non-variational parameters.
+        with tf.GradientTape(watch_accessed_variables=False, persistent=True) as tape:
+            tape.watch(q_mu_vars + q_sqrt_vars + list(non_variational_var_list))
+            training_loss = loss_fn()
+
+        # Take Adam Step on non-variational parameters
+        gradients = tape.gradient(training_loss, non_variational_var_list)
+        self.adam_optimizer.apply_gradients(zip(gradients, non_variational_var_list))
+
+        # Take NatGrad step on variational parameters
+        q_mu_grads, q_sqrt_grads = tape.gradient(training_loss, [q_mu_vars, q_sqrt_vars])
+
+        del tape  # Remove "persistent" tape
+
+        with tf.name_scope(f"{self._name}/natural_gradient_steps"):
+            for q_mu_grad, q_sqrt_grad, q_mu, q_sqrt in zip(
+                q_mu_grads, q_sqrt_grads, q_mus, q_sqrts
+            ):
+                natgrad_apply_gradients(
+                    self.gamma, q_mu_grad, q_sqrt_grad, q_mu, q_sqrt, self.xi_transform
+                )
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"gamma": self._serialize_hyperparameter("gamma")})
+        config.update({"adam_lr": self._serialize_hyperparameter("adam_lr")})
+        return config

--- a/gpflow/optimizers/natgrad_and_adam.py
+++ b/gpflow/optimizers/natgrad_and_adam.py
@@ -65,11 +65,11 @@ class JointNaturalGradientAndAdam(tf.optimizers.Optimizer):
         """
         name = self.__class__.__name__ if name is None else name
         super().__init__(name)
-        self.gamma = gamma
+        self._set_hyper("gamma", gamma)
+        self._set_hyper("adam_lr", adam_lr)
         self.xi_transform = XiNat()
 
-        self.adam_lr = adam_lr
-        self.adam_optimizer = tf.optimizers.Adam(learning_rate=self.adam_lr)
+        self.adam_optimizer = tf.optimizers.Adam(learning_rate=adam_lr)
 
     def minimize(
         self,
@@ -139,7 +139,12 @@ class JointNaturalGradientAndAdam(tf.optimizers.Optimizer):
                 q_mu_grads, q_sqrt_grads, q_mus, q_sqrts
             ):
                 natgrad_apply_gradients(
-                    self.gamma, q_mu_grad, q_sqrt_grad, q_mu, q_sqrt, self.xi_transform
+                    self._get_hyper("gamma", q_mu.dtype.base_dtype),
+                    q_mu_grad,
+                    q_sqrt_grad,
+                    q_mu,
+                    q_sqrt,
+                    self.xi_transform,
                 )
 
     def get_config(self):

--- a/tests/gpflow/optimizers/test_natgrad_and_adam.py
+++ b/tests/gpflow/optimizers/test_natgrad_and_adam.py
@@ -236,3 +236,15 @@ def test_svgp_vs_sgpr(sgpr_and_svgp):
     """
     sgpr, svgp = sgpr_and_svgp
     assert_sgpr_vs_svgp(sgpr, svgp)
+
+
+def test_config():
+    """
+    Test config functionality of JointNaturalGradientAndAdam
+    """
+    gamma, adam_lr = 0.5, 0.01
+    opt = JointNaturalGradientAndAdam(gamma, adam_lr=adam_lr)
+    opt_config = opt.get_config()
+
+    assert opt_config["gamma"] == gamma
+    assert opt_config["adam_lr"] == adam_lr

--- a/tests/gpflow/optimizers/test_natgrad_and_adam.py
+++ b/tests/gpflow/optimizers/test_natgrad_and_adam.py
@@ -1,0 +1,238 @@
+from typing import Optional
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+import gpflow
+from gpflow import set_trainable
+from gpflow.optimizers import JointNaturalGradientAndAdam
+
+from .test_natural_gradient import (
+    Setup,
+    assert_different,
+    data,
+    inducing_variable,
+    kernel,
+    likelihood,
+)
+
+
+@pytest.fixture
+def gpr_and_vgp_fixed_nonvariational(data, kernel, likelihood):
+    vgp = gpflow.models.VGP(data, kernel, likelihood)
+    gpr = gpflow.models.GPR(data, kernel)
+    gpr.likelihood.variance.assign(likelihood.variance)
+    set_trainable(vgp, False)
+    set_trainable(vgp.q_mu, True)
+    set_trainable(vgp.q_sqrt, True)
+    return gpr, vgp
+
+
+@pytest.fixture
+def gpr_and_vgp(data, kernel, likelihood):
+    vgp = gpflow.models.VGP(data, kernel, likelihood)
+    gpr = gpflow.models.GPR(data, kernel)
+    gpr.likelihood.variance.assign(likelihood.variance)
+    set_trainable(vgp.q_mu, False)
+    set_trainable(vgp.q_sqrt, False)
+    return gpr, vgp
+
+
+@pytest.fixture
+def sgpr_and_svgp_fixed_nonvariational(data, inducing_variable, kernel, likelihood):
+    svgp = gpflow.models.SVGP(kernel, likelihood, inducing_variable)
+    sgpr = gpflow.models.SGPR(data, kernel, inducing_variable=inducing_variable)
+    sgpr.likelihood.variance.assign(Setup.likelihood_variance)
+    set_trainable(svgp, False)
+    set_trainable(svgp.q_mu, True)
+    set_trainable(svgp.q_sqrt, True)
+    return sgpr, svgp
+
+
+@pytest.fixture
+def sgpr_and_svgp(data, inducing_variable, kernel, likelihood):
+    svgp = gpflow.models.SVGP(kernel, likelihood, inducing_variable)
+    sgpr = gpflow.models.SGPR(data, kernel, inducing_variable=inducing_variable)
+    sgpr.likelihood.variance.assign(Setup.likelihood_variance)
+    set_trainable(svgp.q_mu, False)
+    set_trainable(svgp.q_sqrt, False)
+    return sgpr, svgp
+
+
+def assert_gpr_vs_vgp_fixed_nonvariational(
+    m1: gpflow.models.BayesianModel,
+    m2: gpflow.models.BayesianModel,
+    gamma: float = 1.0,
+    maxiter: int = 1,
+    xi_transform: Optional[gpflow.optimizers.natgrad.XiTransform] = None,
+):
+    assert maxiter >= 1
+
+    m1_ll_before = m1.training_loss()
+    m2_ll_before = m2.training_loss()
+
+    assert_different(m2_ll_before, m1_ll_before)
+
+    params = (m2.q_mu, m2.q_sqrt)
+    if xi_transform is not None:
+        params += (xi_transform,)
+
+    opt = JointNaturalGradientAndAdam(gamma, adam_lr=0.001)
+
+    @tf.function
+    def minimize_step():
+        opt.minimize(
+            m2.training_loss, variational_var_list=[params], non_variational_var_list=[],
+        )
+
+    for _ in range(maxiter):
+        minimize_step()
+
+    m1_ll_after = m1.training_loss()
+    m2_ll_after = m2.training_loss()
+
+    np.testing.assert_allclose(m1_ll_after, m2_ll_after, atol=1e-4)
+
+
+def assert_gpr_vs_vgp(
+    m1: gpflow.models.BayesianModel,
+    m2: gpflow.models.BayesianModel,
+    gamma: float = 1.0,
+    maxiter: int = 10,
+):
+    assert maxiter >= 1
+
+    m1_ll_before = m1.training_loss()
+    m2_ll_before = m2.training_loss()
+    m2_kernel_before = m2.kernel.lengthscales.numpy()
+
+    assert_different(m2_ll_before, m1_ll_before)
+
+    params = [(m2.q_mu, m2.q_sqrt)]
+
+    opt = JointNaturalGradientAndAdam(gamma, adam_lr=0.1)
+
+    @tf.function
+    def minimize_step():
+        opt.minimize(
+            m2.training_loss,
+            variational_var_list=params,
+            non_variational_var_list=m2.trainable_variables,
+        )
+
+    for _ in range(maxiter):
+        minimize_step()
+
+    m2_ll_after = m2.training_loss()
+    m2_kernel_after = m2.kernel.lengthscales.numpy()
+
+    # Check that the parameters before/after optimization have changed (due to Adam)
+    assert_different(m2_kernel_before, m2_kernel_after)
+
+    # Check that the loss has decreased
+    assert m2_ll_after < m2_ll_before
+
+
+def assert_sgpr_vs_svgp_fixed_nonvariational(
+    m1: gpflow.models.BayesianModel, m2: gpflow.models.BayesianModel,
+):
+    data = m1.data
+
+    m1_ll_before = m1.training_loss()
+    m2_ll_before = m2.training_loss(data)
+
+    assert_different(m2_ll_before, m1_ll_before)
+
+    params = [(m2.q_mu, m2.q_sqrt)]
+
+    opt = JointNaturalGradientAndAdam(1.0, adam_lr=0.001)
+    opt.minimize(
+        m2.training_loss_closure(data),
+        variational_var_list=params,
+        non_variational_var_list=m2.trainable_variables,
+    )
+
+    m1_ll_after = m1.training_loss()
+    m2_ll_after = m2.training_loss(data)
+
+    np.testing.assert_allclose(m1_ll_after, m2_ll_after, atol=1e-4)
+
+
+def assert_sgpr_vs_svgp(
+    m1: gpflow.models.BayesianModel, m2: gpflow.models.BayesianModel, maxiter: int = 10
+):
+    data = m1.data
+
+    m1_ll_before = m1.training_loss()
+    m2_ll_before = m2.training_loss(data)
+    m2_kernel_before = m2.kernel.lengthscales.numpy()
+
+    assert_different(m2_ll_before, m1_ll_before)
+
+    params = [(m2.q_mu, m2.q_sqrt)]
+
+    opt = JointNaturalGradientAndAdam(1.0, adam_lr=1.0)
+
+    @tf.function
+    def minimize_step():
+        opt.minimize(
+            m2.training_loss_closure(data),
+            variational_var_list=params,
+            non_variational_var_list=m2.trainable_variables,
+        )
+
+    for _ in range(maxiter):
+        minimize_step()
+
+    m2_ll_after = m2.training_loss(data)
+    m2_kernel_after = m2.kernel.lengthscales.numpy()
+
+    # Check that the parameters before/after optimization have changed (due to Adam)
+    assert_different(m2_kernel_before, m2_kernel_after)
+
+    # Check that the loss has decreased
+    assert m2_ll_after < m2_ll_before
+
+
+def test_vgp_vs_gpr_fixed_nonvariational(gpr_and_vgp_fixed_nonvariational):
+    """
+    With a Gaussian likelihood Gaussian variational (VGP) model should be equivalent to the exact
+    regression model (GPR) after a single nat grad+Adam step of size 1. This is
+    because the non-variational parameters are fixed, so only a NatGrad step of size 1 is performed on the
+    variational parameters.
+    """
+    gpr, vgp = gpr_and_vgp_fixed_nonvariational
+    assert_gpr_vs_vgp_fixed_nonvariational(gpr, vgp)
+
+
+def test_vgp_vs_gpr(gpr_and_vgp):
+    """
+    Tests a couple of things:
+    1) Due to ADAM step, the VGP non-variational parameters must have moved
+    2) The loss must have decreased due to optimization step
+    """
+    gpr, vgp = gpr_and_vgp
+    assert_gpr_vs_vgp(gpr, vgp)
+
+
+def test_svgp_vs_sgpr_fixed_nonvariational(sgpr_and_svgp_fixed_nonvariational):
+    """
+    With a Gaussian likelihood the sparse Gaussian variational (SVGP) model
+    should be equivalent to the analytically optimal sparse regression model (SGPR)
+    after a single nat grad step of size 1.0. This is
+    because the non-variational parameters are fixed, so only a NatGrad step of size 1 is performed on the
+    variational parameters.
+    """
+    sgpr, svgp = sgpr_and_svgp_fixed_nonvariational
+    assert_sgpr_vs_svgp_fixed_nonvariational(sgpr, svgp)
+
+
+def test_svgp_vs_sgpr(sgpr_and_svgp):
+    """
+    Tests a couple of things:
+    1) Due to ADAM step, the SVGP non-variational parameters must have moved
+    2) The loss must have decreased due to optimization step
+    """
+    sgpr, svgp = sgpr_and_svgp
+    assert_sgpr_vs_svgp(sgpr, svgp)


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:**  new feature

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. #1216 -->

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
Stochastic Variational Inference based GP models typically combine NatGrad to train the variational parameters along with Adam to train the non-variational parameters. However, currently, this occurs as two distinct forward-backward passes - one for each optimiser. This PR, instead, aims to reduce this to a single forward-backward pass to improve computational efficiency.

Thus, we will take a step in the variational parameters space and the hyperparameters space at the same time. This has implications for the behaviour of NatGrad - for example, in the Gaussian likelihood fully Variational case, the NatGrad step (with gamma=1) will no longer be "exact". The variational parameters computed would be exactly optimal with respect to the previous iterations hyperparameters, but no longer with the new hyperparameters.

Initial experiment on a very small toy problem, attached as a notebook, suggests that this nonetheless could be useful. The intuition here is that if we begin with a good setting of the variational parameters (perhaps using some warm-up) and then apply the joint optimiser, then we are likely to end up in the correct place. This is because, as we get closer to the optima, the steps in hyperparameter space are likely to get small, so our variational parameters are likely not to be too far apart from the optima. If this turns out be problematic, it is always possible to finish off the optimisation process with a few steps focusing only on the variational parameter space.

This intuition remains to be robustly and empirically tested. Nonetheless, the hope is that by making this code available via an easy API, the wider audience could already start to benefit from speed-ups in training times.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

c.f. attached notebook example.

## PR checklist
<!-- tick off [X] as applicable -->
- [X] New features: code is well-documented
  - [X] detailed docstrings (API documentation)
  - [X] notebook examples (usage demonstration)
- [X] The bug case / new feature is covered by unit tests
- [X] Code has type annotations
- [X] I ran the black+isort formatter (`make format`)
- [X] I locally tested that the tests pass (`make check-all`)

### Release notes

<!-- leave blank if unsure -->

