### PR TITLE
Update CircleCi build to use next-gen Docker images.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
 jobs:
   verify-install:
     docker:
-      - image: circleci/python:3.6-buster
+      - image: cimg/python:3.6
 
     steps:
       - install_gpflow
@@ -63,7 +63,7 @@ jobs:
 
   type-check:
     docker:
-      - image: circleci/python:3.6-buster
+      - image: cimg/python:3.6
 
     steps:
       - setup_venv
@@ -80,7 +80,7 @@ jobs:
 
   unit-test:
     docker:
-      - image: circleci/python:3.6-buster
+      - image: cimg/python:3.6
 
     steps:
       - run_tests:
@@ -88,7 +88,7 @@ jobs:
 
   notebook-test:
     docker:
-      - image: circleci/python:3.6-buster
+      - image: cimg/python:3.6
 
     steps:
       - run_tests:
@@ -96,7 +96,7 @@ jobs:
 
   format-checker:
     docker:
-      - image: circleci/python:3.6-buster
+      - image: cimg/python:3.6
 
     steps:
       - setup_venv
@@ -113,7 +113,7 @@ jobs:
 
   trigger-docs-generation:
     docker:
-      - image: circleci/python:3.6-buster
+      - image: cimg/python:3.6
         environment:
             ORGANIZATION: GPflow
             PROJECT: docs
@@ -131,7 +131,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.6-buster
+      - image: cimg/python:3.6
     steps:
       - checkout
       - run:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,6 +56,7 @@ This release contains contributions from:
 ## Bug Fixes and Other Changes
 
 * Fixed broken CircleCi build.
+* Update CircleCi build to use next-gen Docker images.
 
 ## Thanks to our Contributors
 


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix

**Related issue(s)/PRs:** resolves #1739

## Summary

**Proposed changes**

Update the image used in CircleCi from the (deprecated) `circleci/python:3.6-buster` to next gen `cimg/python:3.6`.

**What alternatives have you considered?**

N/A

### Minimal working example

N/A

### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** yes

**If not, why is it worth breaking backwards compatibility:**

N/A

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [x] Release management
  - [x] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

