### PR TITLE
Added warning for unconnected gradients

### DIFF
--- a/tests/gpflow/optimizers/test_scipy.py
+++ b/tests/gpflow/optimizers/test_scipy.py
@@ -64,3 +64,17 @@ def test_scipy_jit():
     # due to the changes introduced by PR #1213, which removed some implicit casts
     # to float32. With TF 2.4 / TFP 0.12, we had to further increase atol from 1e-14.
     np.testing.assert_allclose(get_values(m1), get_values(m2), rtol=1e-14, atol=2e-14)
+
+
+def test_scipy_uncon_gradient_warning():
+
+    m1 = _create_full_gp_model()
+    m2 = _create_full_gp_model()
+    opt = gpflow.optimizers.Scipy()
+    with pytest.warns(RuntimeWarning):
+        opt.minimize(
+            m1.training_loss,
+            variables=m2.trainable_variables,
+            options=dict(maxiter=50),
+            compile=False,
+        )


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** enhancement

**Related issue(s)/PRs:** #1600 <!-- GitHub issue number, e.g. #1216 -->

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
* Throw a warning if the computation of loss and gradient in the scipy wrapper returns an object consisting exclusively of zeros (-> gradients are possibly unconnected).
* Let the user choose what the computation of loss and gradient in the scipy wrapper returns if the gradients are unconnected (default: zero tensor).

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
I considered a `[None]` as default case of the second change. I rejected this idea, because this throws an error in most cases. Otherwise, some users could take advantage of this "feature" at the moment because it was the default return value before this PR (that's why I've added the possibility to choose).

### Minimal working example
(Example from `test/gpflow/optimizers/test_scipy.py`)
<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```python

import numpy as np
import gpflow

rng = np.random.RandomState(0)

class Datum:
    X = rng.rand(20, 1) * 10
    Y = np.sin(X) + 0.9 * np.cos(X * 1.6) + rng.randn(*X.shape) * 0.8
    Y = np.tile(Y, 2)  # two identical columns

def _create_full_gp_model():
    return gpflow.models.GPR(
        (Datum.X, Datum.Y),
        kernel=gpflow.kernels.SquaredExponential(),
        mean_function=gpflow.mean_functions.Constant(),
    )

# create two different models
m1 = _create_full_gp_model()
m2 = _create_full_gp_model()

opt = gpflow.optimizers.Scipy()

# try to optimize two separate models -> gradients are unconnected!
opt.minimize(
    m1.training_loss,
    variables=m2.trainable_variables,
    options=dict(maxiter=50),
    compile=False,
)

# >>> RuntimeWarning: At least one of the passed-in variables is not connected to the loss to be minimized. Therefore, this entry of the gradient is a zero tensor.
```

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [X] The bug case / new feature is covered by unit tests
- [X] Code has type annotations
- [X] I ran the black+isort formatter (`make format`)
- [X] I locally tested that the tests pass (`make check-all`)

### Release notes

<!-- leave blank if unsure -->

**Fully backwards compatible:** not sure (see _What alternatives have you considered?_)

**Commit message (for release notes):**

* Added warning for unconnected gradients and associated tests
