### PR TITLE
Make dataclasses dependency conditional at install time

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -81,5 +81,6 @@ Because GitHub's [graph of contributors](http://github.com/GPflow/GPflow/graphs/
 [@Andrew878](https://github.com/Andrew878)
 [@avullo](https://github.com/avullo)
 [@jesnie](https://github.com/jesnie)
+[@tmct](https://github.com/tmct)
 
 Add yourself when you first contribute to GPflow's code, tests, or documentation!

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requirements.extend(
         "typing_extensions",
         "packaging",
         "deprecated",
-        "dataclasses; python_version < "3.7",
+        "dataclasses;python_version<'3.7'",
     ]
 )
 

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,9 @@ requirements.extend(
         "typing_extensions",
         "packaging",
         "deprecated",
+        "dataclasses; python_version < "3.7",
     ]
 )
-
-if sys.version_info < (3, 7):
-    requirements.append("dataclasses")  # became part of stdlib in python 3.7
 
 
 def read_file(filename):


### PR DESCRIPTION
Ensures dataclasses is not treated as a dependency of the "any" wheel on Python 3.7+

<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix

**Related issue(s)/PRs:** -

## Summary

**Proposed changes**
* Make dataclasses dependency conditional at install time rather than conditional at wheel build time

**What alternatives have you considered?**
* Asking you to deprecate Python 3.6
* Asking you to create separate wheels for py36, py38 etc.

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```bash
python --version  # 3.8
pip install gpflow
# dataclasses has been installed into site-packages! :(
```

### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** yes

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

