### PR TITLE
Set kernelspec on cplb.pct.py.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -59,6 +59,7 @@ This release contains contributions from:
 * Update CircleCi build to use next-gen Docker images.
 * Fixed broken link in `README.md`.
 * Make `make dev-install` also install the test requirements.
+* Fix broken build of `cglb.ipynb`.
 
 ## Thanks to our Contributors
 

--- a/doc/source/notebooks/theory/cglb.pct.py
+++ b/doc/source/notebooks/theory/cglb.pct.py
@@ -1,4 +1,19 @@
 # -*- coding: utf-8 -*-
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,.pct.py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.3.3
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
 # %%
 import numpy as np
 import tensorflow as tf


### PR DESCRIPTION
**PR type:** bugfix

**Related issue(s)/PRs:** 1728

## Summary

**Proposed changes**

Add header with `kernelspec` to `cplb.pct.py` - the missing header was preventing it from being built with `make theory/cglb.ipynb`.

**What alternatives have you considered?**

None.

### Minimal working example

```bash
make theory/cglb.ipynb
```

### Release notes

**Fully backwards compatible:** yes

**If not, why is it worth breaking backwards compatibility:**

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [x] Release management
  - [x] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

