### PR TITLE
Fix broken docs generation triggering.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,9 +125,10 @@ jobs:
           # Compiled documentation for readthedocs are built and stored in the https://github.com/GPflow/docs/ repository
           # For configuration of the doc build, see https://github.com/GPflow/docs/blob/develop/.circleci/config.yml
           command: |
-            BUILD_INFO=$(curl -X POST -H -d \
-                "{}" \
-                "https://circleci.com/api/v1/project/$ORGANIZATION/$PROJECT/tree/$BRANCH?circle-token=$DOCS_TOKEN")
+            curl \
+              -u ${DOCS_TOKEN}: \
+              -d 'build_parameters[CIRCLE_JOB]=build' \
+              https://circleci.com/api/v1.1/project/github/GPflow/docs/tree/develop
 
   deploy:
     docker:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -57,6 +57,7 @@ This release contains contributions from:
 
 * Fixed broken CircleCi build.
 * Update CircleCi build to use next-gen Docker images.
+* Fixed broken triggering of docs generation.
 * Fixed broken link in `README.md`.
 * Make `make dev-install` also install the test requirements.
 * Fix broken build of `cglb.ipynb`.


### PR DESCRIPTION
**PR type:** bugfix

**Related issue(s)/PRs:** #1728 

## Summary

**Proposed changes**

Update how documentation builds are triggered. The current command seems to have broken when I updated our Docker images.
This follows the instruction on https://circleci.com/docs/2.0/api-job-trigger/

**What alternatives have you considered?**

Using Pipelines, like the above document suggests. That seems like more work than it is worth.

### Minimal working example

```bash
curl -u ${CIRCLECI_USER_TOKEN}: \
     -d 'build_parameters[CIRCLE_JOB]=trigger-docs-generation' \
     `https://circleci.cm/api/v1.1/project/github/GPflow/GPflow/tree/jesper/1728/trigger`
```

### Release notes

**Fully backwards compatible:** yes

**If not, why is it worth breaking backwards compatibility:**

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [x] Release management
  - [x] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

