### PR TITLE
Handle unconnected gradients in gpflow.optimizers.Scipy.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,13 +55,18 @@ This release contains contributions from:
 
 ## Bug Fixes and Other Changes
 
+* Make `gpflow.optimizers.Scipy` able to handle unused / unconnected variables.
+
+* Make `make dev-install` also install the test requirements.
+
+* Fixed broken link in `README.md`.
+
 * Fixed broken CircleCi build.
+* Make all slow tests depend on fast tests.
 * Update CircleCi build to use next-gen Docker images.
 * Fixed broken triggering of docs generation.
-* Make all slow tests depend on fast tests.
-* Fixed broken link in `README.md`.
-* Make `make dev-install` also install the test requirements.
 * Fix broken build of `cglb.ipynb`.
+
 
 ## Thanks to our Contributors
 

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from typing import Callable, Iterable, List, Optional, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
@@ -36,6 +37,7 @@ class Scipy:
         method: Optional[str] = "L-BFGS-B",
         step_callback: Optional[StepCallback] = None,
         compile: bool = True,
+        allow_unused_variables: bool = False,
         **scipy_kwargs,
     ) -> OptimizeResult:
         """
@@ -59,7 +61,8 @@ class Scipy:
             compile: If True, wraps the evaluation function (the passed `closure`
                 as well as its gradient computation) inside a `tf.function()`,
                 which will improve optimization speed in most cases.
-
+            allow_unused_variables: Whether to allow variables that are not
+                actually used in the closure.
             scipy_kwargs: Arguments passed through to `scipy.optimize.minimize`
                 Note that Scipy's minimize() takes a `callback` argument, but
                 you probably want to use our wrapper and pass in `step_callback`.
@@ -79,7 +82,9 @@ class Scipy:
             )  # pragma: no cover
         initial_params = self.initial_parameters(variables)
 
-        func = self.eval_func(closure, variables, compile=compile)
+        func = self.eval_func(
+            closure, variables, compile=compile, allow_unused_variables=allow_unused_variables
+        )
         if step_callback is not None:
             if "callback" in scipy_kwargs:
                 raise ValueError("Callback passed both via `step_callback` and `callback`")
@@ -97,13 +102,17 @@ class Scipy:
 
     @classmethod
     def eval_func(
-        cls, closure: LossClosure, variables: Sequence[tf.Variable], compile: bool = True
+        cls,
+        closure: LossClosure,
+        variables: Sequence[tf.Variable],
+        compile: bool = True,
+        allow_unused_variables: bool = False,
     ) -> Callable[[np.ndarray], Tuple[np.ndarray, np.ndarray]]:
         def _tf_eval(x: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
             values = cls.unpack_tensors(variables, x)
             cls.assign_tensors(variables, values)
-
             loss, grads = _compute_loss_and_gradients(closure, variables)
+            grads = cls._filter_unused_variables(variables, grads, allow_unused_variables)
             return loss, cls.pack_tensors(grads)
 
         if compile:
@@ -114,6 +123,32 @@ class Scipy:
             return loss.numpy().astype(np.float64), grad.numpy().astype(np.float64)
 
         return _eval
+
+    @staticmethod
+    def _filter_unused_variables(
+        variables: Sequence[tf.Variable], grads: Sequence[tf.Tensor], allow_unused_variables: bool
+    ) -> Sequence[tf.Tensor]:
+        filtered_grads = []
+        unused_variables = []
+        for i, grad in enumerate(grads):
+            if grad is None:
+                variable = variables[i]
+                filtered_grads.append(tf.zeros_like(variable))
+                unused_variables.append(variable.name)
+            else:
+                filtered_grads.append(grad)
+
+        if unused_variables:
+            msg = (
+                "Some variables does not have a gradient, and appear unused in / not connected to"
+                f" the loss closure: {unused_variables}."
+            )
+            if allow_unused_variables:
+                warnings.warn(msg)
+            else:
+                raise ValueError(msg)
+
+        return filtered_grads
 
     @classmethod
     def callback_func(

--- a/tests/gpflow/optimizers/test_scipy.py
+++ b/tests/gpflow/optimizers/test_scipy.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 import numpy as np
 import pytest
 import tensorflow as tf
 from numpy.testing import assert_allclose
 
 import gpflow
-from gpflow.config import default_jitter
+from gpflow.config import default_float, default_jitter
 from gpflow.mean_functions import Constant
 
 rng = np.random.RandomState(0)
@@ -70,3 +72,75 @@ def test_scipy_jit():
     # due to the changes introduced by PR #1213, which removed some implicit casts
     # to float32. With TF 2.4 / TFP 0.12, we had to further increase atol from 1e-14.
     np.testing.assert_allclose(get_values(m1), get_values(m2), rtol=1e-14, atol=2e-14)
+
+
+def test_scipy__optimal() -> None:
+    target1 = [0.2, 0.8]
+    target2 = [0.6]
+    v1 = tf.Variable([0.5, 0.5], dtype=default_float())
+    v2 = tf.Variable([0.5], dtype=default_float())
+    compilation_count = 0
+
+    def f() -> tf.Tensor:
+        nonlocal compilation_count
+        compilation_count += 1
+        return tf.reduce_sum((target1 - v1) ** 2) + tf.reduce_sum((target2 - v2) ** 2)
+
+    opt = gpflow.optimizers.Scipy()
+    result = opt.minimize(f, [v1, v2])
+
+    assert 1 == compilation_count
+    assert result.success
+    np.testing.assert_allclose(target1 + target2, result.x)
+    np.testing.assert_allclose(target1, v1)
+    np.testing.assert_allclose(target2, v2)
+
+
+def test_scipy__partially_disconnected_variable() -> None:
+    target1 = 0.2
+    target2 = 0.6
+    v1 = tf.Variable([0.5, 0.5], dtype=default_float())
+    v2 = tf.Variable(0.5, dtype=default_float())
+
+    def f() -> tf.Tensor:
+        # v1[1] not used.
+        v10 = v1[0]
+        return (target1 - v10) ** 2 + (target2 - v2) ** 2
+
+    opt = gpflow.optimizers.Scipy()
+    result = opt.minimize(f, [v1, v2])
+
+    assert result.success
+    np.testing.assert_allclose([target1, 0.5, target2], result.x)
+    np.testing.assert_allclose([target1, 0.5], v1)
+    np.testing.assert_allclose(target2, v2)
+
+
+@pytest.mark.parametrize("allow_unused_variables", [True, False])
+def test_scipy__disconnected_variable(allow_unused_variables: bool) -> None:
+    target1 = [0.2, 0.8]
+    v1 = tf.Variable([0.5, 0.5], dtype=default_float(), name="v1")
+    v2 = tf.Variable([0.5], dtype=default_float(), name="v2")
+
+    def f() -> tf.Tensor:
+        # v2 not used.
+        return tf.reduce_sum((target1 - v1) ** 2)
+
+    opt = gpflow.optimizers.Scipy()
+
+    if allow_unused_variables:
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = opt.minimize(f, [v1, v2], allow_unused_variables=allow_unused_variables)
+
+        (warning,) = w
+        msg = warning.message.args[0]
+        assert v2.name in msg
+
+        assert result.success
+        np.testing.assert_allclose(target1 + [0.5], result.x)
+        np.testing.assert_allclose(target1, v1)
+        np.testing.assert_allclose([0.5], v2)
+    else:
+        with pytest.raises(ValueError, match=v2.name):
+            opt.minimize(f, [v1, v2], allow_unused_variables=allow_unused_variables)


### PR DESCRIPTION
**PR type:** bugfix / enhancement

**Related issue(s)/PRs:** Fixes #1600

## Summary

**Proposed changes**

* Update `gpflow.optimizers.Scipy.minimize` to take a new parameter `allow_unused_variables`.
* If a variable is unused/unconnected and `allow_unused_variables=True`, then a warning is printed, but optimization continues.
* If a variable is unused/unconnected and `allow_unused_variables=False`, then an exception with an appropriate message is raised.

**What alternatives have you considered?**
This PR competes with #1655 .
I think it's an open question whether `allow_unused_variables` should default to `True` or `False`. The current suggestion is to default to `True`.

### Minimal working example

```python
import tensorflow as tf
import gpflow
from gpflow.config import default_float

target1 = [0.2, 0.8]
v1 = tf.Variable([0.5, 0.5], dtype=default_float(), name="v1")
v2 = tf.Variable([0.5], dtype=default_float(), name="v2")

def f() -> tf.Tensor:
    # v2 not used.
    return tf.reduce_sum((target1 - v1) ** 2)

opt = gpflow.optimizers.Scipy()
print(opt.minimize(f, [v1, v2], allow_unused_variables=True))
```

### Release notes

**Fully` backwards compatible:** yes

**If not, why is it worth breaking backwards compatibility:**
N/A

## PR checklist
<!-- tick off [X] as applicable -->
- [x] New features: code is well-documented
  - [x] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [x] The bug case / new feature is covered by unit tests
- [x] Code has type annotations
- [x] Build checks
  - [x] I ran the black+isort formatter (`make format`)
  - [x] I locally tested that the tests pass (`make check-all`)
- [x] Release management
  - [x] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

