### PR TITLE
John/fc whiten

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,7 @@ This release contains contributions from:
 * Fixes a dynamic shape issue in the quadrature code (#1626).
 * Fixes #1651, a bug in `fully_correlated_conditional_repeat` (#1652).
 * Fixes #1653, a bug in the "fallback" code path for multioutput Kuf (#1654).
+* Fixes a bug in the un-whitened code path for the fully correlated conditional function (#1662).
 
 * Test suite
   * Fixes the test suite for TensorFlow 2.4 / TFP 0.12 (#1625).

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -428,8 +428,7 @@ def fully_correlated_conditional_repeat(
 
     # another backsubstitution in the unwhitened case
     if not white:
-        # A = tf.linalg.triangular_solve(tf.linalg.adjoint(Lm), A, lower=False)  # [M, P]
-        raise NotImplementedError("Need to verify this.")  # pragma: no cover
+        A = tf.linalg.triangular_solve(Lm, A, adjoint=True)  # [M, P]
 
     # f: [M, R]
     fmean = tf.linalg.matmul(f, A, transpose_a=True)  # [R, M]  *  [M, P]  ->  [R, P]

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -198,7 +198,6 @@ class DataMixedKernel(Data):
 # ------------------------------------------
 
 
-@pytest.mark.parametrize("full_cov", [True, False])
 def test_sample_mvn(full_cov):
     """
     Draws 10,000 samples from a distribution
@@ -221,9 +220,6 @@ def test_sample_mvn(full_cov):
     np.testing.assert_array_almost_equal(samples_cov, [[1.0, 0.0], [0.0, 1.0]], decimal=1)
 
 
-@pytest.mark.parametrize("whiten", [True, False])
-@pytest.mark.parametrize("full_cov", [True, False])
-@pytest.mark.parametrize("full_output_cov", [True, False])
 def test_sample_conditional(whiten, full_cov, full_output_cov):
     if full_cov and full_output_cov:
         return
@@ -326,18 +322,6 @@ def _q_sqrt_factory_fixture(request):
 
 
 @pytest.mark.parametrize("R", [1, 2, 5])
-@pytest.mark.parametrize(
-    "whiten",
-    [
-        True,
-        pytest.param(
-            False,
-            marks=pytest.mark.xfail(
-                reason="fully_correlated_conditional_repeat does not support whiten=False"
-            ),
-        ),
-    ],
-)
 def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(
     R, fully_correlated_q_sqrt_factory, full_cov, full_output_cov, whiten
 ):
@@ -378,18 +362,40 @@ def test_fully_correlated_conditional_repeat_shapes_fc_and_foc(
     assert v.shape.as_list() == expected_v_shape
 
 
-@pytest.mark.parametrize(
-    "whiten",
-    [
-        True,
-        pytest.param(
-            False,
-            marks=pytest.mark.xfail(
-                reason="fully_correlated_conditional does not support whiten=False"
-            ),
-        ),
-    ],
-)
+def test_fully_correlated_conditional_repeat_whiten(whiten):
+    """
+    This test checks the effect of the `white` flag, which changes the projection matrix `A`.
+
+    The impact of the flag on the value of `A` can be easily verified by its effect on the
+    predicted mean. While the predicted covariance is also a function of `A` this test does not
+    inspect that value.
+    """
+    N, P = Data.N, Data.P
+
+    Lm = np.random.randn(1, 1).astype(np.float32) ** 2
+    Kmm = Lm * Lm + default_jitter()
+
+    Kmn = tf.ones((1, N, P))
+
+    Knn = tf.ones((N, P))
+    f = np.random.randn(1, 1).astype(np.float32)
+
+    mean, _ = fully_correlated_conditional_repeat(
+        Kmn,
+        Kmm,
+        Knn,
+        f,
+        white=whiten,
+    )
+
+    if whiten:
+        expected_mean = (f * Kmn) / Lm
+    else:
+        expected_mean = (f * Kmn) / Kmm
+
+    np.testing.assert_allclose(mean, expected_mean, rtol=1e-3)
+
+
 def test_fully_correlated_conditional_shapes_fc_and_foc(
     fully_correlated_q_sqrt_factory, full_cov, full_output_cov, whiten
 ):

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -380,13 +380,7 @@ def test_fully_correlated_conditional_repeat_whiten(whiten):
     Knn = tf.ones((N, P))
     f = np.random.randn(1, 1).astype(np.float32)
 
-    mean, _ = fully_correlated_conditional_repeat(
-        Kmn,
-        Kmm,
-        Knn,
-        f,
-        white=whiten,
-    )
+    mean, _ = fully_correlated_conditional_repeat(Kmn, Kmm, Knn, f, white=whiten,)
 
     if whiten:
         expected_mean = (f * Kmn) / Lm

--- a/tests/gpflow/conftest.py
+++ b/tests/gpflow/conftest.py
@@ -23,3 +23,8 @@ def _full_cov_fixture(request):
 @pytest.fixture(name="full_output_cov", params=[True, False])
 def _full_output_cov_fixture(request):
     return request.param
+
+
+@pytest.fixture(name="whiten", params=[True, False])
+def _whiten_fixture(request):
+    return request.param


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix

**Related issue(s)/PRs:** N/A

## Summary

The `fully_correlated_conditional_repeat` throws an exception when called with `white=False`. The error message says that the implementation needs to be verified. 


**Proposed changes**

Part of the testing for the new posterior objects has meant comparing the output of this function to the new implementation with cached variables. I have removed the exception, and added a very simple unit test to cover this behaviour. This function is more thoroughly integration tested as part of the posterior tests: #1659 

### Minimal working example

See the new unit test

### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** no


## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [x] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [x] Build checks
  - [x] I ran the black+isort formatter (`make format`)
  - [x] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [x] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

