### PR TITLE
Added switch_dim parameter to ChangePoints kernel

### DIFF
--- a/tests/gpflow/kernels/reference.py
+++ b/tests/gpflow/kernels/reference.py
@@ -70,7 +70,7 @@ def ref_periodic_kernel(X, base_name, lengthscales, signal_variance, period):
     return signal_variance * exp_dist
 
 
-def ref_changepoints(X, kernels, locations, steepness):
+def ref_changepoints(X, kernels, locations, steepness, switch_dim=0):
     """
     Calculates K(X) for each kernel in `kernels`, then multiply by sigmoid functions
     in order to smoothly transition betwen them. The sigmoid transitions are defined
@@ -81,7 +81,8 @@ def ref_changepoints(X, kernels, locations, steepness):
     locations = np.array(locations).reshape((1, 1, -1))
     steepness = np.array(steepness).reshape((1, 1, -1))
 
-    sig_X = 1.0 / (1.0 + np.exp(-steepness * (X[:, :, None] - locations)))
+    Xslice = X[:, switch_dim].reshape(-1, 1, 1)
+    sig_X = 1.0 / (1.0 + np.exp(-steepness * (Xslice - locations)))
 
     starters = sig_X * np.transpose(sig_X, axes=(1, 0, 2))
     stoppers = (1 - sig_X) * np.transpose((1 - sig_X), axes=(1, 0, 2))

--- a/tests/gpflow/kernels/test_changepoints.py
+++ b/tests/gpflow/kernels/test_changepoints.py
@@ -82,7 +82,7 @@ def _assert_changepoints_kern_err(X, kernels, locations, steepness):
         ],
     ],
 )
-def test_changepoints(N, kernels, locations, steepness):
+def test_changepoint_output(N, kernels, locations, steepness):
     X_data = rng.randn(N, 1)
     _assert_changepoints_kern_err(X_data, kernels, locations, steepness)
 


### PR DESCRIPTION
**PR type:** bugfix / enhancement

**Related issue(s)/PRs:** Resolves https://github.com/GPflow/GPflow/issues/1195, also see https://stackoverflow.com/questions/59613675

## Summary
**Proposed changes**
I propose to add a `switch_dim` parameter to the ChangePoints kernel to make it usable on multidimensional inputs. This parameter allows to define ChangePoints on one particular dimension of the input space, while leaving all dimensions accessible to the kernels being switched. This makes it possible to switch kernels on any (combination of) input dimensions based on one switching dimension.

As an example, this setup allows structures such as:
```python
def switched_k():
    return SquaredExponential(active_dims=[0]) * SquaredExponential(active_dims=[1])

k = ChangePoints([switched_k(), switched_k()], switch_dim=1, location=init_loc)
```
This example has 2D input, and the kernel being switched is a product of kernels on the 1st and 2nd dimension. The `switch_dim` parameter allows to define a ChangePoint for this entire kernel product based on the 2nd dimension of the input.

**What alternatives have you considered?**
I also have a working version of making the `active_dims` parameter accessible to the ChangePoints kernel as proposed on the SO link above. The issue with this was, that it only allows to switch kernels on the dimension on which the ChangePoint is defined, e.g.:
```python
k = SquaredExponential(active_dims=[0]) * ChangePoints([SquaredExponential(), SquaredExponential()], active_dims[1], location=init_loc)
```

**Fully backwards compatible:** I think so, but I will be adding tests to make sure

## State of this PR
The PR is still a bit rough, but I'll be adding tests in the coming days if there's general interest in merging this ChangePoint setup. Alternatively, I'm also happy to contribute the `active_dims` version of handling multiple input dimensions I mention above.


## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [x] The bug case / new feature is covered by unit tests
- [X] Code has type annotations
- [x] Build checks
  - [x] I ran the black+isort formatter (`make format`)
  - [x] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

