### PR TITLE
Adjust test dependencies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ commands:
             virtualenv -p python3.6 .venv
             source .venv/bin/activate
             pip install --progress-bar=off -U pip
-
   install_gpflow:
     steps:
       - setup_venv
@@ -73,10 +72,27 @@ jobs:
             source .venv/bin/activate
             pip install --progress-bar=off mypy types-pkg_resources
       - run:
-          name: Run type checker
+          name: Run type check
           command: |
             source .venv/bin/activate
             mypy gpflow tests
+
+  format-check:
+    docker:
+      - image: cimg/python:3.6
+
+    steps:
+      - setup_venv
+      - run:
+          name: Install black and isort
+          command: |
+            source .venv/bin/activate
+            pip install --progress-bar=off black==20.8b1 isort
+      - run:
+          name: Run format check
+          command: |
+            source .venv/bin/activate
+            make format-check
 
   unit-test:
     docker:
@@ -93,23 +109,6 @@ jobs:
     steps:
       - run_tests:
           pytest_filter: notebooks
-
-  format-checker:
-    docker:
-      - image: cimg/python:3.6
-
-    steps:
-      - setup_venv
-      - run:
-          name: Install black and isort
-          command: |
-            source .venv/bin/activate
-            pip install --progress-bar=off black==20.8b1 isort
-      - run:
-          name: Run format check
-          command: |
-            source .venv/bin/activate
-            make format-check
 
   trigger-docs-generation:
     docker:
@@ -180,24 +179,31 @@ workflows:
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
-      - format-checker:
+      - format-check:
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
       - unit-test:
           requires:
-            - format-checker
+            - verify-install
+            - type-check
+            - format-check
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
       - notebook-test:
           requires:
-            - format-checker
+            - verify-install
+            - type-check
+            - format-check
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
       - trigger-docs-generation:
           requires:
+            - verify-install
+            - type-check
+            - format-check
             - unit-test
             - notebook-test
           filters:
@@ -207,6 +213,9 @@ workflows:
                 - develop
       - deploy:
           requires:
+            - verify-install
+            - type-check
+            - format-check
             - unit-test
             - notebook-test
           filters:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -57,6 +57,7 @@ This release contains contributions from:
 
 * Fixed broken CircleCi build.
 * Update CircleCi build to use next-gen Docker images.
+* Make all slow tests depend on fast tests.
 * Fixed broken link in `README.md`.
 * Make `make dev-install` also install the test requirements.
 


### PR DESCRIPTION
**PR type:** bugfix

**Related issue(s)/PRs:** N/A

## Summary

**Proposed changes**

1. Make the slow tests `unit-test` and `notebook-test` depend on all the fast tests `format-check`, `type-check`, and `verify-install`.
2. Rename `format-checker` to `format-check` for consistency with `type-check`.
3. Move the definition of `format-check` next to `type-check`, to emphasise their similarity.

**What alternatives have you considered?**

1. Maybe they shouldn't depend on `verify-install`? It's not quite as fast as the checks. ~1 minute.
2. Maybe `notebook-test` should depend on `unit-test` to avoid using CPU resource if we know the pipeline is broken? However that would add ~10 minutes to the build time.

### Minimal working example

N/A

### Release notes

**Fully backwards compatible:**` yes

**If not, why is it worth breaking backwards compatibility:**
N/A

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [x] Release management
  - [x] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

