### PR TITLE
Refactor the posterior module into a package

### DIFF
--- a/doc/source/notebooks/advanced/variational_fourier_features.pct.py
+++ b/doc/source/notebooks/advanced/variational_fourier_features.pct.py
@@ -239,7 +239,7 @@ def gauss_kl_vff(q_mu, q_sqrt, K):
 import gpflow.posteriors
 
 
-class VFFPosterior(gpflow.posteriors.AbstractPosterior):
+class VFFPosterior(gpflow.posteriors.BasePosterior):
     def _conditional_fused(self, Xnew, full_cov, full_output_cov):
         """
         Xnew is a tensor with the points of the data or minibatch, shape N x D

--- a/gpflow/conditionals/dispatch.py
+++ b/gpflow/conditionals/dispatch.py
@@ -21,9 +21,9 @@ conditional._gpflow_internal_register = conditional.register
 
 conditional.register = deprecated(
     reason="Registering new implementations of conditional() is deprecated. "
-    "Instead, create your own subclass of gpflow.posteriors.AbstractPosterior "
-    "and register an implementation of gpflow.posteriors.get_posterior_class "
-    "that returns your class."
+    "Instead, create your own subclass of gpflow.posteriors.Posterior and "
+    "register an implementation of gpflow.posteriors.get_posterior_class that "
+    "returns your class."
 )(conditional._gpflow_internal_register)
 
 sample_conditional = Dispatcher("sample_conditional")

--- a/gpflow/posteriors/__init__.py
+++ b/gpflow/posteriors/__init__.py
@@ -14,7 +14,7 @@
 
 
 from .dispatch import create_posterior, get_posterior_class
-from .posterior import PrecomputeCacheType, Posterior
+from .posterior import Posterior, PrecomputeCacheType
 from .svgp import (
     BasePosterior,
     FallbackIndependentLatentPosterior,

--- a/gpflow/posteriors/__init__.py
+++ b/gpflow/posteriors/__init__.py
@@ -1,0 +1,25 @@
+#  Copyright 2021 The GPflow Contributors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from .dispatch import create_posterior, get_posterior_class
+from .posterior import PrecomputeCacheType, Posterior
+from .svgp import (
+    BasePosterior,
+    FallbackIndependentLatentPosterior,
+    FullyCorrelatedPosterior,
+    IndependentPosteriorMultiOutput,
+    IndependentPosteriorSingleOutput,
+    LinearCoregionalizationPosterior,
+)

--- a/gpflow/posteriors/dispatch.py
+++ b/gpflow/posteriors/dispatch.py
@@ -1,0 +1,108 @@
+#  Copyright 2021 The GPflow Contributors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import Union
+
+from .posterior import PrecomputeCacheType
+from .svgp import (
+    IndependentPosteriorMultiOutput,
+    IndependentPosteriorSingleOutput,
+    LinearCoregionalizationPosterior,
+    FullyCorrelatedPosterior,
+    FallbackIndependentLatentPosterior
+)
+from .. import kernels
+from ..inducing_variables import (
+    FallbackSeparateIndependentInducingVariables,
+    FallbackSharedIndependentInducingVariables,
+    InducingPoints,
+    InducingVariables,
+    SeparateIndependentInducingVariables,
+    SharedIndependentInducingVariables,
+)
+from ..utilities import Dispatcher
+
+get_posterior_class = Dispatcher("get_posterior_class")
+
+
+@get_posterior_class.register(kernels.Kernel, InducingVariables)
+def _get_posterior_base_case(kernel, inducing_variable):
+    # independent single output
+    return IndependentPosteriorSingleOutput
+
+
+@get_posterior_class.register(kernels.MultioutputKernel, InducingPoints)
+def _get_posterior_fully_correlated_mo(kernel, inducing_variable):
+    return FullyCorrelatedPosterior
+
+
+@get_posterior_class.register(
+    (kernels.SharedIndependent, kernels.SeparateIndependent),
+    (SeparateIndependentInducingVariables, SharedIndependentInducingVariables),
+)
+def _get_posterior_independent_mo(kernel, inducing_variable):
+    # independent multi-output
+    return IndependentPosteriorMultiOutput
+
+
+@get_posterior_class.register(
+    kernels.IndependentLatent,
+    (FallbackSeparateIndependentInducingVariables, FallbackSharedIndependentInducingVariables),
+)
+def _get_posterior_independentlatent_mo_fallback(kernel, inducing_variable):
+    return FallbackIndependentLatentPosterior
+
+
+@get_posterior_class.register(
+    kernels.LinearCoregionalization,
+    (SeparateIndependentInducingVariables, SharedIndependentInducingVariables),
+)
+def _get_posterior_linearcoregionalization_mo_efficient(kernel, inducing_variable):
+    # Linear mixing---efficient multi-output
+    return LinearCoregionalizationPosterior
+
+
+def _validate_precompute_cache_type(value) -> PrecomputeCacheType:
+    if value is None:
+        return PrecomputeCacheType.NOCACHE
+    elif isinstance(value, PrecomputeCacheType):
+        return value
+    elif isinstance(value, str):
+        return PrecomputeCacheType(value.lower())
+    else:
+        raise ValueError(
+            f"{value} is not a valid PrecomputeCacheType. Valid options: 'tensor', 'variable', 'nocache' (or None)."
+        )
+
+
+def create_posterior(
+    kernel,
+    inducing_variable,
+    q_mu,
+    q_sqrt,
+    whiten,
+    mean_function=None,
+    precompute_cache: Union[PrecomputeCacheType, str, None] = PrecomputeCacheType.TENSOR,
+):
+    posterior_class = get_posterior_class(kernel, inducing_variable)
+    precompute_cache = _validate_precompute_cache_type(precompute_cache)
+    return posterior_class(
+        kernel,
+        inducing_variable,
+        q_mu,
+        q_sqrt,
+        whiten,
+        mean_function,
+        precompute_cache=precompute_cache,
+    )
+

--- a/gpflow/posteriors/dispatch.py
+++ b/gpflow/posteriors/dispatch.py
@@ -13,14 +13,6 @@
 #  limitations under the License.
 from typing import Union
 
-from .posterior import PrecomputeCacheType
-from .svgp import (
-    IndependentPosteriorMultiOutput,
-    IndependentPosteriorSingleOutput,
-    LinearCoregionalizationPosterior,
-    FullyCorrelatedPosterior,
-    FallbackIndependentLatentPosterior
-)
 from .. import kernels
 from ..inducing_variables import (
     FallbackSeparateIndependentInducingVariables,
@@ -31,6 +23,14 @@ from ..inducing_variables import (
     SharedIndependentInducingVariables,
 )
 from ..utilities import Dispatcher
+from .posterior import PrecomputeCacheType
+from .svgp import (
+    FallbackIndependentLatentPosterior,
+    FullyCorrelatedPosterior,
+    IndependentPosteriorMultiOutput,
+    IndependentPosteriorSingleOutput,
+    LinearCoregionalizationPosterior,
+)
 
 get_posterior_class = Dispatcher("get_posterior_class")
 
@@ -105,4 +105,3 @@ def create_posterior(
         mean_function,
         precompute_cache=precompute_cache,
     )
-

--- a/gpflow/posteriors/posterior.py
+++ b/gpflow/posteriors/posterior.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Optional, cast, Tuple
+from typing import Optional, Tuple, cast
 
 import tensorflow as tf
 
@@ -43,7 +43,6 @@ class PrecomputeCacheType(Enum):
 
 
 class Posterior(Module, ABC):
-
     def __init__(
         self,
         kernel,

--- a/gpflow/posteriors/posterior.py
+++ b/gpflow/posteriors/posterior.py
@@ -1,0 +1,207 @@
+#  Copyright 2021 The GPflow Contributors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Optional, cast, Tuple
+
+import tensorflow as tf
+
+from .. import mean_functions
+from ..base import Module
+from ..types import MeanAndVariance
+
+
+class PrecomputeCacheType(Enum):
+    """
+    - `PrecomputeCacheType.TENSOR` (or `"tensor"`): Precomputes the cached
+      quantities and stores them as tensors (which allows differentiating
+      through the prediction). This is the default.
+    - `PrecomputeCacheType.VARIABLE` (or `"variable"`): Precomputes the cached
+      quantities and stores them as variables, which allows for updating
+      their values without changing the compute graph (relevant for AOT
+      compilation).
+    - `PrecomputeCacheType.NOCACHE` (or `"nocache"` or `None`): Avoids
+      immediate cache computation. This is useful for avoiding extraneous
+      computations when you only want to call the posterior's
+      `fused_predict_f` method.
+    """
+
+    TENSOR = "tensor"
+    VARIABLE = "variable"
+    NOCACHE = "nocache"
+
+
+class Posterior(Module, ABC):
+
+    def __init__(
+        self,
+        kernel,
+        mean_function: Optional[mean_functions.MeanFunction] = None,
+        *,
+        precompute_cache: Optional[PrecomputeCacheType],
+    ):
+        """
+        Users should use `create_posterior` to create instances of concrete
+        subclasses of this Posterior class instead of calling this constructor
+        directly. For `create_posterior` to be able to correctly instantiate
+        subclasses, developers need to ensure their subclasses don't change the
+        constructor signature.
+        """
+        self.kernel = kernel
+        self.mean_function = mean_function
+
+        self.alpha = self.Qinv = None
+        if precompute_cache is not None:
+            self.update_cache(precompute_cache)
+
+    def update_cache(self, precompute_cache: Optional[PrecomputeCacheType] = None):
+        """
+        Sets the cache depending on the value of `precompute_cache` to a
+        `tf.Tensor`, `tf.Variable`, or clears the cache. If `precompute_cache`
+        is not given, the setting defaults to the most-recently-used one.
+        """
+        if precompute_cache is None:
+            try:
+                precompute_cache = cast(
+                    PrecomputeCacheType, self._precompute_cache,  # type: ignore
+                )
+            except AttributeError:
+                raise ValueError(
+                    "You must pass precompute_cache explicitly (the cache had not been updated before)."
+                )
+        else:
+            self._precompute_cache = precompute_cache
+
+        if precompute_cache is PrecomputeCacheType.NOCACHE:
+            self.alpha = self.Qinv = None
+
+        elif precompute_cache is PrecomputeCacheType.TENSOR:
+            self.alpha, self.Qinv = self._precompute()
+
+        elif precompute_cache is PrecomputeCacheType.VARIABLE:
+            alpha, Qinv = self._precompute()
+            if isinstance(self.alpha, tf.Variable) and isinstance(self.Qinv, tf.Variable):
+                # re-use existing variables
+                self.alpha.assign(alpha)
+                self.Qinv.assign(Qinv)
+            else:  # create variables
+                self.alpha = tf.Variable(alpha, trainable=False)
+                self.Qinv = tf.Variable(Qinv, trainable=False)
+
+    def _add_mean_function(self, Xnew, mean):
+        if self.mean_function is None:
+            return mean
+        else:
+            return mean + self.mean_function(Xnew)
+
+    def fused_predict_f(
+        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
+    ) -> MeanAndVariance:
+        """
+        Computes predictive mean and (co)variance at Xnew, including mean_function
+        Does not make use of caching
+        """
+        mean, cov = self._conditional_fused(
+            Xnew, full_cov=full_cov, full_output_cov=full_output_cov
+        )
+        return self._add_mean_function(Xnew, mean), cov
+
+    @abstractmethod
+    def _conditional_fused(
+        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
+    ) -> MeanAndVariance:
+        """
+        Computes predictive mean and (co)variance at Xnew, *excluding* mean_function
+        Does not make use of caching
+        """
+
+    def predict_f(
+        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
+    ) -> MeanAndVariance:
+        """
+        Computes predictive mean and (co)variance at Xnew, including mean_function.
+        Relies on precomputed alpha and Qinv (see _precompute method)
+        """
+        if self.alpha is None or self.Qinv is None:
+            raise ValueError(
+                "Cache has not been precomputed yet. Call update_cache first or use fused_predict_f"
+            )
+        mean, cov = self._conditional_with_precompute(
+            Xnew, full_cov=full_cov, full_output_cov=full_output_cov
+        )
+        return self._add_mean_function(Xnew, mean), cov
+
+    @abstractmethod
+    def _precompute(self) -> Tuple[tf.Tensor, tf.Tensor]:
+        """
+        Precomputes alpha and Qinv that do not depend on Xnew
+        """
+
+    @abstractmethod
+    def _conditional_with_precompute(
+        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
+    ) -> MeanAndVariance:
+        """
+        Computes predictive mean and (co)variance at Xnew, *excluding* mean_function.
+        Relies on precomputed alpha and Qinv (see _precompute method)
+        """
+
+
+class _QDistribution(Module):
+    """
+    Base class for our parametrization of q(u) in the `VariationalPosteriorMixin`.
+    Internal - do not rely on this outside of GPflow.
+    """
+
+
+class _DeltaDist(_QDistribution):
+    def __init__(self, q_mu):
+        self.q_mu = q_mu  # [M, L]
+
+    @property
+    def q_sqrt(self):
+        return None
+
+
+class _DiagNormal(_QDistribution):
+    def __init__(self, q_mu, q_sqrt):
+        self.q_mu = q_mu  # [M, L]
+        self.q_sqrt = q_sqrt  # [M, L]
+
+
+class _MvNormal(_QDistribution):
+    def __init__(self, q_mu, q_sqrt):
+        self.q_mu = q_mu  # [M, L]
+        self.q_sqrt = q_sqrt  # [L, M, M], lower-triangular
+
+
+class VariationalPosteriorMixin:
+
+    _q_dist: _QDistribution
+
+    @property
+    def q_mu(self):
+        return self._q_dist.q_mu
+
+    @property
+    def q_sqrt(self):
+        return self._q_dist.q_sqrt
+
+    def _set_qdist(self, q_mu, q_sqrt):
+        if q_sqrt is None:
+            self._q_dist = _DeltaDist(q_mu)
+        elif len(q_sqrt.shape) == 2:  # q_diag
+            self._q_dist = _DiagNormal(q_mu, q_sqrt)
+        else:
+            self._q_dist = _MvNormal(q_mu, q_sqrt)

--- a/gpflow/posteriors/svgp.py
+++ b/gpflow/posteriors/svgp.py
@@ -16,7 +16,6 @@ from typing import Optional
 
 import tensorflow as tf
 
-from .posterior import _DeltaDist, _DiagNormal, _MvNormal, PrecomputeCacheType, Posterior, VariationalPosteriorMixin
 from .. import covariances, kernels, mean_functions
 from ..conditionals.util import (
     base_conditional,
@@ -29,10 +28,17 @@ from ..conditionals.util import (
 from ..config import default_jitter
 from ..inducing_variables import SharedIndependentInducingVariables
 from ..types import MeanAndVariance
+from .posterior import (
+    Posterior,
+    PrecomputeCacheType,
+    VariationalPosteriorMixin,
+    _DeltaDist,
+    _DiagNormal,
+    _MvNormal,
+)
 
 
 class BasePosterior(Posterior, VariationalPosteriorMixin, ABC):
-
     def __init__(
         self,
         kernel,

--- a/gpflow/posteriors/svgp.py
+++ b/gpflow/posteriors/svgp.py
@@ -1,28 +1,24 @@
-# Copyright 2016-2020 The GPflow Contributors. All Rights Reserved.
+#  Copyright 2021 The GPflow Contributors. All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#  http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from abc import ABC
+from typing import Optional
 
-import enum
-from abc import ABC, abstractmethod
-from typing import Optional, Tuple, Union, cast
-
-import numpy as np
 import tensorflow as tf
-import tensorflow_probability as tfp
 
-from . import covariances, kernels, mean_functions
-from .base import Module
-from .conditionals.util import (
+from .posterior import _DeltaDist, _DiagNormal, _MvNormal, PrecomputeCacheType, Posterior, VariationalPosteriorMixin
+from .. import covariances, kernels, mean_functions
+from ..conditionals.util import (
     base_conditional,
     expand_independent_outputs,
     fully_correlated_conditional,
@@ -30,81 +26,13 @@ from .conditionals.util import (
     mix_latent_gp,
     separate_independent_conditional_implementation,
 )
-from .config import default_float, default_jitter
-from .inducing_variables import (
-    FallbackSeparateIndependentInducingVariables,
-    FallbackSharedIndependentInducingVariables,
-    InducingPoints,
-    InducingVariables,
-    SeparateIndependentInducingVariables,
-    SharedIndependentInducingVariables,
-)
-from .types import MeanAndVariance
-from .utilities import Dispatcher
+from ..config import default_jitter
+from ..inducing_variables import SharedIndependentInducingVariables
+from ..types import MeanAndVariance
 
 
-class _QDistribution(Module):
-    """
-    Base class for our parametrization of q(u) in the `AbstractPosterior`.
-    Internal - do not rely on this outside of GPflow.
-    """
+class BasePosterior(Posterior, VariationalPosteriorMixin, ABC):
 
-
-class _DeltaDist(_QDistribution):
-    def __init__(self, q_mu):
-        self.q_mu = q_mu  # [M, L]
-
-    @property
-    def q_sqrt(self):
-        return None
-
-
-class _DiagNormal(_QDistribution):
-    def __init__(self, q_mu, q_sqrt):
-        self.q_mu = q_mu  # [M, L]
-        self.q_sqrt = q_sqrt  # [M, L]
-
-
-class _MvNormal(_QDistribution):
-    def __init__(self, q_mu, q_sqrt):
-        self.q_mu = q_mu  # [M, L]
-        self.q_sqrt = q_sqrt  # [L, M, M], lower-triangular
-
-
-class PrecomputeCacheType(enum.Enum):
-    """
-    - `PrecomputeCacheType.TENSOR` (or `"tensor"`): Precomputes the cached
-      quantities and stores them as tensors (which allows differentiating
-      through the prediction). This is the default.
-    - `PrecomputeCacheType.VARIABLE` (or `"variable"`): Precomputes the cached
-      quantities and stores them as variables, which allows for updating
-      their values without changing the compute graph (relevant for AOT
-      compilation).
-    - `PrecomputeCacheType.NOCACHE` (or `"nocache"` or `None`): Avoids
-      immediate cache computation. This is useful for avoiding extraneous
-      computations when you only want to call the posterior's
-      `fused_predict_f` method.
-    """
-
-    TENSOR = "tensor"
-    VARIABLE = "variable"
-    NOCACHE = "nocache"
-
-
-def _validate_precompute_cache_type(value) -> PrecomputeCacheType:
-    if value is None:
-        return PrecomputeCacheType.NOCACHE
-    elif isinstance(value, PrecomputeCacheType):
-        return value
-    elif isinstance(value, str):
-        return PrecomputeCacheType(value.lower())
-    else:
-        raise ValueError(
-            f"{value} is not a valid PrecomputeCacheType. Valid options: 'tensor', 'variable', 'nocache' (or None)."
-        )
-
-
-class AbstractPosterior(Module, ABC):
     def __init__(
         self,
         kernel,
@@ -118,131 +46,17 @@ class AbstractPosterior(Module, ABC):
     ):
         """
         Users should use `create_posterior` to create instances of concrete
-        subclasses of this AbstractPosterior class instead of calling this
-        constructor directly. For `create_posterior` to be able to correctly
-        instantiate subclasses, developers need to ensure their subclasses
-        don't change the constructor signature.
+        subclasses of this Posterior class instead of calling this constructor
+        directly. For `create_posterior` to be able to correctly instantiate
+        subclasses, developers need to ensure their subclasses don't change the
+        constructor signature.
         """
         self.inducing_variable = inducing_variable
-        self.kernel = kernel
-        self.mean_function = mean_function
         self.whiten = whiten
         self._set_qdist(q_mu, q_sqrt)
 
-        self.alpha = self.Qinv = None
-        if precompute_cache is not None:
-            self.update_cache(precompute_cache)
+        super().__init__(kernel, mean_function, precompute_cache=precompute_cache)
 
-    @property
-    def q_mu(self):
-        return self._q_dist.q_mu
-
-    @property
-    def q_sqrt(self):
-        return self._q_dist.q_sqrt
-
-    def _set_qdist(self, q_mu, q_sqrt):
-        if q_sqrt is None:
-            self._q_dist = _DeltaDist(q_mu)
-        elif len(q_sqrt.shape) == 2:  # q_diag
-            self._q_dist = _DiagNormal(q_mu, q_sqrt)
-        else:
-            self._q_dist = _MvNormal(q_mu, q_sqrt)
-
-    def update_cache(self, precompute_cache: Optional[PrecomputeCacheType] = None):
-        """
-        Sets the cache depending on the value of `precompute_cache` to a
-        `tf.Tensor`, `tf.Variable`, or clears the cache. If `precompute_cache`
-        is not given, the setting defaults to the most-recently-used one.
-        """
-        if precompute_cache is None:
-            try:
-                precompute_cache = cast(
-                    PrecomputeCacheType, self._precompute_cache,  # type: ignore
-                )
-            except AttributeError:
-                raise ValueError(
-                    "You must pass precompute_cache explicitly (the cache had not been updated before)."
-                )
-        else:
-            self._precompute_cache = precompute_cache
-
-        if precompute_cache is PrecomputeCacheType.NOCACHE:
-            self.alpha = self.Qinv = None
-
-        elif precompute_cache is PrecomputeCacheType.TENSOR:
-            self.alpha, self.Qinv = self._precompute()
-
-        elif precompute_cache is PrecomputeCacheType.VARIABLE:
-            alpha, Qinv = self._precompute()
-            if isinstance(self.alpha, tf.Variable) and isinstance(self.Qinv, tf.Variable):
-                # re-use existing variables
-                self.alpha.assign(alpha)
-                self.Qinv.assign(Qinv)
-            else:  # create variables
-                self.alpha = tf.Variable(alpha, trainable=False)
-                self.Qinv = tf.Variable(Qinv, trainable=False)
-
-    def _add_mean_function(self, Xnew, mean):
-        if self.mean_function is None:
-            return mean
-        else:
-            return mean + self.mean_function(Xnew)
-
-    def fused_predict_f(
-        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
-    ) -> MeanAndVariance:
-        """
-        Computes predictive mean and (co)variance at Xnew, including mean_function
-        Does not make use of caching
-        """
-        mean, cov = self._conditional_fused(
-            Xnew, full_cov=full_cov, full_output_cov=full_output_cov
-        )
-        return self._add_mean_function(Xnew, mean), cov
-
-    @abstractmethod
-    def _conditional_fused(
-        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
-    ) -> MeanAndVariance:
-        """
-        Computes predictive mean and (co)variance at Xnew, *excluding* mean_function
-        Does not make use of caching
-        """
-
-    def predict_f(
-        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
-    ) -> MeanAndVariance:
-        """
-        Computes predictive mean and (co)variance at Xnew, including mean_function.
-        Relies on precomputed alpha and Qinv (see _precompute method)
-        """
-        if self.alpha is None or self.Qinv is None:
-            raise ValueError(
-                "Cache has not been precomputed yet. Call update_cache first or use fused_predict_f"
-            )
-        mean, cov = self._conditional_with_precompute(
-            Xnew, full_cov=full_cov, full_output_cov=full_output_cov
-        )
-        return self._add_mean_function(Xnew, mean), cov
-
-    @abstractmethod
-    def _precompute(self) -> Tuple[tf.Tensor, tf.Tensor]:
-        """
-        Precomputes alpha and Qinv that do not depend on Xnew
-        """
-
-    @abstractmethod
-    def _conditional_with_precompute(
-        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
-    ) -> MeanAndVariance:
-        """
-        Computes predictive mean and (co)variance at Xnew, *excluding* mean_function.
-        Relies on precomputed alpha and Qinv (see _precompute method)
-        """
-
-
-class BasePosterior(AbstractPosterior):
     def _precompute(self):
         Kuu = covariances.Kuu(
             self.inducing_variable, self.kernel, jitter=default_jitter()
@@ -556,65 +370,3 @@ class FallbackIndependentLatentPosterior(FullyCorrelatedPosterior):  # XXX
             q_sqrt=self.q_sqrt,
             white=self.whiten,
         )
-
-
-get_posterior_class = Dispatcher("get_posterior_class")
-
-
-@get_posterior_class.register(kernels.Kernel, InducingVariables)
-def _get_posterior_base_case(kernel, inducing_variable):
-    # independent single output
-    return IndependentPosteriorSingleOutput
-
-
-@get_posterior_class.register(kernels.MultioutputKernel, InducingPoints)
-def _get_posterior_fully_correlated_mo(kernel, inducing_variable):
-    return FullyCorrelatedPosterior
-
-
-@get_posterior_class.register(
-    (kernels.SharedIndependent, kernels.SeparateIndependent),
-    (SeparateIndependentInducingVariables, SharedIndependentInducingVariables),
-)
-def _get_posterior_independent_mo(kernel, inducing_variable):
-    # independent multi-output
-    return IndependentPosteriorMultiOutput
-
-
-@get_posterior_class.register(
-    kernels.IndependentLatent,
-    (FallbackSeparateIndependentInducingVariables, FallbackSharedIndependentInducingVariables),
-)
-def _get_posterior_independentlatent_mo_fallback(kernel, inducing_variable):
-    return FallbackIndependentLatentPosterior
-
-
-@get_posterior_class.register(
-    kernels.LinearCoregionalization,
-    (SeparateIndependentInducingVariables, SharedIndependentInducingVariables),
-)
-def _get_posterior_linearcoregionalization_mo_efficient(kernel, inducing_variable):
-    # Linear mixing---efficient multi-output
-    return LinearCoregionalizationPosterior
-
-
-def create_posterior(
-    kernel,
-    inducing_variable,
-    q_mu,
-    q_sqrt,
-    whiten,
-    mean_function=None,
-    precompute_cache: Union[PrecomputeCacheType, str, None] = PrecomputeCacheType.TENSOR,
-):
-    posterior_class = get_posterior_class(kernel, inducing_variable)
-    precompute_cache = _validate_precompute_cache_type(precompute_cache)
-    return posterior_class(
-        kernel,
-        inducing_variable,
-        q_mu,
-        q_sqrt,
-        whiten,
-        mean_function,
-        precompute_cache=precompute_cache,
-    )

--- a/tests/gpflow/posteriors/conftest.py
+++ b/tests/gpflow/posteriors/conftest.py
@@ -1,0 +1,60 @@
+#  Copyright 2021 The GPflow Contributors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import warnings
+from inspect import isabstract
+
+import pytest
+
+import gpflow
+
+TESTED_POSTERIORS = set()
+
+
+@pytest.fixture(scope="package", autouse=True)
+def _ensure_all_posteriors_are_tested_fixture():
+    """
+    This fixture ensures that all concrete posteriors have unit tests which compare the predictions
+    from the fused and precomputed code paths. When adding a new concrete posterior class to
+    GPFlow, ensure that it is also tested in this manner.
+
+    This autouse, module scoped fixture will always be executed when tests in this module are run.
+    """
+    # Code here will be executed before any of the tests in this module.
+
+    yield  # Run tests in this module.
+
+    # Code here will be executed after all of the tests in this module.
+
+    available_posteriors = list(gpflow.ci_utils.subclasses(gpflow.posteriors.Posterior))
+    concrete_posteriors = set([k for k in available_posteriors if not isabstract(k)])
+
+    untested_posteriors = concrete_posteriors - TESTED_POSTERIORS
+
+    if untested_posteriors:
+        message = (
+            f"No tests have been registered for the following posteriors: {untested_posteriors}."
+        )
+        if gpflow.ci_utils.is_continuous_integration():
+            raise AssertionError(message)
+        else:
+            warnings.warn(message)
+
+
+@pytest.fixture(name="register_posterior_test")
+def _register_posterior_test_fixture():
+    def _verify_and_register_posterior_test(posterior, expected_posterior_class):
+        assert isinstance(posterior, expected_posterior_class)
+        TESTED_POSTERIORS.add(expected_posterior_class)
+
+    return _verify_and_register_posterior_test

--- a/tests/gpflow/posteriors/test_svgp.py
+++ b/tests/gpflow/posteriors/test_svgp.py
@@ -23,7 +23,6 @@ import gpflow.ci_utils
 from gpflow.conditionals import conditional
 from gpflow.models.util import inducingpoint_wrapper
 from gpflow.posteriors import (
-    AbstractPosterior,
     FallbackIndependentLatentPosterior,
     FullyCorrelatedPosterior,
     IndependentPosteriorMultiOutput,
@@ -80,48 +79,6 @@ def _num_latent_gps_fixture(request):
 @pytest.fixture(name="output_dims", params=[1, 5])
 def _output_dims_fixture(request):
     return request.param
-
-
-TESTED_POSTERIORS = set()
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _ensure_all_posteriors_are_tested_fixture():
-    """
-    This fixture ensures that all concrete posteriors have unit tests which compare the predictions
-    from the fused and precomputed code paths. When adding a new concrete posterior class to
-    GPFlow, ensure that it is also tested in this manner.
-
-    This autouse, module scoped fixture will always be executed when tests in this module are run.
-    """
-    # Code here will be executed before any of the tests in this module.
-
-    yield  # Run tests in this module.
-
-    # Code here will be executed after all of the tests in this module.
-
-    available_posteriors = list(gpflow.ci_utils.subclasses(AbstractPosterior))
-    concrete_posteriors = set([k for k in available_posteriors if not isabstract(k)])
-
-    untested_posteriors = concrete_posteriors - TESTED_POSTERIORS
-
-    if untested_posteriors:
-        message = (
-            f"No tests have been registered for the following posteriors: {untested_posteriors}."
-        )
-        if gpflow.ci_utils.is_continuous_integration():
-            raise AssertionError(message)
-        else:
-            warnings.warn(message)
-
-
-@pytest.fixture(name="register_posterior_test")
-def _register_posterior_test_fixture():
-    def _verify_and_register_posterior_test(posterior, expected_posterior_class):
-        assert isinstance(posterior, expected_posterior_class)
-        TESTED_POSTERIORS.add(expected_posterior_class)
-
-    return _verify_and_register_posterior_test
 
 
 def create_conditional(

--- a/tests/gpflow/posteriors/test_svgp.py
+++ b/tests/gpflow/posteriors/test_svgp.py
@@ -454,11 +454,14 @@ def test_linear_coregionalization_shi(
     )
 
 
-@pytest.mark.parametrize("precompute_cache,expected_cache_type", [
-    (None, None),
-    (PrecomputeCacheType.TENSOR, tf.Tensor),
-    (PrecomputeCacheType.VARIABLE.value, tf.Variable)
-])
+@pytest.mark.parametrize(
+    "precompute_cache,expected_cache_type",
+    [
+        (None, None),
+        (PrecomputeCacheType.TENSOR, tf.Tensor),
+        (PrecomputeCacheType.VARIABLE.value, tf.Variable),
+    ],
+)
 def test_valid_precompute_type(precompute_cache, expected_cache_type):
     kernel = gpflow.kernels.SquaredExponential()
     inducing_variable = inducingpoint_wrapper(np.random.randn(3, 2))
@@ -466,7 +469,12 @@ def test_valid_precompute_type(precompute_cache, expected_cache_type):
     q_mu = np.random.randn(3, 1)
 
     posterior = create_posterior(
-        kernel=kernel, inducing_variable=inducing_variable, q_mu=q_mu, q_sqrt=None, whiten=True, precompute_cache=precompute_cache
+        kernel=kernel,
+        inducing_variable=inducing_variable,
+        q_mu=q_mu,
+        q_sqrt=None,
+        whiten=True,
+        precompute_cache=precompute_cache,
     )
 
     if expected_cache_type is None:


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** enhancement

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

**Proposed changes**

This PR refactors the posteriors module into a package and separates the `Posterior` base class from both the variational parameters and the inducing points. This is the first step towards creating a posterior object for the `GPR` and `VGP` models.

### Release notes
Refactor posteriors to enable adding new posterior objects without variational parameters and inducing points.

**Fully backwards compatible:** yes

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

