### PR TITLE
Small refactor of the posteriors to support other models

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -45,8 +45,7 @@ This release contains contributions from:
 
 ## Major Features and Improvements
 
-* <INSERT MAJOR FEATURE HERE, USING MARKDOWN SYNTAX>
-* <IF RELEASE CONTAINS MULTIPLE FEATURES FROM SAME AREA, GROUP THEM TOGETHER>
+* Refactor posterior base class to support other model types.
 
 ## Bug Fixes and Other Changes
 

--- a/doc/source/notebooks/advanced/fast_predictions.pct.py
+++ b/doc/source/notebooks/advanced/fast_predictions.pct.py
@@ -16,7 +16,7 @@
 # # Faster predictions by caching
 
 # + [markdown] id="PLuPjfS7KLQ-"
-# The default behaviour of `predict_f` in GPflow models is to compute the predictions from scratch on each call. This is convenient when predicting and training are interleaved, and simplifies the use of these models. There are some use cases, such as Bayesian optimisation, where prediction (at different test points) happens much more frequently than training. In these cases it is convenient to cache parts of the calculation which do not depend upon the test points, and reuse those parts between predictions. 
+# The default behaviour of `predict_f` in GPflow models is to compute the predictions from scratch on each call. This is convenient when predicting and training are interleaved, and simplifies the use of these models. There are some use cases, such as Bayesian optimisation, where prediction (at different test points) happens much more frequently than training. In these cases it is convenient to cache parts of the calculation which do not depend upon the test points, and reuse those parts between predictions.
 #
 # There are three models to which we want to add this caching capability: GPR, (S)VGP and SGPR. The VGP and SVGP can be considered together; the difference between the models is whether to condition on the full training data set (VGP) or on the inducing variables (SVGP).
 
@@ -55,7 +55,7 @@
 # \Sigma = K_{nn} - K_{nu}L^{-1}(I - B^{-1})L^{-1}K_{un}
 # \end{equation*}
 #
-# Where the mean function is not the zero function, the predictive mean should have the mean function evaluated at the test points added to it. 
+# Where the mean function is not the zero function, the predictive mean should have the mean function evaluated at the test points added to it.
 
 # + [markdown] id="GX1U-fYPKPrt"
 # ## What can be cached?
@@ -98,7 +98,7 @@ Xnew = np.linspace(-1.1, 1.1, 1000)[:, None]
 # The `predict_f` method on the `GPModel` class performs no caching.
 
 # %%timeit
-model.predict_f(Xnew);
+model.predict_f(Xnew)
 
 # To make use of the caching, first retrieve the posterior class from the model. The posterior class has methods to predict the parameters of marginal distributions at test points, in the same way as the `predict_f` method of the `GPModel` .
 

--- a/doc/source/notebooks/advanced/fast_predictions.pct.py
+++ b/doc/source/notebooks/advanced/fast_predictions.pct.py
@@ -104,8 +104,5 @@ model.predict_f(Xnew);
 
 posterior = model.posterior()
 
-
 # %%timeit
 posterior.predict_f(Xnew)
-
-

--- a/doc/source/notebooks/advanced/fast_predictions.pct.py
+++ b/doc/source/notebooks/advanced/fast_predictions.pct.py
@@ -1,0 +1,111 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# + [markdown] id="eYrSpUncKGSk"
+# # Faster predictions by caching
+
+# + [markdown] id="PLuPjfS7KLQ-"
+# The default behaviour of `predict_f` in GPflow models is to compute the predictions from scratch on each call. This is convenient when predicting and training are interleaved, and simplifies the use of these models. There are some use cases, such as Bayesian optimisation, where prediction (at different test points) happens much more frequently than training. In these cases it is convenient to cache parts of the calculation which do not depend upon the test points, and reuse those parts between predictions. 
+#
+# There are three models to which we want to add this caching capability: GPR, (S)VGP and SGPR. The VGP and SVGP can be considered together; the difference between the models is whether to condition on the full training data set (VGP) or on the inducing variables (SVGP).
+
+# + [markdown] id="EACkO-iRKM5T"
+# ## Posterior predictive distribution
+#
+# The posterior predictive distribution evaluated at a set of test points $\mathbf{x}_*$ for a Gaussian process model is given by:
+# \begin{equation*}
+# p(\mathbf{f}_*|X, Y) = \mathcal{N}(\mu, \Sigma)
+# \end{equation*}
+#
+# In the case of the GPR model, the parameters $\mu$ and $\Sigma$ are given by:
+# \begin{equation*}
+# \mu = K_{nm}[K_{mm} + \sigma^2I]^{-1}\mathbf{y}
+# \end{equation*}
+# and
+# \begin{equation*}
+# \Sigma = K_{nn} - K_{nm}[K_{mm} + \sigma^2I]^{-1}K_{mn}
+# \end{equation*}
+#
+# The posterior predictive distribution for the VGP and SVGP model is parameterised as follows:
+# \begin{equation*}
+# \mu = K_{nu}K_{uu}^{-1}\mathbf{u}
+# \end{equation*}
+# and
+# \begin{equation*}
+# \Sigma = K_{nn} - K_{nu}K_{uu}^{-1}K_{un}
+# \end{equation*}
+#
+# Finally, the parameters for the SGPR model are:
+# \begin{equation*}
+# \mu = K_{nu}L^{-T}L_B^{-T}\mathbf{c}
+# \end{equation*}
+# and
+# \begin{equation*}
+# \Sigma = K_{nn} - K_{nu}L^{-1}(I - B^{-1})L^{-1}K_{un}
+# \end{equation*}
+#
+# Where the mean function is not the zero function, the predictive mean should have the mean function evaluated at the test points added to it. 
+
+# + [markdown] id="GX1U-fYPKPrt"
+# ## What can be cached?
+#
+# We cache two separate values: $\alpha$ and $Q^{-1}$. These correspond to the parts of the mean and covariance functions respectively which do not depend upon the test points. Specifically, in the case of the GPR model these are:
+# \begin{equation*}
+#     \alpha = [K_{mm} + \sigma^2I]^{-1}\mathbf{y}\\ Q^{-1} = [K_{mm} + \sigma^2I]^{-1}
+# \end{equation*}
+# in the case of the VGP and SVGP model these are:
+# \begin{equation*}
+#     \alpha = K_{uu}^{-1}\mathbf{u}\\ Q^{-1} = K_{uu}^{-1}
+# \end{equation*}
+# and in the case of the SGPR model these are:
+# \begin{equation*}
+#     \alpha = L^{-T}L_B^{-T}\mathbf{c}\\ Q^{-1} = L^{-1}(I - B^{-1})L^{-1}
+# \end{equation*}
+#
+#
+# Note that in the (S)VGP case, $\alpha$ is the parameter as proposed by Opper and Archambeau for the mean of the predictive distribution.
+
+# + [markdown] id="FzCgor4nKUcW"
+# ## Example
+#
+# We will construct an SVGP model to demonstrate the faster predictions from using the cached data in the GPFlow posterior classes (subclasses of `gpflow.posteriors.AbstractPosterior`).
+
+# + id="BMnIdXNiKU6t"
+import gpflow
+import numpy as np
+
+
+model = gpflow.models.SVGP(
+    gpflow.kernels.SquaredExponential(),
+    gpflow.likelihoods.Gaussian(),
+    np.linspace(-1.1, 1.1, 1000)[:, None],
+)
+
+Xnew = np.linspace(-1.1, 1.1, 1000)[:, None]
+# -
+
+# The `predict_f` method on the `GPModel` class performs no caching.
+
+# %%timeit
+model.predict_f(Xnew);
+
+# To make use of the caching, first retrieve the posterior class from the model. The posterior class has methods to predict the parameters of marginal distributions at test points, in the same way as the `predict_f` method of the `GPModel` .
+
+posterior = model.posterior()
+
+
+# %%timeit
+posterior.predict_f(Xnew)
+
+

--- a/doc/source/notebooks/advanced/variational_fourier_features.pct.py
+++ b/doc/source/notebooks/advanced/variational_fourier_features.pct.py
@@ -239,7 +239,7 @@ def gauss_kl_vff(q_mu, q_sqrt, K):
 import gpflow.posteriors
 
 
-class VFFPosterior(gpflow.posteriors.AbstractPosterior):
+class VFFPosterior(gpflow.posteriors.BasePosterior):
     def _conditional_fused(self, Xnew, full_cov, full_output_cov):
         """
         Xnew is a tensor with the points of the data or minibatch, shape N x D
@@ -253,8 +253,8 @@ class VFFPosterior(gpflow.posteriors.AbstractPosterior):
         # num_data = tf.shape(Xnew)[0]  # M
         num_func = tf.shape(f)[1]  # K
 
-        Kuu = cov.Kuu(self.inducing_variable, self.kernel)  # this is now a LinearOperator
-        Kuf = cov.Kuf(self.inducing_variable, self.kernel, Xnew)  # still a Tensor
+        Kuu = cov.Kuu(self.X_data, self.kernel)  # this is now a LinearOperator
+        Kuf = cov.Kuf(self.X_data, self.kernel, Xnew)  # still a Tensor
 
         KuuInv_Kuf = Kuu.solve(Kuf)
 
@@ -310,7 +310,7 @@ class VFFPosterior(gpflow.posteriors.AbstractPosterior):
     # to speed up predictions:
 
     def _precompute(self):
-        Kuu = cov.Kuu(self.inducing_variable, self.kernel)  # this is now a LinearOperator
+        Kuu = cov.Kuu(self.X_data, self.kernel)  # this is now a LinearOperator
 
         q_mu = self._q_dist.q_mu
         q_sqrt = self._q_dist.q_sqrt
@@ -336,7 +336,7 @@ class VFFPosterior(gpflow.posteriors.AbstractPosterior):
         if full_output_cov:
             raise NotImplementedError
 
-        Kuf = cov.Kuf(self.inducing_variable, self.kernel, Xnew)  # still a Tensor
+        Kuf = cov.Kuf(self.X_data, self.kernel, Xnew)  # still a Tensor
 
         # construct the conditional mean
         fmean = tf.matmul(Kuf, self.alpha, transpose_a=True)

--- a/doc/source/notebooks/intro.md
+++ b/doc/source/notebooks/intro.md
@@ -58,6 +58,7 @@ This section explains the more complex models and features that are available in
   - [Inter-domain Variational Fourier features](advanced/variational_fourier_features.ipynb): how to add new inter-domain inducing variables, at the example of representing sparse GPs in the spectral domain.
   - [Manipulating kernels](advanced/kernels.ipynb): information on the covariances that are included in the library, and how you can combine them to create new ones.
   - [Convolutional GPs](advanced/convolutional.ipynb): how we can use GPs with convolutional kernels for image classification.
+  - [Fast predictions by caching](advanced/fast_predictions.ipynd): how to use caching to speed up repeated predictions.
 
 ### Features
 

--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -21,7 +21,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 from . import covariances, kernels, mean_functions
-from .base import Module
+from .base import Module, TensorType
 from .conditionals.util import (
     base_conditional,
     expand_independent_outputs,
@@ -106,15 +106,12 @@ def _validate_precompute_cache_type(value) -> PrecomputeCacheType:
 
 class AbstractPosterior(Module, ABC):
     def __init__(
-        self,
-        kernel,
-        inducing_variable,
-        q_mu: tf.Tensor,
-        q_sqrt: tf.Tensor,
-        whiten: bool = True,
-        mean_function: Optional[mean_functions.MeanFunction] = None,
-        *,
-        precompute_cache: Optional[PrecomputeCacheType],
+            self,
+            kernel,
+            X_data: Union[tf.Tensor, InducingVariables],
+            alpha: Optional[TensorType] = None,
+            Qinv: Optional[TensorType] = None,
+            mean_function: Optional[mean_functions.MeanFunction] = None
     ):
         """
         Users should use `create_posterior` to create instances of concrete
@@ -123,13 +120,90 @@ class AbstractPosterior(Module, ABC):
         instantiate subclasses, developers need to ensure their subclasses
         don't change the constructor signature.
         """
-        self.inducing_variable = inducing_variable
+        super().__init__()
+
         self.kernel = kernel
+        self.X_data = X_data
+        self.alpha = alpha
+        self.Qinv = Qinv
+        self.mean_function = mean_function
+
+    def _add_mean_function(self, Xnew, mean):
+        if self.mean_function is None:
+            return mean
+        else:
+            return mean + self.mean_function(Xnew)
+
+    def fused_predict_f(
+        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
+    ) -> MeanAndVariance:
+        """
+        Computes predictive mean and (co)variance at Xnew, including mean_function
+        Does not make use of caching
+        """
+        mean, cov = self._conditional_fused(
+            Xnew, full_cov=full_cov, full_output_cov=full_output_cov
+        )
+        return self._add_mean_function(Xnew, mean), cov
+
+    @abstractmethod
+    def _conditional_fused(
+        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
+    ) -> MeanAndVariance:
+        """
+        Computes predictive mean and (co)variance at Xnew, *excluding* mean_function
+        Does not make use of caching
+        """
+
+    def predict_f(
+        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
+    ) -> MeanAndVariance:
+        """
+        Computes predictive mean and (co)variance at Xnew, including mean_function.
+        Relies on precomputed alpha and Qinv (see _precompute method)
+        """
+        if self.alpha is None or self.Qinv is None:
+            raise ValueError(
+                "Cache has not been precomputed yet. Call update_cache first or use fused_predict_f"
+            )
+        mean, cov = self._conditional_with_precompute(
+            Xnew, full_cov=full_cov, full_output_cov=full_output_cov
+        )
+        return self._add_mean_function(Xnew, mean), cov
+
+    @abstractmethod
+    def _conditional_with_precompute(
+        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
+    ) -> MeanAndVariance:
+        """
+        Computes predictive mean and (co)variance at Xnew, *excluding* mean_function.
+        Relies on cached alpha and Qinv.
+        """
+        Kmn = self.kernel(self.X_data, Xnew)
+        Knn = self.kernel(Xnew, full_cov=full_cov)
+
+        return base_conditional(Kmn, self.Qinv, Knn, self.alpha, full_cov=full_cov)
+
+
+class BasePosterior(AbstractPosterior):
+
+    def __init__(
+            self,
+            kernel,
+            inducing_variable,
+            q_mu: tf.Tensor,
+            q_sqrt: tf.Tensor,
+            whiten: bool = True,
+            mean_function: Optional[mean_functions.MeanFunction] = None,
+            *,
+            precompute_cache: Optional[PrecomputeCacheType],
+    ):
+
+        super().__init__(kernel, inducing_variable, mean_function=mean_function)
         self.mean_function = mean_function
         self.whiten = whiten
         self._set_qdist(q_mu, q_sqrt)
 
-        self.alpha = self.Qinv = None
         if precompute_cache is not None:
             self.update_cache(precompute_cache)
 
@@ -184,69 +258,9 @@ class AbstractPosterior(Module, ABC):
                 self.alpha = tf.Variable(alpha, trainable=False)
                 self.Qinv = tf.Variable(Qinv, trainable=False)
 
-    def _add_mean_function(self, Xnew, mean):
-        if self.mean_function is None:
-            return mean
-        else:
-            return mean + self.mean_function(Xnew)
-
-    def fused_predict_f(
-        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
-    ) -> MeanAndVariance:
-        """
-        Computes predictive mean and (co)variance at Xnew, including mean_function
-        Does not make use of caching
-        """
-        mean, cov = self._conditional_fused(
-            Xnew, full_cov=full_cov, full_output_cov=full_output_cov
-        )
-        return self._add_mean_function(Xnew, mean), cov
-
-    @abstractmethod
-    def _conditional_fused(
-        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
-    ) -> MeanAndVariance:
-        """
-        Computes predictive mean and (co)variance at Xnew, *excluding* mean_function
-        Does not make use of caching
-        """
-
-    def predict_f(
-        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
-    ) -> MeanAndVariance:
-        """
-        Computes predictive mean and (co)variance at Xnew, including mean_function.
-        Relies on precomputed alpha and Qinv (see _precompute method)
-        """
-        if self.alpha is None or self.Qinv is None:
-            raise ValueError(
-                "Cache has not been precomputed yet. Call update_cache first or use fused_predict_f"
-            )
-        mean, cov = self._conditional_with_precompute(
-            Xnew, full_cov=full_cov, full_output_cov=full_output_cov
-        )
-        return self._add_mean_function(Xnew, mean), cov
-
-    @abstractmethod
-    def _precompute(self) -> Tuple[tf.Tensor, tf.Tensor]:
-        """
-        Precomputes alpha and Qinv that do not depend on Xnew
-        """
-
-    @abstractmethod
-    def _conditional_with_precompute(
-        self, Xnew, full_cov: bool = False, full_output_cov: bool = False
-    ) -> MeanAndVariance:
-        """
-        Computes predictive mean and (co)variance at Xnew, *excluding* mean_function.
-        Relies on precomputed alpha and Qinv (see _precompute method)
-        """
-
-
-class BasePosterior(AbstractPosterior):
     def _precompute(self):
         Kuu = covariances.Kuu(
-            self.inducing_variable, self.kernel, jitter=default_jitter()
+            self.X_data, self.kernel, jitter=default_jitter()
         )  # [(R), M, M]
         q_mu = self._q_dist.q_mu
 
@@ -338,7 +352,7 @@ class IndependentPosterior(BasePosterior):
         # Qinv: [L, M, M]
         # alpha: [M, L]
 
-        Kuf = covariances.Kuf(self.inducing_variable, self.kernel, Xnew)  # [(R), M, N]
+        Kuf = covariances.Kuf(self.X_data, self.kernel, Xnew)  # [(R), M, N]
         Kff = self._get_Kff(Xnew, full_cov)
 
         mean = tf.matmul(Kuf, self.alpha, transpose_a=True)
@@ -367,9 +381,9 @@ class IndependentPosteriorSingleOutput(IndependentPosterior):
         Knn = self.kernel(Xnew, full_cov=full_cov)
 
         Kmm = covariances.Kuu(
-            self.inducing_variable, self.kernel, jitter=default_jitter()
+            self.X_data, self.kernel, jitter=default_jitter()
         )  # [M, M]
-        Kmn = covariances.Kuf(self.inducing_variable, self.kernel, Xnew)  # [M, N]
+        Kmn = covariances.Kuf(self.X_data, self.kernel, Xnew)  # [M, N]
 
         fmean, fvar = base_conditional(
             Kmn, Kmm, Knn, self.q_mu, full_cov=full_cov, q_sqrt=self.q_sqrt, white=self.whiten
@@ -381,7 +395,7 @@ class IndependentPosteriorMultiOutput(IndependentPosterior):
     def _conditional_fused(
         self, Xnew, full_cov: bool = False, full_output_cov: bool = False
     ) -> MeanAndVariance:
-        if isinstance(self.inducing_variable, SharedIndependentInducingVariables) and isinstance(
+        if isinstance(self.X_data, SharedIndependentInducingVariables) and isinstance(
             self.kernel, kernels.SharedIndependent
         ):
             # same as IndependentPosteriorSingleOutput except for following line
@@ -389,9 +403,9 @@ class IndependentPosteriorMultiOutput(IndependentPosterior):
             # we don't call self.kernel() directly as that would do unnecessary tiling
 
             Kmm = covariances.Kuu(
-                self.inducing_variable, self.kernel, jitter=default_jitter()
+                self.X_data, self.kernel, jitter=default_jitter()
             )  # [M, M]
-            Kmn = covariances.Kuf(self.inducing_variable, self.kernel, Xnew)  # [M, N]
+            Kmn = covariances.Kuf(self.X_data, self.kernel, Xnew)  # [M, N]
 
             fmean, fvar = base_conditional(
                 Kmn, Kmm, Knn, self.q_mu, full_cov=full_cov, q_sqrt=self.q_sqrt, white=self.whiten
@@ -401,14 +415,14 @@ class IndependentPosteriorMultiOutput(IndependentPosterior):
 
             # Following are: [P, M, M]  -  [P, M, N]  -  [P, N](x N)
             Kmms = covariances.Kuu(
-                self.inducing_variable, self.kernel, jitter=default_jitter()
+                self.X_data, self.kernel, jitter=default_jitter()
             )  # [P, M, M]
-            Kmns = covariances.Kuf(self.inducing_variable, self.kernel, Xnew)  # [P, M, N]
+            Kmns = covariances.Kuf(self.X_data, self.kernel, Xnew)  # [P, M, N]
             if isinstance(self.kernel, kernels.Combination):
                 kernel_list = self.kernel.kernels
             else:
                 kernel_list = [self.kernel.kernel] * len(
-                    self.inducing_variable.inducing_variable_list
+                    self.X_data.inducing_variable_list
                 )
             Knns = tf.stack(
                 [k.K(Xnew) if full_cov else k.K_diag(Xnew) for k in kernel_list], axis=0
@@ -447,7 +461,7 @@ class FullyCorrelatedPosterior(BasePosterior):
         # Qinv: [L, M, M]
         # alpha: [M, L]
 
-        Kuf = covariances.Kuf(self.inducing_variable, self.kernel, Xnew)
+        Kuf = covariances.Kuf(self.X_data, self.kernel, Xnew)
         assert Kuf.shape.ndims == 4
         M, L, N, K = tf.unstack(tf.shape(Kuf), num=Kuf.shape.ndims, axis=0)
         Kuf = tf.reshape(Kuf, (M * L, N * K))
@@ -504,9 +518,9 @@ class FullyCorrelatedPosterior(BasePosterior):
         self, Xnew, full_cov: bool = False, full_output_cov: bool = False
     ) -> MeanAndVariance:
         Kmm = covariances.Kuu(
-            self.inducing_variable, self.kernel, jitter=default_jitter()
+            self.X_data, self.kernel, jitter=default_jitter()
         )  # [M, L, M, L]
-        Kmn = covariances.Kuf(self.inducing_variable, self.kernel, Xnew)  # [M, L, N, P]
+        Kmn = covariances.Kuf(self.X_data, self.kernel, Xnew)  # [M, L, N, P]
         Knn = self.kernel(
             Xnew, full_cov=full_cov, full_output_cov=full_output_cov
         )  # [N, P](x N)x P  or  [N, P](x P)
@@ -542,9 +556,9 @@ class FallbackIndependentLatentPosterior(FullyCorrelatedPosterior):  # XXX
         self, Xnew, full_cov: bool = False, full_output_cov: bool = False
     ) -> MeanAndVariance:
         Kmm = covariances.Kuu(
-            self.inducing_variable, self.kernel, jitter=default_jitter()
+            self.X_data, self.kernel, jitter=default_jitter()
         )  # [L, M, M]
-        Kmn = covariances.Kuf(self.inducing_variable, self.kernel, Xnew)  # [M, L, N, P]
+        Kmn = covariances.Kuf(self.X_data, self.kernel, Xnew)  # [M, L, N, P]
         Knn = self.kernel(
             Xnew, full_cov=full_cov, full_output_cov=full_output_cov
         )  # [N, P](x N)x P  or  [N, P](x P)

--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -171,6 +171,7 @@ class AbstractPosterior(Module, ABC):
         )
         return self._add_mean_function(Xnew, mean), cov
 
+    @abstractmethod
     def _conditional_with_precompute(
         self, Xnew, full_cov: bool = False, full_output_cov: bool = False
     ) -> MeanAndVariance:
@@ -178,10 +179,6 @@ class AbstractPosterior(Module, ABC):
         Computes predictive mean and (co)variance at Xnew, *excluding* mean_function.
         Relies on cached alpha and Qinv.
         """
-        Kmn = self.kernel(self.X_data, Xnew)
-        Knn = self.kernel(Xnew, full_cov=full_cov)
-
-        return base_conditional(Kmn, self.Qinv, Knn, self.alpha, full_cov=full_cov)
 
 
 class BasePosterior(AbstractPosterior):

--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -171,7 +171,6 @@ class AbstractPosterior(Module, ABC):
         )
         return self._add_mean_function(Xnew, mean), cov
 
-    @abstractmethod
     def _conditional_with_precompute(
         self, Xnew, full_cov: bool = False, full_output_cov: bool = False
     ) -> MeanAndVariance:
@@ -199,7 +198,6 @@ class BasePosterior(AbstractPosterior):
     ):
 
         super().__init__(kernel, inducing_variable, mean_function=mean_function)
-        self.mean_function = mean_function
         self.whiten = whiten
         self._set_qdist(q_mu, q_sqrt)
 

--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -106,12 +106,12 @@ def _validate_precompute_cache_type(value) -> PrecomputeCacheType:
 
 class AbstractPosterior(Module, ABC):
     def __init__(
-            self,
-            kernel,
-            X_data: Union[tf.Tensor, InducingVariables],
-            alpha: Optional[TensorType] = None,
-            Qinv: Optional[TensorType] = None,
-            mean_function: Optional[mean_functions.MeanFunction] = None
+        self,
+        kernel,
+        X_data: Union[tf.Tensor, InducingVariables],
+        alpha: Optional[TensorType] = None,
+        Qinv: Optional[TensorType] = None,
+        mean_function: Optional[mean_functions.MeanFunction] = None,
     ):
         """
         Users should use `create_posterior` to create instances of concrete
@@ -186,17 +186,16 @@ class AbstractPosterior(Module, ABC):
 
 
 class BasePosterior(AbstractPosterior):
-
     def __init__(
-            self,
-            kernel,
-            inducing_variable,
-            q_mu: tf.Tensor,
-            q_sqrt: tf.Tensor,
-            whiten: bool = True,
-            mean_function: Optional[mean_functions.MeanFunction] = None,
-            *,
-            precompute_cache: Optional[PrecomputeCacheType],
+        self,
+        kernel,
+        inducing_variable,
+        q_mu: tf.Tensor,
+        q_sqrt: tf.Tensor,
+        whiten: bool = True,
+        mean_function: Optional[mean_functions.MeanFunction] = None,
+        *,
+        precompute_cache: Optional[PrecomputeCacheType],
     ):
 
         super().__init__(kernel, inducing_variable, mean_function=mean_function)
@@ -259,9 +258,7 @@ class BasePosterior(AbstractPosterior):
                 self.Qinv = tf.Variable(Qinv, trainable=False)
 
     def _precompute(self):
-        Kuu = covariances.Kuu(
-            self.X_data, self.kernel, jitter=default_jitter()
-        )  # [(R), M, M]
+        Kuu = covariances.Kuu(self.X_data, self.kernel, jitter=default_jitter())  # [(R), M, M]
         q_mu = self._q_dist.q_mu
 
         if Kuu.shape.ndims == 4:
@@ -380,9 +377,7 @@ class IndependentPosteriorSingleOutput(IndependentPosterior):
         # same as IndependentPosteriorMultiOutput, Shared~/Shared~ branch, except for following line:
         Knn = self.kernel(Xnew, full_cov=full_cov)
 
-        Kmm = covariances.Kuu(
-            self.X_data, self.kernel, jitter=default_jitter()
-        )  # [M, M]
+        Kmm = covariances.Kuu(self.X_data, self.kernel, jitter=default_jitter())  # [M, M]
         Kmn = covariances.Kuf(self.X_data, self.kernel, Xnew)  # [M, N]
 
         fmean, fvar = base_conditional(
@@ -402,9 +397,7 @@ class IndependentPosteriorMultiOutput(IndependentPosterior):
             Knn = self.kernel.kernel(Xnew, full_cov=full_cov)
             # we don't call self.kernel() directly as that would do unnecessary tiling
 
-            Kmm = covariances.Kuu(
-                self.X_data, self.kernel, jitter=default_jitter()
-            )  # [M, M]
+            Kmm = covariances.Kuu(self.X_data, self.kernel, jitter=default_jitter())  # [M, M]
             Kmn = covariances.Kuf(self.X_data, self.kernel, Xnew)  # [M, N]
 
             fmean, fvar = base_conditional(
@@ -414,16 +407,12 @@ class IndependentPosteriorMultiOutput(IndependentPosterior):
             # this is the messy thing with tf.map_fn, cleaned up by the st/clean_up_broadcasting_conditionals branch
 
             # Following are: [P, M, M]  -  [P, M, N]  -  [P, N](x N)
-            Kmms = covariances.Kuu(
-                self.X_data, self.kernel, jitter=default_jitter()
-            )  # [P, M, M]
+            Kmms = covariances.Kuu(self.X_data, self.kernel, jitter=default_jitter())  # [P, M, M]
             Kmns = covariances.Kuf(self.X_data, self.kernel, Xnew)  # [P, M, N]
             if isinstance(self.kernel, kernels.Combination):
                 kernel_list = self.kernel.kernels
             else:
-                kernel_list = [self.kernel.kernel] * len(
-                    self.X_data.inducing_variable_list
-                )
+                kernel_list = [self.kernel.kernel] * len(self.X_data.inducing_variable_list)
             Knns = tf.stack(
                 [k.K(Xnew) if full_cov else k.K_diag(Xnew) for k in kernel_list], axis=0
             )
@@ -517,9 +506,7 @@ class FullyCorrelatedPosterior(BasePosterior):
     def _conditional_fused(
         self, Xnew, full_cov: bool = False, full_output_cov: bool = False
     ) -> MeanAndVariance:
-        Kmm = covariances.Kuu(
-            self.X_data, self.kernel, jitter=default_jitter()
-        )  # [M, L, M, L]
+        Kmm = covariances.Kuu(self.X_data, self.kernel, jitter=default_jitter())  # [M, L, M, L]
         Kmn = covariances.Kuf(self.X_data, self.kernel, Xnew)  # [M, L, N, P]
         Knn = self.kernel(
             Xnew, full_cov=full_cov, full_output_cov=full_output_cov
@@ -555,9 +542,7 @@ class FallbackIndependentLatentPosterior(FullyCorrelatedPosterior):  # XXX
     def _conditional_fused(
         self, Xnew, full_cov: bool = False, full_output_cov: bool = False
     ) -> MeanAndVariance:
-        Kmm = covariances.Kuu(
-            self.X_data, self.kernel, jitter=default_jitter()
-        )  # [L, M, M]
+        Kmm = covariances.Kuu(self.X_data, self.kernel, jitter=default_jitter())  # [L, M, M]
         Kmn = covariances.Kuf(self.X_data, self.kernel, Xnew)  # [M, L, N, P]
         Knn = self.kernel(
             Xnew, full_cov=full_cov, full_output_cov=full_output_cov


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** enhancement / doc improvement

**Related issue(s)/PRs:** 

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->
This PR refactors the posterior objects. The current posterior objects are tightly coupled to the SVGP model, by requiring both inducing points and variational parameters. This PR changes the constructor of the base class (`AbstractPosterior`) to accept the `alpha` and `Qinv` values (alongside the inducing points or training data points). This makes the base class sufficiently flexible to support the GPR, SGPR and VGP models, which can be added later.

The posterior object is not necessarily responsible for calculating `alpha` and `Qinv`. Subclasses of `AbstractPosterior` for different posteriors could have a `precompute` method like the SVGP `BasePosterior`, or the models could calculate the tensor values when creating a posterior object.

The base class for the SVGP posteriors is still `BasePosterior`. Updating the cached values has been left on the `BasePosterior`. 

This PR also includes a draft of a notebook about the caching functionality, with examples of the maths for the GPR, SGPR and (S)VGP models.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

### Minimal working example

See the timing example at the end of the new notebook.

### Release notes
<!-- leave blank if unsure -->
Refactor the posterior base classes to support other models than the SVGP model.

**Fully backwards compatible:** yes

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [x] notebook examples (usage demonstration)
- [x] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [x] Build checks
  - [x] I ran the black+isort formatter (`make format`)
  - [x] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [x] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

