### PR TITLE
fix gpflow.config module-level docstring

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,6 +56,7 @@ This release contains contributions from:
 * Fixes #1653, a bug in the "fallback" code path for multioutput Kuf (#1654).
 * Fixes a bug in the un-whitened code path for the fully correlated conditional function (#1662).
 * Fixes a bug in `independent_interdomain_conditional` (#1663).
+* Fixes an issue with the gpflow.config API documentation (#1664).
 
 * Test suite
   * Fixes the test suite for TensorFlow 2.4 / TFP 0.12 (#1625).

--- a/gpflow/config/__init__.py
+++ b/gpflow/config/__init__.py
@@ -1,2 +1,2 @@
-from .__config__ import __doc__  # needs explicit import
 from .__config__ import *
+from .__config__ import __doc__  # needs explicit import

--- a/gpflow/config/__init__.py
+++ b/gpflow/config/__init__.py
@@ -1,1 +1,2 @@
+from .__config__ import __doc__  # needs explicit import
 from .__config__ import *


### PR DESCRIPTION
I just realized that https://gpflow.readthedocs.io/en/master/gpflow/config/index.html does not actually include the module-level docstring, which is fixed by directly importing the docstring from `__config__`.
