### PR TITLE
John/iic whiten

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -54,6 +54,7 @@ This release contains contributions from:
 * Fixes a dynamic shape issue in the quadrature code (#1626).
 * Fixes #1651, a bug in `fully_correlated_conditional_repeat` (#1652).
 * Fixes #1653, a bug in the "fallback" code path for multioutput Kuf (#1654).
+* Fixes a bug in `independent_interdomain_conditional` (#1663).
 
 * Test suite
   * Fixes the test suite for TensorFlow 2.4 / TFP 0.12 (#1625).

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -300,7 +300,9 @@ def independent_interdomain_conditional(
 
     # another backsubstitution in the unwhitened case
     if not white:
-        A = tf.linalg.triangular_solve(Lm, A, adjoint=True)  # [L, M, M] \ [L, M, N*P]  ->  [L, M, N*P]
+        A = tf.linalg.triangular_solve(
+            Lm, A, adjoint=True
+        )  # [L, M, M] \ [L, M, N*P]  ->  [L, M, N*P]
         Ar = tf.reshape(A, (L, M, N, P))
 
     fmean = tf.tensordot(Ar, f, [[1, 0], [0, 1]])  # [N, P]

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -300,7 +300,7 @@ def independent_interdomain_conditional(
 
     # another backsubstitution in the unwhitened case
     if not white:
-        A = tf.linalg.triangular_solve(Lm, A)  # [L, M, M] \ [L, M, N*P]  ->  [L, M, N*P]
+        A = tf.linalg.triangular_solve(Lm, A, adjoint=True)  # [L, M, M] \ [L, M, N*P]  ->  [L, M, N*P]
         Ar = tf.reshape(A, (L, M, N, P))
 
     fmean = tf.tensordot(Ar, f, [[1, 0], [0, 1]])  # [N, P]

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -887,4 +887,3 @@ def test_independent_interdomain_conditional_whiten(whiten):
         expected_mean = (f * Kmn) / Kmm
 
     np.testing.assert_allclose(mean, expected_mean[0][0], rtol=1e-2)
-

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -859,3 +859,32 @@ def test_independent_interdomain_conditional_bug_regression():
     _, _ = independent_interdomain_conditional(
         Kmn, Kmm, Knn, q_mu, q_sqrt=q_sqrt, full_cov=False, full_output_cov=False
     )
+
+
+def test_independent_interdomain_conditional_whiten(whiten):
+    """
+    This test checks the effect of the `white` flag, which changes the projection matrix `A`.
+
+    The impact of the flag on the value of `A` can be easily verified by its effect on the
+    predicted mean. While the predicted covariance is also a function of `A` this test does not
+    inspect that value.
+    """
+    N, P = Data.N, Data.P
+
+    Lm = np.random.randn(1, 1, 1).astype(np.float32) ** 2
+    Kmm = Lm * Lm + default_jitter()
+
+    Kmn = tf.ones((1, 1, N, P))
+
+    Knn = tf.ones((N, P))
+    f = np.random.randn(1, 1).astype(np.float32)
+
+    mean, _ = independent_interdomain_conditional(Kmn, Kmm, Knn, f, white=whiten,)
+
+    if whiten:
+        expected_mean = (f * Kmn) / Lm
+    else:
+        expected_mean = (f * Kmn) / Kmm
+
+    np.testing.assert_allclose(mean, expected_mean[0][0], rtol=1e-2)
+

--- a/tests/gpflow/conftest.py
+++ b/tests/gpflow/conftest.py
@@ -23,3 +23,8 @@ def _full_cov_fixture(request):
 @pytest.fixture(name="full_output_cov", params=[True, False])
 def _full_output_cov_fixture(request):
     return request.param
+
+
+@pytest.fixture(name="whiten", params=[True, False])
+def _whiten_fixture(request):
+    return request.param


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix

**Related issue(s)/PRs:** #1295 

## Summary

The `independent_interdomain_conditional` function returns the wrong values for mean and covariance with the parameter value `whiten=False`.

When not using the whitened representation, the projection matrix should be `K_mm^{-1} K_mn`. This is implemented by left-multiplying `K_mn` by the cholesky factory `L_m` twice. The issue is that the second left-multiplication should be with the adjoint tensor of `L_m`.

**Proposed changes**
Use the adjoint tensor for the second left-multiplication.

### Minimal working example

See the unit test.

### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:**  no

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [x] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [x] Build checks
  - [x] I ran the black+isort formatter (`make format`)
  - [x] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

