### PR TITLE
Add posterior object for VGP model.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -60,7 +60,10 @@ This release contains contributions from:
 
 ## Major Features and Improvements
 
-* Added `gpflow.experimental.check_shapes` for checking tensor shapes. (#1760)
+* Add new posterior class to enable faster predictions from the VGP model. (#1761)
+
+* Added `experimental` sub-package for features that are still under developmet.
+  * Added `gpflow.experimental.check_shapes` for checking tensor shapes. (#1760)
 
 ## Bug Fixes and Other Changes
 

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -154,14 +154,12 @@ class SVGP_deprecated(GPModel, ExternalDataTrainingLossMixin):
         return tf.reduce_sum(var_exp) * scale - kl
 
     def predict_f(self, Xnew: InputData, full_cov=False, full_output_cov=False) -> MeanAndVariance:
-        q_mu = self.q_mu
-        q_sqrt = self.q_sqrt
         mu, var = conditional(
             Xnew,
             self.inducing_variable,
             self.kernel,
-            q_mu,
-            q_sqrt=q_sqrt,
+            self.q_mu,
+            q_sqrt=self.q_sqrt,
             full_cov=full_cov,
             white=self.whiten,
             full_output_cov=full_output_cov,

--- a/tests/gpflow/models/test_vgp_posterior.py
+++ b/tests/gpflow/models/test_vgp_posterior.py
@@ -1,0 +1,74 @@
+import numpy as np
+import pytest
+
+import gpflow
+from gpflow.models.vgp import VGP_deprecated, VGP_with_posterior
+from gpflow.posteriors import PrecomputeCacheType
+
+
+def make_models(regression_data, likelihood: gpflow.likelihoods.Likelihood):
+    """Helper function to create models"""
+
+    k = gpflow.kernels.Matern52()
+    likelihood = gpflow.likelihoods.Gaussian()
+
+    mold = VGP_deprecated(data=regression_data, kernel=k, likelihood=likelihood)
+    mnew = VGP_with_posterior(data=regression_data, kernel=k, likelihood=likelihood)
+    return mold, mnew
+
+
+def _get_data_for_tests():
+    """Helper function to create testing data"""
+    X = np.random.randn(5, 6)
+    Y = np.random.randn(5, 2)
+    X_new = np.random.randn(3, 10, 5, 6)
+    return X, X_new, Y
+
+
+@pytest.mark.parametrize("cache_type", [PrecomputeCacheType.TENSOR, PrecomputeCacheType.VARIABLE])
+@pytest.mark.parametrize(
+    "likelihood", [gpflow.likelihoods.Gaussian(), gpflow.likelihoods.Exponential()]
+)
+@pytest.mark.parametrize("full_cov", [True, False])
+@pytest.mark.parametrize("full_output_cov", [True, False])
+def test_old_vs_new_gp_fused(
+    cache_type: PrecomputeCacheType,
+    likelihood: gpflow.likelihoods.Likelihood,
+    full_cov: bool,
+    full_output_cov: bool,
+):
+    X, X_new, Y = _get_data_for_tests()
+    mold, mnew = make_models((X, Y), likelihood)
+
+    mu_old, var2_old = mold.predict_f(X_new, full_cov=full_cov, full_output_cov=full_output_cov)
+    mu_new_fuse, var2_new_fuse = mnew.predict_f(
+        X_new, full_cov=full_cov, full_output_cov=full_output_cov
+    )
+    # check new fuse is same as old version
+    np.testing.assert_allclose(mu_new_fuse, mu_old)
+    np.testing.assert_allclose(var2_new_fuse, var2_old)
+
+
+@pytest.mark.parametrize("cache_type", [PrecomputeCacheType.TENSOR, PrecomputeCacheType.VARIABLE])
+@pytest.mark.parametrize(
+    "likelihood", [gpflow.likelihoods.Gaussian(), gpflow.likelihoods.Exponential()]
+)
+@pytest.mark.parametrize("full_cov", [True, False])
+@pytest.mark.parametrize("full_output_cov", [True, False])
+def test_old_vs_new_with_posterior(
+    cache_type: PrecomputeCacheType,
+    likelihood: gpflow.likelihoods.Likelihood,
+    full_cov: bool,
+    full_output_cov: bool,
+):
+    X, X_new, Y = _get_data_for_tests()
+    mold, mnew = make_models((X, Y), likelihood)
+
+    mu_old, var2_old = mold.predict_f(X_new, full_cov=full_cov, full_output_cov=full_output_cov)
+    mu_new_cache, var2_new_cache = mnew.posterior(cache_type).predict_f(
+        X_new, full_cov=full_cov, full_output_cov=full_output_cov
+    )
+
+    # check new cache is same as old version
+    np.testing.assert_allclose(mu_old, mu_new_cache)
+    np.testing.assert_allclose(var2_old, var2_new_cache)


### PR DESCRIPTION
**PR type:** new feature

**Related issue(s)/PRs:** fixes #1748 

## Summary

**Proposed changes**

Add a `VGPPosterior` class, and a `posterior` method to the VGP model.

I have no idea what I'm doing - I've just shuffled around existing code. Please review carefully.

### Minimal working example

```python
model.posterior(PrecomputeCacheType.VARIABLE).predict_f(X_new)
```

### Release notes

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

