### PR TITLE
Proposed fix for the fully_correlated_conditional_repeat issue

### DIFF
--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -459,7 +459,8 @@ def fully_correlated_conditional_repeat(
             addvar = tf.reshape(tf.reduce_sum(tf.square(LTA), axis=1), (R, N, P))  # [R, N, P]
             fvar = fvar[None, ...] + addvar  # [R, N, P]
     else:
-        fvar = tf.broadcast_to(fvar[None], tf.shape(fmean))
+        fvar_shape = tf.concat([[R], tf.shape(fvar)], axis=0)
+        fvar = tf.broadcast_to(fvar[None], fvar_shape)
 
     shape_constraints.extend(
         [(Knn, intended_cov_shape), (fmean, ["R", "N", "P"]), (fvar, ["R"] + intended_cov_shape),]

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -324,26 +324,16 @@ def _q_sqrt_factory_fixture(request):
     return request.param
 
 
-@pytest.fixture(name="full_cov", params=[True, False])
-def _full_cov_fixture(request):
-    return request.param
-
-
-@pytest.fixture(name="full_output_cov", params=[True, False])
-def _full_output_cov_fixture(request):
-    return request.param
-
-
 @pytest.mark.parametrize("R", [1, 2, 5])
 @pytest.mark.parametrize("whiten", [
     True,
     pytest.param(
         False,
-        marks=pytest.mark.xfail("fully_correlated_conditional_repeat does not support whiten=False"),
+        marks=pytest.mark.xfail(reason="fully_correlated_conditional_repeat does not support whiten=False"),
     ),
 ])       
 def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(
-    R, q_sqrt_factory, full_cov, full_output_cov, whiten
+    R, fully_correlated_q_sqrt_factory, full_cov, full_output_cov, whiten
 ):
 
     L, M, N, P = Data.L, Data.M, Data.N, Data.P
@@ -365,7 +355,7 @@ def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(
         expected_v_shape = [R, N, P]
 
     f = tf.ones((L * M, R))
-    q_sqrt = q_sqrt_factory(L * M, R)
+    q_sqrt = fully_correlated_q_sqrt_factory(L * M, R)
 
     m, v = fully_correlated_conditional_repeat(
         Kmn,
@@ -386,10 +376,10 @@ def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(
     True,
     pytest.param(
         False,
-        marks=pytest.mark.xfail("fully_correlated_conditional does not support whiten=False"),
+        marks=pytest.mark.xfail(reason="fully_correlated_conditional does not support whiten=False"),
     ),
 ])       
-def test_fully_correlated_conditional_shapes_fc_and_foc(q_sqrt_factory, full_cov, full_output_cov, whiten):
+def test_fully_correlated_conditional_shapes_fc_and_foc(fully_correlated_q_sqrt_factory, full_cov, full_output_cov, whiten):
     L, M, N, P = Data.L, Data.M, Data.N, Data.P
 
     Kmm = tf.ones((L * M, L * M)) + default_jitter() * tf.eye(L * M)
@@ -409,7 +399,7 @@ def test_fully_correlated_conditional_shapes_fc_and_foc(q_sqrt_factory, full_cov
         expected_v_shape = [N, P]
 
     f = tf.ones((L * M, 1))
-    q_sqrt = q_sqrt_factory(L * M, 1)
+    q_sqrt = fully_correlated_q_sqrt_factory(L * M, 1)
 
     m, v = fully_correlated_conditional(
         Kmn,

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -317,10 +317,9 @@ def test_sample_conditional_mixedkernel():
     )
 
 
-@pytest.fixture(name="q_sqrt_factory", params=[
-    lambda _, __: None,
-    lambda LM, R: tf.eye(LM, batch_shape=(R,))
-])
+@pytest.fixture(
+    name="q_sqrt_factory", params=[lambda _, __: None, lambda LM, R: tf.eye(LM, batch_shape=(R,))]
+)
 def _q_sqrt_factory_fixture(request):
     return request.param
 
@@ -336,7 +335,9 @@ def _full_output_cov_fixture(request):
 
 
 @pytest.mark.parametrize("R", [1, 2, 5])
-def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(R, q_sqrt_factory, full_cov, full_output_cov):
+def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(
+    R, q_sqrt_factory, full_cov, full_output_cov
+):
     # fully_correlated_conditional_repeat does not support whiten = False
     whiten = True
 
@@ -362,7 +363,14 @@ def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(R, q_sqrt_factory
     q_sqrt = q_sqrt_factory(L * M, R)
 
     m, v = fully_correlated_conditional_repeat(
-        Kmn, Kmm, Knn, f, full_cov=full_cov, full_output_cov=full_output_cov, q_sqrt=q_sqrt, white=whiten,
+        Kmn,
+        Kmm,
+        Knn,
+        f,
+        full_cov=full_cov,
+        full_output_cov=full_output_cov,
+        q_sqrt=q_sqrt,
+        white=whiten,
     )
 
     assert m.shape.as_list() == [R, N, P]
@@ -395,7 +403,14 @@ def test_fully_correlated_conditional_fc_and_foc(q_sqrt_factory, full_cov, full_
     q_sqrt = q_sqrt_factory(L * M, 1)
 
     m, v = fully_correlated_conditional(
-        Kmn, Kmm, Knn, f, full_cov=full_cov, full_output_cov=full_output_cov, q_sqrt=q_sqrt, white=whiten,
+        Kmn,
+        Kmm,
+        Knn,
+        f,
+        full_cov=full_cov,
+        full_output_cov=full_output_cov,
+        q_sqrt=q_sqrt,
+        white=whiten,
     )
 
     assert m.shape.as_list() == [N, P]

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -335,11 +335,16 @@ def _full_output_cov_fixture(request):
 
 
 @pytest.mark.parametrize("R", [1, 2, 5])
+@pytest.mark.parametrize("whiten", [
+    True,
+    pytest.param(
+        False,
+        marks=pytest.mark.xfail("fully_correlated_conditional_repeat does not support whiten=False"),
+    ),
+])       
 def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(
-    R, q_sqrt_factory, full_cov, full_output_cov
+    R, q_sqrt_factory, full_cov, full_output_cov, whiten
 ):
-    # fully_correlated_conditional_repeat does not support whiten = False
-    whiten = True
 
     L, M, N, P = Data.L, Data.M, Data.N, Data.P
 

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -318,7 +318,7 @@ def test_sample_conditional_mixedkernel():
 
 
 @pytest.fixture(
-    name="q_sqrt_factory", params=[lambda _, __: None, lambda LM, R: tf.eye(LM, batch_shape=(R,))]
+    name="fully_correlated_q_sqrt_factory", params=[lambda _, __: None, lambda LM, R: tf.eye(LM, batch_shape=(R,))]
 )
 def _q_sqrt_factory_fixture(request):
     return request.param

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -318,20 +318,26 @@ def test_sample_conditional_mixedkernel():
 
 
 @pytest.fixture(
-    name="fully_correlated_q_sqrt_factory", params=[lambda _, __: None, lambda LM, R: tf.eye(LM, batch_shape=(R,))]
+    name="fully_correlated_q_sqrt_factory",
+    params=[lambda _, __: None, lambda LM, R: tf.eye(LM, batch_shape=(R,))],
 )
 def _q_sqrt_factory_fixture(request):
     return request.param
 
 
 @pytest.mark.parametrize("R", [1, 2, 5])
-@pytest.mark.parametrize("whiten", [
-    True,
-    pytest.param(
-        False,
-        marks=pytest.mark.xfail(reason="fully_correlated_conditional_repeat does not support whiten=False"),
-    ),
-])       
+@pytest.mark.parametrize(
+    "whiten",
+    [
+        True,
+        pytest.param(
+            False,
+            marks=pytest.mark.xfail(
+                reason="fully_correlated_conditional_repeat does not support whiten=False"
+            ),
+        ),
+    ],
+)
 def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(
     R, fully_correlated_q_sqrt_factory, full_cov, full_output_cov, whiten
 ):
@@ -372,14 +378,21 @@ def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(
     assert v.shape.as_list() == expected_v_shape
 
 
-@pytest.mark.parametrize("whiten", [
-    True,
-    pytest.param(
-        False,
-        marks=pytest.mark.xfail(reason="fully_correlated_conditional does not support whiten=False"),
-    ),
-])       
-def test_fully_correlated_conditional_shapes_fc_and_foc(fully_correlated_q_sqrt_factory, full_cov, full_output_cov, whiten):
+@pytest.mark.parametrize(
+    "whiten",
+    [
+        True,
+        pytest.param(
+            False,
+            marks=pytest.mark.xfail(
+                reason="fully_correlated_conditional does not support whiten=False"
+            ),
+        ),
+    ],
+)
+def test_fully_correlated_conditional_shapes_fc_and_foc(
+    fully_correlated_q_sqrt_factory, full_cov, full_output_cov, whiten
+):
     L, M, N, P = Data.L, Data.M, Data.N, Data.P
 
     Kmm = tf.ones((L * M, L * M)) + default_jitter() * tf.eye(L * M)

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -382,10 +382,14 @@ def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(
     assert v.shape.as_list() == expected_v_shape
 
 
-def test_fully_correlated_conditional_fc_and_foc(q_sqrt_factory, full_cov, full_output_cov):
-    # fully_correlated_conditional_repeat does not support whiten = False
-    whiten = True
-
+@pytest.mark.parametrize("whiten", [
+    True,
+    pytest.param(
+        False,
+        marks=pytest.mark.xfail("fully_correlated_conditional does not support whiten=False"),
+    ),
+])       
+def test_fully_correlated_conditional_shapes_fc_and_foc(q_sqrt_factory, full_cov, full_output_cov, whiten):
     L, M, N, P = Data.L, Data.M, Data.N, Data.P
 
     Kmm = tf.ones((L * M, L * M)) + default_jitter() * tf.eye(L * M)

--- a/tests/gpflow/conftest.py
+++ b/tests/gpflow/conftest.py
@@ -1,0 +1,25 @@
+#  Copyright 2021 The GPflow Contributors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+
+@pytest.fixture(name="full_cov", params=[True, False])
+def _full_cov_fixture(request):
+    return request.param
+
+
+@pytest.fixture(name="full_output_cov", params=[True, False])
+def _full_output_cov_fixture(request):
+    return request.param


### PR DESCRIPTION
Proposal to fix #1651. 

I have expanded the unit test cases for the `fully_correlated_conditional_repeat` and `fully_correlated_conditional` to cover the problematic parameter combinations.