### PR TITLE
Fix IndependentPosteriorMultiOutput for kernels with active_dims

### DIFF
--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -615,7 +615,7 @@ class IndependentPosteriorMultiOutput(IndependentPosterior):
             else:
                 kernel_list = [self.kernel.kernel] * len(self.X_data.inducing_variable_list)
             Knns = tf.stack(
-                [k.K(Xnew) if full_cov else k.K_diag(Xnew) for k in kernel_list], axis=0
+                [k(Xnew, full_cov=full_cov) for k in kernel_list], axis=0
             )
 
             fmean, fvar = separate_independent_conditional_implementation(


### PR DESCRIPTION
I propose to replace use of K method by __call__ as explained in #1723

<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** enhancement 

**Related issue(s)/PRs:** #1723






