### PR TITLE
Update README and require TensorFlow>=2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ GPflow would not be the same without the community. **We are grateful to [all co
 
 GPflow implements modern Gaussian process inference for composable kernels and likelihoods. The [online documentation (develop)](http://gpflow.readthedocs.io/en/develop/)/[(master)](http://gpflow.readthedocs.io/en/master/) contains more details.
 
-GPflow 2.0 uses [TensorFlow 2.1+](http://www.tensorflow.org) for running computations, which allows fast execution on GPUs, and uses Python ≥ 3.6.
-
+GPflow 2.1 uses [TensorFlow 2.2+](http://www.tensorflow.org) for running computations, which allows fast execution on GPUs, and uses Python ≥ 3.6.
 
 ## Install GPflow 2
 
-**We have experienced issues with `pip`'s pre-2020 dependency resolver; if you encounter issues with incompatible third-party package versions when installing GPflow using the `pip` commands below, try adding the `--use-feature=2020-resolver` argument.**
+We have experienced issues with `pip`'s pre-2020 dependency resolver; if you encounter issues with incompatible third-party package versions when installing GPflow using the `pip` commands below, try adding the `--use-feature=2020-resolver` argument.
+
+**NOTE** GPflow depends on both TensorFlow (TF) and TensorFlow Probability (TFP). TensorFlow Probability releases are tightly coupled to TensorFlow, e.g. TFP 0.12 requires TF>=2.4, TFP 0.11 requires TF>=2.3, and TFP 0.10 requires TF>=2.2. Unfortunately, this is _not_ specified in TFP's dependencies. So if you already have an (older) version of TensorFlow installed, GPflow will pull in the latest TFP, which will be incompatible. If you get errors such as `ImportError: This version of TensorFlow Probability requires TensorFlow version >= 2.4`, you have to either upgrade TensorFlow (`pip install -U tensorflow`) or manually install an older version of the `tensorflow_probability` package.
 
 ### Latest release from PyPI
 
@@ -46,7 +47,7 @@ GPflow 2.0 uses [TensorFlow 2.1+](http://www.tensorflow.org) for running computa
 pip install gpflow
 ```
 
-The current release series, 2.x, requires TensorFlow ≥ 2.1 and TensorFlow Probability ≥ 0.10.1.
+The current release series, 2.x, requires TensorFlow ≥ 2.2 and TensorFlow Probability ≥ 0.10.1.
 
 ### Latest source from GitHub
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ GPflow 2.1 uses [TensorFlow 2.2+](http://www.tensorflow.org) for running computa
 
 ## Install GPflow 2
 
-We have experienced issues with `pip`'s pre-2020 dependency resolver; if you encounter issues with incompatible third-party package versions when installing GPflow using the `pip` commands below, try adding the `--use-feature=2020-resolver` argument.
 
 **NOTE** GPflow depends on both TensorFlow (TF) and TensorFlow Probability (TFP). TensorFlow Probability releases are tightly coupled to TensorFlow, e.g. TFP 0.12 requires TF>=2.4, TFP 0.11 requires TF>=2.3, and TFP 0.10 requires TF>=2.2. Unfortunately, this is _not_ specified in TFP's dependencies. So if you already have an (older) version of TensorFlow installed, GPflow will pull in the latest TFP, which will be incompatible. If you get errors such as `ImportError: This version of TensorFlow Probability requires TensorFlow version >= 2.4`, you have to either upgrade TensorFlow (`pip install -U tensorflow`) or manually install an older version of the `tensorflow_probability` package.
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import find_packages, setup
 # not to append tensorflow and tensorflow_probability to the requirements:
 if os.environ.get("READTHEDOCS") != "True":
     requirements = [
-        "tensorflow>=2.1.0",
+        "tensorflow>=2.2.0",
         "tensorflow-probability>0.10.0",  # tensorflow-probability==0.10.0 doesn't install correctly, https://github.com/tensorflow/probability/issues/991
         # NOTE: once we require tensorflow-probability>=0.12, we can remove our custom deepcopy handling
         "setuptools>=41.0.0",  # to satisfy dependency constraints


### PR DESCRIPTION
Adds explanation of TensorFlow/TFP dependencies (as brought up by https://github.com/GPflow/GPflow/issues/1623).
Also updates the TensorFlow version requirement to >= 2.2 (which is what TFP 0.10 needs).
