### PR TITLE
predict_f and predict_y as NamedTuple

### DIFF
--- a/doc/source/notebooks/basics/regression.pct.py
+++ b/doc/source/notebooks/basics/regression.pct.py
@@ -180,7 +180,7 @@ _ = plt.xlim(-0.1, 1.1)
 
 
 # %% [markdown]
-# Moreover, you can get the mean and variance data individually for example as `m.predict_f(xx).mean` instead of `m.predict_f(xx)[0]`.
+# Moreover, you can get the mean and variance predictions individually, using for `m.predict_f(xx).mean` instead of `m.predict_f(xx)[0]` and `m.predict_f(xx).variance` instead of `m.predict_f(xx)[1]`.
 
 # %% [markdown]
 # ## GP regression in higher dimensions

--- a/doc/source/notebooks/basics/regression.pct.py
+++ b/doc/source/notebooks/basics/regression.pct.py
@@ -180,7 +180,7 @@ _ = plt.xlim(-0.1, 1.1)
 
 
 # %% [markdown]
-# Moreover, you can get the mean and variance predictions individually, using for `m.predict_f(xx).mean` instead of `m.predict_f(xx)[0]` and `m.predict_f(xx).variance` instead of `m.predict_f(xx)[1]`.
+# Moreover, you can get the mean and variance predictions individually, using for `m.predict_f(xx).mean` instead of `m.predict_f(xx)[0]` and `m.predict_f(xx).variance` instead of `m.predict_f(xx)[1]`. If you pass `full_cov=True` or `full_output_cov=True` to `m.predict_f`, you will get information about the covariance instead of variance prediction. You can access it with `m.predict_f(xx).covariance`.
 
 # %% [markdown]
 # ## GP regression in higher dimensions

--- a/doc/source/notebooks/basics/regression.pct.py
+++ b/doc/source/notebooks/basics/regression.pct.py
@@ -180,6 +180,9 @@ _ = plt.xlim(-0.1, 1.1)
 
 
 # %% [markdown]
+# Moreover, you can get the mean and variance data individually for example as `m.predict_f(xx).mean` instead of `m.predict_f(xx)[0]`.
+
+# %% [markdown]
 # ## GP regression in higher dimensions
 #
 # Very little changes when the input space has more than one dimension. By default, the `lengthscales` is an isotropic (scalar) parameter. It is generally recommended that you allow to tune a different lengthscale for each dimension (Automatic Relevance Determination, ARD): simply initialize `lengthscales` with an array of length $D$ corresponding to the input dimension of `X`.  See [Manipulating kernels](../advanced/kernels.ipynb) for further information.

--- a/gpflow/models/gplvm.py
+++ b/gpflow/models/gplvm.py
@@ -262,7 +262,7 @@ class BayesianGPLVM(GPModel, InternalDataTrainingLossMixin):
             )
             shape = tf.stack([1, tf.shape(Y_data)[1]])
             var = tf.tile(tf.expand_dims(var, 1), shape)
-        return mean + self.mean_function(Xnew), var
+        return MeanAndVariance(mean + self.mean_function(Xnew), var)
 
     def predict_log_density(self, data: OutputData) -> tf.Tensor:
         raise NotImplementedError

--- a/gpflow/models/gpmc.py
+++ b/gpflow/models/gpmc.py
@@ -106,4 +106,4 @@ class GPMC(GPModel, InternalDataTrainingLossMixin):
         mu, var = conditional(
             Xnew, X_data, self.kernel, self.V, full_cov=full_cov, q_sqrt=None, white=True
         )
-        return mu + self.mean_function(Xnew), var
+        return MeanAndVariance(mu + self.mean_function(Xnew), var)

--- a/gpflow/models/gpr.py
+++ b/gpflow/models/gpr.py
@@ -115,4 +115,4 @@ class GPR(GPModel, InternalDataTrainingLossMixin):
             kmn, kmm_plus_s, knn, err, full_cov=full_cov, white=False
         )  # [N, P], [N, P] or [P, N, N]
         f_mean = f_mean_zero + self.mean_function(Xnew)
-        return f_mean, f_var
+        return MeanAndVariance(f_mean, f_var)

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -261,8 +261,6 @@ class GPModel(BayesianModel):
             )
 
         f_mean, f_var = self.predict_f(Xnew, full_cov=full_cov, full_output_cov=full_output_cov)
-        if full_cov or full_output_cov:
-            return MeanAndCovariance(*self.likelihood.predict_mean_and_var(f_mean, f_var))
         return MeanAndVariance(*self.likelihood.predict_mean_and_var(f_mean, f_var))
 
     def predict_log_density(

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -27,7 +27,7 @@ from .training_mixins import InputData, RegressionData
 
 
 class MeanAndVariance(NamedTuple):
-    """ NamedTuple to access mean- and variance-function separately """
+    """ NamedTuple that holds mean and variance as named fields """
 
     mean: tf.Tensor
     variance: tf.Tensor

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -25,8 +25,10 @@ from ..mean_functions import MeanFunction, Zero
 from ..utilities import to_default_float
 from .training_mixins import InputData, RegressionData
 
+
 class MeanAndVariance(NamedTuple):
     """ NamedTuple to access mean- and variance-function separately """
+
     mean: tf.Tensor
     variance: tf.Tensor
 

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import abc
-from typing import Optional, Tuple
+from typing import NamedTuple, Optional
 
 import tensorflow as tf
 
@@ -25,7 +25,10 @@ from ..mean_functions import MeanFunction, Zero
 from ..utilities import to_default_float
 from .training_mixins import InputData, RegressionData
 
-MeanAndVariance = Tuple[tf.Tensor, tf.Tensor]
+class MeanAndVariance(NamedTuple):
+    """ NamedTuple to access mean- and variance-function separately """
+    mean: tf.Tensor
+    variance: tf.Tensor
 
 
 class BayesianModel(Module, metaclass=abc.ABCMeta):
@@ -218,7 +221,7 @@ class GPModel(BayesianModel):
             )
 
         f_mean, f_var = self.predict_f(Xnew, full_cov=full_cov, full_output_cov=full_output_cov)
-        return self.likelihood.predict_mean_and_var(f_mean, f_var)
+        return MeanAndVariance(*self.likelihood.predict_mean_and_var(f_mean, f_var))
 
     def predict_log_density(
         self, data: RegressionData, full_cov: bool = False, full_output_cov: bool = False

--- a/gpflow/models/sgpmc.py
+++ b/gpflow/models/sgpmc.py
@@ -127,4 +127,4 @@ class SGPMC(GPModel, InternalDataTrainingLossMixin):
             white=True,
             full_output_cov=full_output_cov,
         )
-        return mu + self.mean_function(Xnew), var
+        return MeanAndVariance(mu + self.mean_function(Xnew), var)

--- a/gpflow/models/sgpr.py
+++ b/gpflow/models/sgpr.py
@@ -227,7 +227,7 @@ class SGPR(SGPRBase):
                 - tf.reduce_sum(tf.square(tmp1), 0)
             )
             var = tf.tile(var[:, None], [1, self.num_latent_gps])
-        return mean + self.mean_function(Xnew), var
+        return MeanAndVariance(mean + self.mean_function(Xnew), var)
 
     def compute_qu(self) -> Tuple[tf.Tensor, tf.Tensor]:
         """
@@ -384,4 +384,4 @@ class GPRFITC(SGPRBase):
             )  # [N, P]
             var = tf.tile(var[:, None], [1, self.num_latent_gps])
 
-        return mean, var
+        return MeanAndVariance(mean, var)

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -169,4 +169,4 @@ class SVGP(GPModel, ExternalDataTrainingLossMixin):
             full_output_cov=full_output_cov,
         )
         # tf.debugging.assert_positive(var)  # We really should make the tests pass with this here
-        return mu + self.mean_function(Xnew), var
+        return MeanAndVariance(mu + self.mean_function(Xnew), var)

--- a/gpflow/models/vgp.py
+++ b/gpflow/models/vgp.py
@@ -118,7 +118,7 @@ class VGP(GPModel, InternalDataTrainingLossMixin):
         mu, var = conditional(
             Xnew, X_data, self.kernel, self.q_mu, q_sqrt=self.q_sqrt, full_cov=full_cov, white=True,
         )
-        return mu + self.mean_function(Xnew), var
+        return MeanAndVariance(mu + self.mean_function(Xnew), var)
 
 
 class VGPOpperArchambeau(GPModel, InternalDataTrainingLossMixin):
@@ -252,4 +252,4 @@ class VGPOpperArchambeau(GPModel, InternalDataTrainingLossMixin):
             f_var = self.kernel(Xnew) - tf.linalg.matmul(LiKx, LiKx, transpose_a=True)
         else:
             f_var = self.kernel(Xnew, full_cov=False) - tf.reduce_sum(tf.square(LiKx), axis=1)
-        return f_mean, tf.transpose(f_var)
+        return MeanAndVariance(f_mean, tf.transpose(f_var))

--- a/tests/gpflow/models/test_model_predict.py
+++ b/tests/gpflow/models/test_model_predict.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from gpflow.models.model import MeanAndVariance
 import numpy as np
 import pytest
 
@@ -96,6 +97,9 @@ def test_gaussian_mean_and_variance(Ntrain, Ntest, D):
 
     assert np.allclose(mu_f, mu_y)
     assert np.allclose(var_f, var_y - 1.0)
+
+    assert np.allclose(model_gp.predict_f(Xtest).mean, mu_f)
+    assert np.allclose(model_gp.predict_f(Xtest).variance, model_gp.predict_f(Xtest)[1])
 
 
 @pytest.mark.parametrize("Ntrain, Ntest, D", [[100, 10, 2]])

--- a/tests/gpflow/models/test_model_predict.py
+++ b/tests/gpflow/models/test_model_predict.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gpflow.models.model import MeanAndVariance
 import numpy as np
 import pytest
 
 import gpflow
 from gpflow.inducing_variables import InducingPoints
 from gpflow.kernels import Matern32
+from gpflow.models.model import MeanAndVariance
 
 rng = np.random.RandomState(0)
 

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -6,6 +6,7 @@ pytest-cov
 pytest-random-order
 pytest-xdist  # for local tests only
 codecov
+typing-extensions
 
 # Notebook tests:
 tensorflow-datasets


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you do not need to edit/remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** enhancement

**Related issue:** #1567 <!-- GitHub issue number, e.g. #1216 -->

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
* By requesting `predict_f` or `predict_y`, GPflow returns an instance of `MeanAndVariance`, a subclass of NamedTuple. By that, the user can access mean and variance individually.  
* You can find a hint to this enhancement in the example "Basic (Gaussian likelihood) GP regression model".

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
I've considered shorter names for`.mean` and `.variance` but rejected this idea because the current resulting code is a) more readable b) already shorter than before.
### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```python
import gpflow
import numpy as np

rng = np.random.RandomState(0)

data = rng.randn(100, 2), rng.randn(100, 1)
Xtest, _ = rng.randn(Ntest, D), rng.randn(Ntest, 1)
kernel = Matern32() + gpflow.kernels.White()
model_gp = gpflow.models.GPR(data, kernel=kernel)

mu_f = model_gp.predict_f(Xtest).mean # instead of 'model.predict_f(Xtest)[0]' or 'mu_f, _ = model.predict_f(Xtest)'
var_y = model_gp.predict_y(Xtest).variance # instead of 'model.predict_y(Xtest)[1]' or '_, var_y = model.predict_y(Xtest)'
```

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [X] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [X] I ran the black+isort formatter (`make format`)
- [X] I locally tested that the tests pass (`make check-all`)

### Release notes

<!-- leave blank if unsure -->

**Fully backwards compatible:** yes

**Commit message (for release notes):**

* MeanAndVariance as NamedTuple
* Added test about backwards compatibility
* Added hint in docs, format

(Is likely to be rebased)
