### PR TITLE
Andrewl/fix gpr posterior leading dim

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -170,14 +170,16 @@ stefanosele, johnamcleod, st--
 * Fixes a bug in the un-whitened code path for the fully correlated conditional function (#1662).
 * Fixes a bug in `independent_interdomain_conditional` (#1663).
 * Fixes an issue with the gpflow.config API documentation (#1664).
+* Fixes leading dimension issues with `GPRPosterior._conditional_with_precompute()`
 
 * Test suite
   * Fixes the test suite for TensorFlow 2.4 / TFP 0.12 (#1625).
   * Fixes mypy call (#1637).
   * Fixes a bug in test_method_equivalence.py (#1649).
+  * Amends `test_gpr_posterior.py` so it will cover leading dimension uses.
 
 ## Thanks to our Contributors
 
 This release contains contributions from:
 
-johnamcleod, st--, vatsalaggarwal, sam-willis, vdutor
+johnamcleod, st--, vatsalaggarwal, sam-willis, vdutor, Andrew878

--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -41,6 +41,7 @@ from .inducing_variables import (
 )
 from .types import MeanAndVariance
 from .utilities import Dispatcher, add_noise_cov
+from .utilities.ops import leading_transpose
 
 
 class _QDistribution(Module):
@@ -262,15 +263,7 @@ class GPRPosterior(AbstractPosterior):
         leading_dims = tf.shape(Kmn)[:-2]
 
         # get the leading dims in Knm to the front of the tensor Knm
-        perm_T = tf.concat(
-            [
-                tf.reshape(0, [1]),  # [M]
-                tf.reshape(K - 1, [1]),
-                tf.reshape(tf.range(1, K - 1), [K - 2]),  # leading dims (...)
-            ],
-            0,
-        )  # [N]
-        Knm = tf.transpose(Kmn, perm=perm_T)
+        Knm = leading_transpose(Kmn, [..., -1, -2])
 
         Knn = self.kernel(Xnew, full_cov=full_cov)
         err = self.Y_data - self.mean_function(self.X_data)  # type: ignore

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 
 import copy
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
-
-EllipsisType = type(...)
 
 
 def cast(
@@ -38,12 +36,11 @@ def eye(num: int, value: tf.Tensor, dtype: Optional[tf.DType] = None) -> tf.Tens
     return tf.linalg.diag(tf.fill([num], value))
 
 
-def leading_transpose(
-    tensor: tf.Tensor, perm: List[Union[int, EllipsisType]], leading_dim: int = 0
-) -> tf.Tensor:
+def leading_transpose(tensor: tf.Tensor, perm: List[Any], leading_dim: int = 0) -> tf.Tensor:
     """
     Transposes tensors with leading dimensions. Leading dimensions in
-    permutation list represented via ellipsis `...`.
+    permutation list represented via ellipsis `...` and is of type List[Union[int, type(...)]
+    (please note, due to mypy issues, List[Any] is used instead).
     When leading dimensions are found, `transpose` method
     considers them as a single grouped element indexed by 0 in `perm` list. So, passing
     `perm=[-2, ..., -1]`, you assume that your input tensor has [..., A, B] shape,

--- a/tests/gpflow/models/test_gpr_posterior.py
+++ b/tests/gpflow/models/test_gpr_posterior.py
@@ -22,7 +22,7 @@ def _get_data_for_tests():
     """Helper function to create testing data"""
     X = np.random.randn(5, 2)
     Y = np.random.randn(output_dim)
-    X_new = np.random.randn(10, 5, 2)
+    X_new = np.random.randn(3, 10, 5, 2)
     return X, X_new, Y
 
 

--- a/tests/gpflow/models/test_gpr_posterior.py
+++ b/tests/gpflow/models/test_gpr_posterior.py
@@ -5,8 +5,7 @@ import gpflow
 from gpflow.models.gpr import GPR_deprecated, GPR_with_posterior
 from gpflow.posteriors import PrecomputeCacheType
 
-input_dim = 7
-output_dim = 1
+output_dim = 2
 
 
 def make_models(regression_data):
@@ -21,9 +20,9 @@ def make_models(regression_data):
 
 def _get_data_for_tests():
     """Helper function to create testing data"""
-    X = np.random.randn(100, input_dim)
-    Y = np.random.randn(100, output_dim)
-    X_new = np.random.randn(100, input_dim)
+    X = np.random.randn(5, 2)
+    Y = np.random.randn(output_dim)
+    X_new = np.random.randn(10, 5, 2)
     return X, X_new, Y
 
 

--- a/tests/gpflow/models/test_gpr_posterior.py
+++ b/tests/gpflow/models/test_gpr_posterior.py
@@ -5,8 +5,6 @@ import gpflow
 from gpflow.models.gpr import GPR_deprecated, GPR_with_posterior
 from gpflow.posteriors import PrecomputeCacheType
 
-output_dim = 2
-
 
 def make_models(regression_data):
     """Helper function to create models"""
@@ -20,9 +18,9 @@ def make_models(regression_data):
 
 def _get_data_for_tests():
     """Helper function to create testing data"""
-    X = np.random.randn(5, 2)
-    Y = np.random.randn(output_dim)
-    X_new = np.random.randn(3, 10, 5, 2)
+    X = np.random.randn(5, 6)
+    Y = np.random.randn(5, 2)
+    X_new = np.random.randn(3, 10, 5, 6)
     return X, X_new, Y
 
 


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix 

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
* The GPR posterior implementation was not working for `predict_f` calls with inputs containing leading dimensions.
* This PR addresses the problem and also amends the test so that it is covered in the future
* ...

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->


### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: 
* Issue before 
--> 


This would work:
```python
# refer to test_gpr_posterior.py
m = GPR_with_posterior(data=some_regression_data, kernel=k)
X_new = np.random.randn(5, 2)
m.posterior(cache_type).predict_f(X_new, full_cov=full_cov, full_output_cov=full_output_cov)

```
But this wouldn't
```python
# refer to test_gpr_posterior.py
m = GPR_with_posterior(data=some_regression_data, kernel=k)
X_new = np.random.randn(10, 5, 2)
m.posterior(cache_type).predict_f(X_new, full_cov=full_cov, full_output_cov=full_output_cov)

```
and would result in `InvalidArgumentError`

The PR addresses this. 
### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** yes / no

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ X] The bug case / new feature is covered by unit tests
- [ X] Code has type annotations
- [ X] Build checks
  - [X ] I ran the black+isort formatter (`make format`)
  - [X ] I locally tested that the tests pass (`make check-all`)
- [ X] Release management
  - [X ] RELEASE.md updated with entry for this change
  - [ X] New contributors: I've added myself to CONTRIBUTORS.md

