### PR TITLE
Fix fallback inducing points with multioutput Kuf.

### DIFF
--- a/gpflow/covariances/multioutput/kufs.py
+++ b/gpflow/covariances/multioutput/kufs.py
@@ -80,18 +80,20 @@ def _Kuf(
     return tf.stack(Kufs, axis=0)  # [L, M, N]
 
 
-def _fallback_Kuf(kuf_impl, inducing_variable: Union[
+def _fallback_Kuf(
+    kuf_impl,
+    inducing_variable: Union[
         SeparateIndependentInducingVariables, SharedIndependentInducingVariables
-    ],    kernel: LinearCoregionalization,
-    Xnew: tf.Tensor,):
+    ],
+    kernel: LinearCoregionalization,
+    Xnew: tf.Tensor,
+):
     K = tf.transpose(kuf_impl(inducing_variable, kernel, Xnew), [1, 0, 2])  # [M, L, N]
     return K[:, :, :, None] * tf.transpose(kernel.W)[None, :, None, :]  # [M, L, N, P]
 
 
 @Kuf.register(
-    FallbackSeparateIndependentInducingVariables,
-    LinearCoregionalization,
-    object,
+    FallbackSeparateIndependentInducingVariables, LinearCoregionalization, object,
 )
 def _Kuf(
     inducing_variable: SeparateIndependentInducingVariables,
@@ -103,9 +105,7 @@ def _Kuf(
 
 
 @Kuf.register(
-    FallbackSharedIndependentInducingVariables,
-    LinearCoregionalization,
-    object,
+    FallbackSharedIndependentInducingVariables, LinearCoregionalization, object,
 )
 def _Kuf(
     inducing_variable: SharedIndependentInducingVariables,

--- a/tests/gpflow/covariances/test_multioutput.py
+++ b/tests/gpflow/covariances/test_multioutput.py
@@ -67,29 +67,48 @@ multioutput_kernel_list = [
 
 @pytest.mark.parametrize("inducing_variable", multioutput_inducing_variable_list)
 @pytest.mark.parametrize("kernel", multioutput_kernel_list)
-def test_kuu(inducing_variable, kernel):
+def test_kuu_shape(inducing_variable, kernel):
     Kuu = mo_kuus.Kuu(inducing_variable, kernel, jitter=1e-9)
-    tf.linalg.cholesky(Kuu)
+    t = tf.linalg.cholesky(Kuu)
+
+    if isinstance(kernel, mk.SharedIndependent):
+        if isinstance(inducing_variable, mf.SeparateIndependentInducingVariables):
+            assert t.shape == (3, 10, 10)
+        else:
+            assert t.shape == (10, 10)
+    else:
+        assert t.shape == (2, 10, 10)
 
 
 @pytest.mark.parametrize("inducing_variable", multioutput_inducing_variable_list)
 @pytest.mark.parametrize("kernel", multioutput_kernel_list)
-def test_kuf(inducing_variable, kernel):
+def test_kuf_shape(inducing_variable, kernel):
     Kuf = mo_kufs.Kuf(inducing_variable, kernel, Datum.Xnew)
+
+    if isinstance(kernel, mk.SharedIndependent):
+        if isinstance(inducing_variable, mf.SeparateIndependentInducingVariables):
+            assert Kuf.shape == (3, 10, 100)
+        else:
+            assert Kuf.shape == (10, 100)
+    else:
+        assert Kuf.shape == (2, 10, 100)
 
 
 @pytest.mark.parametrize("inducing_variable", multioutput_fallback_inducing_variable_list)
-def test_kuf_fallback_shared_inducing_variables(inducing_variable):
+def test_kuf_fallback_shared_inducing_variables_shape(inducing_variable):
     kernel = mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W)
     Kuf = mo_kufs.Kuf(inducing_variable, kernel, Datum.Xnew)
 
+    assert Kuf.shape == (10, 2, 100, 3)
+
 
 @pytest.mark.parametrize("fun", [mo_kuus.Kuu, mo_kufs.Kuf])
-def test_mixed_shared(fun):
+def test_mixed_shared_shape(fun):
     inducing_variable = mf.SharedIndependentInducingVariables(make_ip())
     kernel = mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W)
     if fun is mo_kuus.Kuu:
         t = tf.linalg.cholesky(fun(inducing_variable, kernel, jitter=1e-9))
+        assert t.shape == (2, 10, 10)
     else:
         t = fun(inducing_variable, kernel, Datum.Xnew)
-        print(t.shape)
+        assert t.shape == (2, 10, 100)

--- a/tests/gpflow/covariances/test_multioutput.py
+++ b/tests/gpflow/covariances/test_multioutput.py
@@ -49,9 +49,7 @@ class Datum:
 
 
 multioutput_inducing_variable_list = [
-    mf.SharedIndependentInducingVariables(
-        gpflow.inducing_variables.InducingPoints(np.random.rand(1, 1))
-    ),
+    mf.SharedIndependentInducingVariables(make_ip()),
     mf.SeparateIndependentInducingVariables(make_ips(Datum.P)),
 ]
 

--- a/tests/gpflow/covariances/test_multioutput.py
+++ b/tests/gpflow/covariances/test_multioutput.py
@@ -49,7 +49,9 @@ class Datum:
 
 
 multioutput_inducing_variable_list = [
-    mf.SharedIndependentInducingVariables(gpflow.inducing_variables.InducingPoints(np.random.rand(1, 1))),
+    mf.SharedIndependentInducingVariables(
+        gpflow.inducing_variables.InducingPoints(np.random.rand(1, 1))
+    ),
     mf.SeparateIndependentInducingVariables(make_ips(Datum.P)),
 ]
 

--- a/tests/gpflow/covariances/test_multioutput.py
+++ b/tests/gpflow/covariances/test_multioutput.py
@@ -49,8 +49,13 @@ class Datum:
 
 
 multioutput_inducing_variable_list = [
-    mf.SharedIndependentInducingVariables(make_ip()),
+    mf.SharedIndependentInducingVariables(gpflow.inducing_variables.InducingPoints(np.random.rand(1, 1))),
     mf.SeparateIndependentInducingVariables(make_ips(Datum.P)),
+]
+
+multioutput_fallback_inducing_variable_list = [
+    mf.FallbackSharedIndependentInducingVariables(make_ip()),
+    mf.FallbackSeparateIndependentInducingVariables(make_ips(Datum.P)),
 ]
 
 multioutput_kernel_list = [
@@ -70,6 +75,12 @@ def test_kuu(inducing_variable, kernel):
 @pytest.mark.parametrize("inducing_variable", multioutput_inducing_variable_list)
 @pytest.mark.parametrize("kernel", multioutput_kernel_list)
 def test_kuf(inducing_variable, kernel):
+    Kuf = mo_kufs.Kuf(inducing_variable, kernel, Datum.Xnew)
+
+
+@pytest.mark.parametrize("inducing_variable", multioutput_fallback_inducing_variable_list)
+def test_kuf_fallback_shared_inducing_variables(inducing_variable):
+    kernel = mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W)
     Kuf = mo_kufs.Kuf(inducing_variable, kernel, Datum.Xnew)
 
 


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix

**Related issue:** #1653 

fix #1653 

## Summary

**Proposed changes**
This is a simple change to address the issue. It is not possible to deal with both of the `Fallback*` classes together, so they have been split into two separate functions. This PR also expands the unit tests to cover additional combinations of parameters.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
The design of these inducing points classes does not work properly with multiple dispatch. The superclasses are more constrained than the subclasses, which goes against the Liscov substitution principle which is assumed by the multiple dispatch functionality.

A better solution would be to place the shape constraints on the subclasses rather than the superclasses, but that would not be backwards compatible.

### Minimal working example

A minimal failing example was given in the issue. This PR contains unit tests of the fixed behaviour.


### Release notes

<!-- leave blank if unsure -->

**Fully backwards compatible:** yes 

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

**Commit message (for release notes):**

* ...
