### PR TITLE
Clean up posterior caching code.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,8 +39,12 @@ This release contains contributions from:
 
 ## Breaking Changes
 
-* <DOCUMENT BREAKING CHANGES HERE>
-* <THIS SECTION SHOULD CONTAIN API AND BEHAVIORAL BREAKING CHANGES>
+* Slight change to the API of custom posterior objects.
+  `gpflow.posteriors.AbstractPosterior._precompute` no longer must return an `alpha` and an `Qinv`
+  - instead it returns any arbitrary tuple of tensors.
+  Correspondingly `gpflow.posteriors.AbstractPosterior._conditional_with_precompute` should no
+  longer try to access `self.alpha` and `self.Qinv`, but instead is passed the tuple of tensors
+  returned by `_precompute`, as a parameter. (#1763)
 
 ## Known Caveats
 

--- a/doc/source/notebooks/advanced/variational_fourier_features.pct.py
+++ b/doc/source/notebooks/advanced/variational_fourier_features.pct.py
@@ -332,17 +332,19 @@ class VFFPosterior(gpflow.posteriors.BasePosterior):
 
         return alpha, Qinv
 
-    def _conditional_with_precompute(self, Xnew, full_cov, full_output_cov):
+    def _conditional_with_precompute(self, cache, Xnew, full_cov, full_output_cov):
+        alpha, Qinv = cache
+
         if full_output_cov:
             raise NotImplementedError
 
         Kuf = cov.Kuf(self.X_data, self.kernel, Xnew)  # still a Tensor
 
         # construct the conditional mean
-        fmean = tf.matmul(Kuf, self.alpha, transpose_a=True)
+        fmean = tf.matmul(Kuf, alpha, transpose_a=True)
 
-        num_func = tf.shape(self.alpha)[1]  # K
-        Qinv_Kuf = tf.matmul(self.Qinv, Kuf)
+        num_func = tf.shape(alpha)[1]  # K
+        Qinv_Kuf = tf.matmul(Qinv, Kuf)
 
         # compute the covariance due to the conditioning
         if full_cov:


### PR DESCRIPTION
Clean up posterior caching code:

1. Instead of requiring an `alpha` and a `Qinv`, cache an arbitrary tuple of tensors.
2. Instead of letting `_conditional_with_precompute` access the cache directly, pass it to the method.
3. Declare `_precompute` as an abstract method.
4. Initialise `self._precompute_cache`, instead of dynamically creating it.