### PR TITLE
Add mypy annotations to some of the tests.

### DIFF
--- a/gpflow/conditionals/conditionals.py
+++ b/gpflow/conditionals/conditionals.py
@@ -14,13 +14,10 @@
 
 import tensorflow as tf
 
-from ..config import default_jitter
 from ..inducing_variables import InducingVariables
 from ..kernels import Kernel
 from ..posteriors import VGPPosterior, get_posterior_class
-from ..utilities.ops import eye
 from .dispatch import conditional
-from .util import base_conditional
 
 
 @conditional._gpflow_internal_register(object, InducingVariables, Kernel, object)

--- a/gpflow/expectations/products.py
+++ b/gpflow/expectations/products.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from functools import reduce
-from typing import Type, Union
+from typing import Type
 
 import tensorflow as tf
 

--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -20,7 +20,6 @@ import tensorflow as tf
 
 from . import covariances, kernels, mean_functions
 from .base import MeanAndVariance, Module, Parameter, RegressionData, TensorType
-from .conditionals.dispatch import conditional
 from .conditionals.util import (
     base_conditional,
     base_conditional_with_lm,

--- a/gpflow/utilities/traversal.py
+++ b/gpflow/utilities/traversal.py
@@ -15,7 +15,7 @@
 import copy
 import re
 from functools import lru_cache
-from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, Mapping, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 import tensorflow as tf
@@ -46,7 +46,7 @@ Accumulator = Tuple[Path, State]
 TraverseUpdateCallable = Callable[[TraverseInput, Path, State], State]
 
 
-def multiple_assign(module: tf.Module, parameters: Dict[str, tf.Tensor]):
+def multiple_assign(module: tf.Module, parameters: Mapping[str, tf.Tensor]):
     """
     Multiple assign takes a dictionary with new values. Dictionary keys are paths to the
     `tf.Variable`s or `gpflow.Parameter` of the input module.

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,7 @@ strict = True
 ignore_missing_imports = True
 disallow_subclassing_any = False
 disallow_untyped_calls = False
+disallow_untyped_decorators = False
 ; It would actually be good to disallow implicit reexport, but that will take some effort to be
 ; strict about our use of __all__.
 implicit_reexport = True
@@ -18,11 +19,59 @@ warn_return_any = False
 [mypy-gpflow.conditionals.*]
 ignore_errors = True
 
-[mypy-gpflow.kernels.*,gpflow.models.*,gpflow.monitor.*,gpflow.optimizers.natgrad,gpflow.optimizers.mcmc,gpflow.utilities.*]
+[mypy-gpflow.kernels.*]
 ignore_errors = True
 
 [mypy-gpflow.mean_functions]
 ignore_errors = True
 
-[mypy-tests.*]
+[mypy-gpflow.models.*]
+ignore_errors = True
+
+[mypy-gpflow.monitor.*]
+ignore_errors = True
+
+[mypy-gpflow.optimizers.mcmc]
+ignore_errors = True
+
+[mypy-gpflow.optimizers.natgrad]
+ignore_errors = True
+
+[mypy-gpflow.utilities.*]
+ignore_errors = True
+
+[mypy-tests.gpflow.conditionals.*]
+ignore_errors = True
+
+[mypy-tests.gpflow.config.*]
+ignore_errors = True
+
+[mypy-tests.gpflow.covariances.*]
+ignore_errors = True
+
+[mypy-tests.gpflow.expectations.*]
+ignore_errors = True
+
+[mypy-tests.gpflow.experimental.*]
+ignore_errors = True
+
+[mypy-tests.gpflow.kernels.*]
+ignore_errors = True
+
+[mypy-tests.gpflow.likelihoods.*]
+ignore_errors = True
+
+[mypy-tests.gpflow.models.*]
+ignore_errors = True
+
+[mypy-tests.gpflow.optimizers.*]
+ignore_errors = True
+
+[mypy-tests.gpflow.posteriors.*]
+ignore_errors = True
+
+[mypy-tests.gpflow.utilities.*]
+ignore_errors = True
+
+[mypy-tests.integration.*]
 ignore_errors = True

--- a/tests/gpflow/conftest.py
+++ b/tests/gpflow/conftest.py
@@ -13,18 +13,19 @@
 #  limitations under the License.
 
 import pytest
+from _pytest.fixtures import SubRequest
 
 
 @pytest.fixture(name="full_cov", params=[True, False])
-def _full_cov_fixture(request):
+def _full_cov_fixture(request: SubRequest) -> bool:
     return request.param
 
 
 @pytest.fixture(name="full_output_cov", params=[True, False])
-def _full_output_cov_fixture(request):
+def _full_output_cov_fixture(request: SubRequest) -> bool:
     return request.param
 
 
 @pytest.fixture(name="whiten", params=[True, False])
-def _whiten_fixture(request):
+def _whiten_fixture(request: SubRequest) -> bool:
     return request.param

--- a/tests/gpflow/quadrature/test_quadrature.py
+++ b/tests/gpflow/quadrature/test_quadrature.py
@@ -86,7 +86,7 @@ def test_ndiagquad_does_not_throw_error() -> None:
     Regression test for https://github.com/GPflow/GPflow/issues/1547.
     """
 
-    @tf.function(autograph=False)  # type: ignore
+    @tf.function(autograph=False)
     def func_ndiagquad_autograph_false() -> tf.Tensor:
         mu = np.array([1.0, 1.3])
         var = np.array([3.0, 3.5])
@@ -105,7 +105,7 @@ def test_quadrature_autograph() -> None:
     """
 
     def compute(autograph: bool) -> np.ndarray:
-        @tf.function(autograph=autograph)  # type: ignore
+        @tf.function(autograph=autograph)
         def func() -> tf.Tensor:
             mu = np.array([1.0, 1.3])
             var = np.array([3.0, 3.5])

--- a/tests/gpflow/test_base.py
+++ b/tests/gpflow/test_base.py
@@ -21,11 +21,11 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 
 import gpflow
-from gpflow.base import PriorOn
+from gpflow.base import PriorOn, TensorData
 from gpflow.utilities import positive
 
 
-def test_parameter_assign_validation():
+def test_parameter_assign_validation() -> None:
     with pytest.raises(tf.errors.InvalidArgumentError):
         param = gpflow.Parameter(0.0, transform=positive())
 
@@ -35,7 +35,7 @@ def test_parameter_assign_validation():
         param.assign(0.0)
 
 
-def test_cast_to_dtype_precision_issue():
+def test_cast_to_dtype_precision_issue() -> None:
     """
     TensorFlow's tf.cast(value, dtype) implicitly does a tf.convert_to_tensor(value)
     *before* the cast when the value is not a tensor already. When value is a python float,
@@ -62,11 +62,11 @@ def test_cast_to_dtype_precision_issue():
     assert actual_value == expected_value
 
 
-def test_parameter_saved():
+def test_parameter_saved() -> None:
     dtype = tf.float64
 
     class Model(tf.Module):
-        def __init__(self):
+        def __init__(self) -> None:
             self.p = gpflow.Parameter(0.1, dtype=dtype, transform=gpflow.utilities.positive())
 
         @tf.function(input_signature=[tf.TensorSpec([], dtype=dtype)])
@@ -84,7 +84,7 @@ def test_parameter_saved():
 
 
 @pytest.mark.parametrize("value", [0.0, [1.2, 1.1]])
-def test_construct_parameter_from_existing_parameter_check_value(value):
+def test_construct_parameter_from_existing_parameter_check_value(value: TensorData) -> None:
     initial_parameter = gpflow.Parameter(value)
     new_parameter = gpflow.Parameter(initial_parameter)
 
@@ -92,14 +92,14 @@ def test_construct_parameter_from_existing_parameter_check_value(value):
 
 
 @pytest.mark.parametrize("value", [0.0, [1.2, 1.1]])
-def test_construct_parameter_from_existing_parameter_override_value(value):
+def test_construct_parameter_from_existing_parameter_override_value(value: TensorData) -> None:
     initial_parameter = gpflow.Parameter(value)
     new_parameter = gpflow.Parameter(initial_parameter + 1.0)
 
     np.testing.assert_equal(new_parameter.numpy(), np.array(value) + 1.0)
 
 
-def test_construct_parameter_from_existing_parameter_check_transform():
+def test_construct_parameter_from_existing_parameter_check_transform() -> None:
     transform = tfp.bijectors.Sigmoid(
         tf.constant(0.0, dtype=tf.float64), tf.constant(2.0, dtype=tf.float64)
     )
@@ -109,7 +109,7 @@ def test_construct_parameter_from_existing_parameter_check_transform():
     assert new_parameter.transform == transform
 
 
-def test_construct_parameter_from_existing_parameter_override_transform():
+def test_construct_parameter_from_existing_parameter_override_transform() -> None:
     initial_parameter = gpflow.Parameter([1.2, 1.1])
 
     transform = tfp.bijectors.Sigmoid(
@@ -120,7 +120,7 @@ def test_construct_parameter_from_existing_parameter_override_transform():
     assert new_parameter.transform == transform
 
 
-def test_construct_parameter_from_existing_parameter_check_prior():
+def test_construct_parameter_from_existing_parameter_check_prior() -> None:
     prior = tfp.distributions.Normal(0.0, 1.0)
     initial_parameter = gpflow.Parameter([1.2, 1.1], prior=prior)
     new_parameter = gpflow.Parameter(initial_parameter)
@@ -128,7 +128,7 @@ def test_construct_parameter_from_existing_parameter_check_prior():
     assert new_parameter.prior == prior
 
 
-def test_construct_parameter_from_existing_parameter_override_prior():
+def test_construct_parameter_from_existing_parameter_override_prior() -> None:
     initial_parameter = gpflow.Parameter([1.2, 1.1])
 
     prior = tfp.distributions.Normal(0.0, 1.0)
@@ -138,7 +138,7 @@ def test_construct_parameter_from_existing_parameter_override_prior():
 
 
 @pytest.mark.parametrize("prior_on", [PriorOn.CONSTRAINED, PriorOn.UNCONSTRAINED])
-def test_construct_parameter_from_existing_parameter_check_prior_on(prior_on):
+def test_construct_parameter_from_existing_parameter_check_prior_on(prior_on: PriorOn) -> None:
     initial_parameter = gpflow.Parameter([1.2, 1.1], prior_on=prior_on)
     new_parameter = gpflow.Parameter(initial_parameter)
 
@@ -146,7 +146,7 @@ def test_construct_parameter_from_existing_parameter_check_prior_on(prior_on):
 
 
 @pytest.mark.parametrize("prior_on", [PriorOn.CONSTRAINED, PriorOn.UNCONSTRAINED])
-def test_construct_parameter_from_existing_parameter_override_prior_on(prior_on):
+def test_construct_parameter_from_existing_parameter_override_prior_on(prior_on: PriorOn) -> None:
     initial_parameter = gpflow.Parameter([1.2, 1.1])
     new_parameter = gpflow.Parameter(initial_parameter, prior_on=prior_on)
 
@@ -154,7 +154,7 @@ def test_construct_parameter_from_existing_parameter_override_prior_on(prior_on)
 
 
 @pytest.mark.parametrize("trainable", [True, False])
-def test_construct_parameter_from_existing_parameter_check_trainable(trainable):
+def test_construct_parameter_from_existing_parameter_check_trainable(trainable: bool) -> None:
     initial_parameter = gpflow.Parameter([1.2, 1.1], trainable=trainable)
     new_parameter = gpflow.Parameter(initial_parameter)
 
@@ -162,7 +162,7 @@ def test_construct_parameter_from_existing_parameter_check_trainable(trainable):
 
 
 @pytest.mark.parametrize("trainable", [True, False])
-def test_construct_parameter_from_existing_parameter_override_trainable(trainable):
+def test_construct_parameter_from_existing_parameter_override_trainable(trainable: bool) -> None:
     initial_parameter = gpflow.Parameter([1.2, 1.1], trainable=trainable)
     new_parameter = gpflow.Parameter(initial_parameter, trainable=not trainable)
 
@@ -170,7 +170,7 @@ def test_construct_parameter_from_existing_parameter_override_trainable(trainabl
 
 
 @pytest.mark.parametrize("dtype", [tf.float32, tf.float64])
-def test_construct_parameter_from_existing_parameter_check_dtype(dtype):
+def test_construct_parameter_from_existing_parameter_check_dtype(dtype: tf.DType) -> None:
     initial_parameter = gpflow.Parameter([1.1, 2.1], dtype=dtype)
     new_parameter = gpflow.Parameter(initial_parameter)
 
@@ -178,14 +178,14 @@ def test_construct_parameter_from_existing_parameter_check_dtype(dtype):
 
 
 @pytest.mark.parametrize("dtype", [tf.float32, tf.float64])
-def test_construct_parameter_from_existing_parameter_override_dtype(dtype):
+def test_construct_parameter_from_existing_parameter_override_dtype(dtype: tf.DType) -> None:
     initial_parameter = gpflow.Parameter([1.1, 2.1])
     new_parameter = gpflow.Parameter(initial_parameter, dtype=dtype)
 
     assert new_parameter.dtype == dtype
 
 
-def test_construct_parameter_from_existing_parameter_check_name():
+def test_construct_parameter_from_existing_parameter_check_name() -> None:
     transform = tfp.bijectors.Sigmoid(
         tf.constant(0.0, dtype=tf.float64), tf.constant(2.0, dtype=tf.float64)
     )
@@ -195,7 +195,7 @@ def test_construct_parameter_from_existing_parameter_check_name():
     assert new_parameter.name == transform.name
 
 
-def test_construct_parameter_from_existing_parameter_override_name():
+def test_construct_parameter_from_existing_parameter_override_name() -> None:
     initial_parameter = gpflow.Parameter([1.2, 1.1])
     transform = tfp.bijectors.Sigmoid(
         tf.constant(0.0, dtype=tf.float64), tf.constant(2.0, dtype=tf.float64)
@@ -205,7 +205,7 @@ def test_construct_parameter_from_existing_parameter_override_name():
     assert new_parameter.name == transform.name
 
 
-def test_construct_parameter_from_existing_parameter_value_becomes_invalid():
+def test_construct_parameter_from_existing_parameter_value_becomes_invalid() -> None:
     initial_parameter = gpflow.Parameter(0.0)
     transform = tfp.bijectors.Reciprocal()
 

--- a/tests/gpflow/test_base_prior.py
+++ b/tests/gpflow/test_base_prior.py
@@ -1,3 +1,5 @@
+from typing import Any, Tuple, Type
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -19,7 +21,7 @@ class Datum:
     lengthscale = 3.3
 
 
-def test_gpr_objective_equivalence():
+def test_gpr_objective_equivalence() -> None:
     """
     In Maximum Likelihood Estimation (MLE), i.e. when there are no priors on
     the parameters, the objective should not depend on any transforms on the
@@ -42,7 +44,7 @@ def test_gpr_objective_equivalence():
     ), "MLE objective should not depend on Parameter transform"
 
 
-def test_log_prior_with_no_prior():
+def test_log_prior_with_no_prior() -> None:
     """
     A parameter without any prior should have zero log-prior,
     even if it has a transform to constrain it.
@@ -51,7 +53,7 @@ def test_log_prior_with_no_prior():
     assert param.log_prior_density().numpy() == 0.0
 
 
-def test_log_prior_for_uniform_prior():
+def test_log_prior_for_uniform_prior() -> None:
     """
     If we assign a Uniform prior to a parameter, we should not expect the value of the prior density
     to change with the parameter value, even if it has a transform associated with it.
@@ -66,7 +68,7 @@ def test_log_prior_for_uniform_prior():
     assert np.isclose(low_value, high_value)
 
 
-def test_log_prior_on_unconstrained():
+def test_log_prior_on_unconstrained() -> None:
     """
     A parameter with an Exp transform, and a uniform prior on its unconstrained, should have a
     prior in the constrained space that scales as 1/value.
@@ -92,7 +94,7 @@ class DummyModel(gpflow.models.BayesianModel):
     value = 3.3
     log_scale = 0.4
 
-    def __init__(self, with_transform):
+    def __init__(self, with_transform: bool) -> None:
         super().__init__()
 
         prior = tfp.distributions.Normal(to_default_float(1.0), to_default_float(1.0))
@@ -107,11 +109,13 @@ class DummyModel(gpflow.models.BayesianModel):
 
         self.theta = gpflow.Parameter(self.value, prior=prior, transform=transform)
 
-    def maximum_log_likelihood_objective(self):
+    def maximum_log_likelihood_objective(self, *args: Any, **kwargs: Any) -> tf.Tensor:
+        assert not args
+        assert not kwargs
         return (self.theta + 5) ** 2
 
 
-def test_map_invariance_to_transform():
+def test_map_invariance_to_transform() -> None:
     m1 = DummyModel(with_transform=True)
     m2 = DummyModel(with_transform=False)
     assert np.allclose(
@@ -119,7 +123,7 @@ def test_map_invariance_to_transform():
     ), "log posterior density should not be affected by a transform"
 
 
-def get_gpmc_model_params():
+def get_gpmc_model_params() -> Tuple[Any, ...]:
     kernel = gpflow.kernels.Matern32()
     likelihood = gpflow.likelihoods.Gaussian()
     data = [np.random.randn(5, 1), np.random.randn(5, 1)]
@@ -133,7 +137,7 @@ def get_gpmc_model_params():
         # (gpflow.models.SGPMC, get_SGPMC_model_params()) # Fails due to inducing_variable=None bug
     ],
 )
-def test_v_prior_dtypes(model_class, args):
+def test_v_prior_dtypes(model_class: Type[Any], args: Tuple[Any, ...]) -> None:
     with gpflow.config.as_context():
         set_default_float(np.float32)
         m = model_class(*args)

--- a/tests/gpflow/test_base_training.py
+++ b/tests/gpflow/test_base_training.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 
+from typing import Any, Mapping
+
 import numpy as np
 import pytest
 import tensorflow as tf
 
 import gpflow
+from gpflow.models import SVGP
 from gpflow.utilities import leaf_components, multiple_assign, read_values
 
 rng = np.random.RandomState(0)
@@ -41,8 +44,8 @@ class Data:
 
 
 @pytest.fixture
-def model():
-    return gpflow.models.SVGP(
+def model() -> SVGP:
+    return SVGP(
         kernel=gpflow.kernels.SquaredExponential(lengthscales=Data.ls, variance=Data.var),
         likelihood=gpflow.likelihoods.Gaussian(),
         inducing_variable=Data.Z,
@@ -74,7 +77,9 @@ model_wrong_value = [
 
 
 @pytest.mark.parametrize("var_update_dict", [model_param_updates])
-def test_multiple_assign_updates_correct_values(model, var_update_dict):
+def test_multiple_assign_updates_correct_values(
+    model: SVGP, var_update_dict: Mapping[str, Any]
+) -> None:
     old_value_dict = leaf_components(model).copy()
     multiple_assign(model, var_update_dict)
     for path, variable in leaf_components(model).items():
@@ -85,29 +90,33 @@ def test_multiple_assign_updates_correct_values(model, var_update_dict):
 
 
 @pytest.mark.parametrize("wrong_var_update_dict", model_wrong_path)
-def test_multiple_assign_fails_with_invalid_path(model, wrong_var_update_dict):
+def test_multiple_assign_fails_with_invalid_path(
+    model: SVGP, wrong_var_update_dict: Mapping[str, Any]
+) -> None:
     with pytest.raises(KeyError):
         multiple_assign(model, wrong_var_update_dict)
 
 
 @pytest.mark.parametrize("wrong_var_update_dict", model_wrong_value)
-def test_multiple_assign_fails_with_invalid_values(model, wrong_var_update_dict):
+def test_multiple_assign_fails_with_invalid_values(
+    model: SVGP, wrong_var_update_dict: Mapping[str, Any]
+) -> None:
     with pytest.raises(ValueError):
         multiple_assign(model, wrong_var_update_dict)
 
 
-def test_dict_utilities(model):
+def test_dict_utilities(model: SVGP) -> None:
     """
     Test both `parameter_dict()` and `read_values()`
     """
 
     class SubModule(tf.Module):
-        def __init__(self):
+        def __init__(self) -> None:
             self.parameter = gpflow.Parameter(1.0)
             self.variable = tf.Variable(1.0)
 
     class Module(tf.Module):
-        def __init__(self):
+        def __init__(self) -> None:
             self.submodule = SubModule()
             self.top_parameter = gpflow.Parameter(3.0)
 

--- a/tests/gpflow/test_inducing_variables.py
+++ b/tests/gpflow/test_inducing_variables.py
@@ -18,7 +18,7 @@ import tensorflow as tf
 import gpflow
 
 
-def test_inducing_points_with_variable_shape():
+def test_inducing_points_with_variable_shape() -> None:
     N, M1, D, P = 50, 13, 3, 1
     X, Y = np.random.randn(N, D), np.random.randn(N, P)
 
@@ -37,7 +37,7 @@ def test_inducing_points_with_variable_shape():
     opt = tf.optimizers.Adam()
 
     @tf.function
-    def optimization_step():
+    def optimization_step() -> None:
         opt.minimize(m.training_loss, m.trainable_variables)
 
     optimization_step()

--- a/tests/gpflow/test_kullback_leiblers.py
+++ b/tests/gpflow/test_kullback_leiblers.py
@@ -23,7 +23,9 @@ from numpy.testing import assert_allclose, assert_almost_equal
 
 import gpflow
 from gpflow import Parameter, default_float, default_jitter
+from gpflow.base import TensorType
 from gpflow.inducing_variables import InducingPoints
+from gpflow.kernels import Kernel
 from gpflow.kullback_leiblers import gauss_kl, prior_kl
 from gpflow.utilities.bijectors import triangular
 
@@ -39,19 +41,19 @@ Mn = 50
 
 
 @pytest.fixture(scope="module")
-def kernel():
+def kernel() -> Kernel:
     k = gpflow.kernels.Matern32() + gpflow.kernels.White()
     k.kernels[1].variance.assign(0.01)
     return k
 
 
 @pytest.fixture(scope="module")
-def inducing_points():
+def inducing_points() -> InducingPoints:
     return InducingPoints(rng.randn(Nn, 1))
 
 
 @pytest.fixture(scope="module")
-def mu():
+def mu() -> Parameter:
     return Parameter(rng.randn(Nn, Ln))
 
 
@@ -60,17 +62,17 @@ def mu():
 # ------------------------------------------
 
 
-def make_sqrt(N, M):
+def make_sqrt(N: int, M: int) -> TensorType:
     return np.array([np.tril(rng.randn(M, M)) for _ in range(N)])  # [N, M, M]
 
 
-def make_K_batch(N, M):
+def make_K_batch(N: int, M: int) -> TensorType:
     K_np = rng.randn(N, M, M)
     beye = np.array([np.eye(M) for _ in range(N)])
     return 0.1 * (K_np + np.transpose(K_np, (0, 2, 1))) + beye
 
 
-def compute_kl_1d(q_mu, q_sigma, p_var=1.0):
+def compute_kl_1d(q_mu: TensorType, q_sigma: TensorType, p_var: TensorType = 1.0) -> TensorType:
     p_var = tf.ones_like(q_sigma) if p_var is None else p_var
     q_var = tf.square(q_sigma)
     kl = 0.5 * (q_var / p_var + tf.square(q_mu) / p_var - 1 + tf.math.log(p_var / q_var))
@@ -96,7 +98,7 @@ class Datum:
 
 
 @pytest.mark.parametrize("diag", [True, False])
-def test_kl_k_cholesky(diag):
+def test_kl_k_cholesky(diag: bool) -> None:
     """
     Test that passing K or K_cholesky yield the same answer
     """
@@ -109,7 +111,7 @@ def test_kl_k_cholesky(diag):
 
 
 @pytest.mark.parametrize("white", [True, False])
-def test_diags(white):
+def test_diags(white: bool) -> None:
     """
     The covariance of q(x) can be Cholesky matrices or diagonal matrices.
     Here we make sure the behaviours overlap.
@@ -125,7 +127,7 @@ def test_diags(white):
 
 
 @pytest.mark.parametrize("diag", [True, False])
-def test_whitened(diag):
+def test_whitened(diag: bool) -> None:
     """
     Check that K=Identity and K=None give same answer
     """
@@ -142,7 +144,7 @@ def test_whitened(diag):
 
 @pytest.mark.parametrize("shared_k", [True, False])
 @pytest.mark.parametrize("diag", [True, False])
-def test_sumkl_equals_batchkl(shared_k, diag):
+def test_sumkl_equals_batchkl(shared_k: bool, diag: bool) -> None:
     """
     gauss_kl implicitely performs a sum of KL divergences
     This test checks that doing the sum outside of the function is equivalent
@@ -169,7 +171,7 @@ def test_sumkl_equals_batchkl(shared_k, diag):
 
 
 @patch("tensorflow.__version__", "2.1.0")
-def test_sumkl_equals_batchkl_shared_k_not_diag_mocked_tf21():
+def test_sumkl_equals_batchkl_shared_k_not_diag_mocked_tf21() -> None:
     """
     Version of test_sumkl_equals_batchkl with shared_k=True and diag=False
     that tests the TensorFlow < 2.2 workaround with tiling still works.
@@ -189,7 +191,7 @@ def test_sumkl_equals_batchkl_shared_k_not_diag_mocked_tf21():
 
 @pytest.mark.parametrize("dim", [0, 1])
 @pytest.mark.parametrize("white", [True, False])
-def test_oned(white, dim):
+def test_oned(white: bool, dim: bool) -> None:
     """
     Check that the KL divergence matches a 1D by-hand calculation.
     """
@@ -206,7 +208,7 @@ def test_oned(white, dim):
     np.testing.assert_allclose(kl, kl_1d)
 
 
-def test_unknown_size_inputs():
+def test_unknown_size_inputs() -> None:
     """
     Test for #725 and #734. When the shape of the Gaussian's mean had at least
     one unknown parameter, `gauss_kl` would blow up. This happened because
@@ -222,7 +224,9 @@ def test_unknown_size_inputs():
 
 
 @pytest.mark.parametrize("white", [True, False])
-def test_q_sqrt_constraints(inducing_points, kernel, mu, white):
+def test_q_sqrt_constraints(
+    inducing_points: bool, kernel: Kernel, mu: np.ndarray, white: bool
+) -> None:
     """Test that sending in an unconstrained q_sqrt returns the same conditional
     evaluation and gradients. This is important to match the behaviour of the KL, which
     enforces q_sqrt is triangular.

--- a/tests/gpflow/test_logdensities.py
+++ b/tests/gpflow/test_logdensities.py
@@ -26,14 +26,14 @@ rng = np.random.RandomState(1)
 
 
 @pytest.mark.parametrize("x, mu, var", [(0.9, 0.5, 1.3)])
-def test_gaussian(x, mu, var):
+def test_gaussian(x: float, mu: float, var: float) -> None:
     gpf = logdensities.gaussian(x, mu, var).numpy()
     sps = scipy.stats.norm(loc=mu, scale=np.sqrt(var)).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
 
 
 @pytest.mark.parametrize("x, mu, var", [(0.9, 0.5, 1.3)])
-def test_lognormal(x, mu, var):
+def test_lognormal(x: float, mu: float, var: float) -> None:
     gpf = logdensities.lognormal(x, mu, var).numpy()
     sps = scipy.stats.lognorm(s=np.sqrt(var), scale=np.exp(mu)).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
@@ -46,7 +46,7 @@ def test_lognormal(x, mu, var):
         [0, 0.6],
     ],
 )
-def test_bernoulli(x, p):
+def test_bernoulli(x: float, p: float) -> None:
     gpf = logdensities.bernoulli(x, p).numpy()
     sps = scipy.stats.bernoulli.logpmf(k=x, p=p)
     np.testing.assert_allclose(gpf, sps)
@@ -60,21 +60,21 @@ def test_bernoulli(x, p):
         [2, 1.3],
     ],
 )
-def test_poisson(x, lam):
+def test_poisson(x: float, lam: float) -> None:
     gpf = logdensities.poisson(x, lam).numpy()
     sps = scipy.stats.poisson.logpmf(k=x, mu=lam)
     np.testing.assert_allclose(gpf, sps)
 
 
 @pytest.mark.parametrize("x, scale", [(0.9, 1.3)])
-def test_exponential(x, scale):
+def test_exponential(x: float, scale: float) -> None:
     gpf = logdensities.exponential(x, scale).numpy()
     sps = scipy.stats.expon(loc=0.0, scale=scale).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
 
 
 @pytest.mark.parametrize("x, shape, scale", [(0.9, 0.5, 1.3)])
-def test_gamma(x, shape, scale):
+def test_gamma(x: float, shape: float, scale: float) -> None:
     gpf = logdensities.gamma(x, shape, scale).numpy()
     sps = scipy.stats.gamma(a=shape, loc=0.0, scale=scale).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
@@ -88,7 +88,7 @@ def test_gamma(x, shape, scale):
         (0.9, 0.5, 1.3, 3),
     ],
 )
-def test_student_t(x, mean, scale, df):
+def test_student_t(x: float, mean: float, scale: float, df: int) -> None:
     cast = to_default_float
     gpf = logdensities.student_t(cast(x), cast(mean), cast(scale), df).numpy()
     sps = scipy.stats.t(df=df, loc=mean, scale=scale).logpdf(x)
@@ -96,14 +96,14 @@ def test_student_t(x, mean, scale, df):
 
 
 @pytest.mark.parametrize("x, alpha, beta", [(0.9, 0.5, 1.3)])
-def test_beta(x, alpha, beta):
+def test_beta(x: float, alpha: float, beta: float) -> None:
     gpf = logdensities.beta(x, alpha, beta).numpy()
     sps = scipy.stats.beta(a=alpha, b=beta).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
 
 
 @pytest.mark.parametrize("x, mu, sigma", [(0.9, 0.5, 1.3)])
-def test_laplace(x, mu, sigma):
+def test_laplace(x: float, mu: float, sigma: float) -> None:
     gpf = logdensities.laplace(x, mu, sigma).numpy()
     sps = scipy.stats.laplace(loc=mu, scale=sigma).logpdf(x)
     np.testing.assert_allclose(gpf, sps)
@@ -112,7 +112,7 @@ def test_laplace(x, mu, sigma):
 @pytest.mark.parametrize("x", [randn(4, 10), randn(4, 1)])
 @pytest.mark.parametrize("mu", [randn(4, 10), randn(4, 1)])
 @pytest.mark.parametrize("cov_sqrt", [randn(4, 4), np.eye(4)])
-def test_multivariate_normal(x, mu, cov_sqrt):
+def test_multivariate_normal(x: np.ndarray, mu: np.ndarray, cov_sqrt: np.ndarray) -> None:
     cov = np.dot(cov_sqrt, cov_sqrt.T)
     L = np.linalg.cholesky(cov)
 

--- a/tests/gpflow/test_mean_functions.py
+++ b/tests/gpflow/test_mean_functions.py
@@ -12,14 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Sequence, Type
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
 import gpflow
+from gpflow.base import TensorType
 from gpflow.config import default_int
 from gpflow.inducing_variables import InducingPoints
-from gpflow.mean_functions import Additive, Constant, Linear, Product, SwitchedMeanFunction, Zero
+from gpflow.mean_functions import (
+    Additive,
+    Constant,
+    Linear,
+    MeanFunction,
+    Product,
+    SwitchedMeanFunction,
+    Zero,
+)
 
 rng = np.random.RandomState(99021)
 
@@ -42,7 +53,9 @@ _mean_functions = [
 @pytest.mark.parametrize("mean_function_1", _mean_functions)
 @pytest.mark.parametrize("mean_function_2", _mean_functions)
 @pytest.mark.parametrize("operation", ["+", "*"])
-def test_mean_functions_output_shape(mean_function_1, mean_function_2, operation):
+def test_mean_functions_output_shape(
+    mean_function_1: MeanFunction, mean_function_2: MeanFunction, operation: str
+) -> None:
     """
     Test the output shape for basic and compositional mean functions, also
     check that the combination of mean functions returns the correct class
@@ -67,7 +80,9 @@ def test_mean_functions_output_shape(mean_function_1, mean_function_2, operation
 @pytest.mark.parametrize("mean_function_1", _mean_functions)
 @pytest.mark.parametrize("mean_function_2", _mean_functions)
 @pytest.mark.parametrize("operation", ["+", "*"])
-def test_mean_functions_composite_type(mean_function_1, mean_function_2, operation):
+def test_mean_functions_composite_type(
+    mean_function_1: MeanFunction, mean_function_2: MeanFunction, operation: str
+) -> None:
     if operation == "+":
         mean_composed = mean_function_1 + mean_function_2
         assert isinstance(mean_composed, Additive)
@@ -94,14 +109,16 @@ _constant_functions = [Constant(c=rng.randn(Datum.output_dim, 1).reshape(-1)) fo
 _constant_functions.append(Constant(c=-1.0 * _constant_functions[0].c))
 
 
-def _create_GPR_model_with_bias(X, Y, mean_function):
+def _create_GPR_model_with_bias(
+    X: TensorType, Y: TensorType, mean_function: MeanFunction
+) -> gpflow.models.GPR:
     return gpflow.models.GPR(
         (X, Y), mean_function=mean_function, kernel=gpflow.kernels.Bias(Datum.input_dim)
     )
 
 
 @pytest.mark.parametrize("mean_functions", [_linear_functions, _constant_functions])
-def test_mean_functions_distributive_property(mean_functions):
+def test_mean_functions_distributive_property(mean_functions: Sequence[MeanFunction]) -> None:
     """
     Tests that distributive property of addition and multiplication holds for mean functions
     (both Constant and Linear): A * (B + C) = A * B + A * C
@@ -123,7 +140,7 @@ def test_mean_functions_distributive_property(mean_functions):
 
 
 @pytest.mark.parametrize("mean_functions", [_linear_functions, _constant_functions])
-def test_mean_functions_A_minus_A_equals_zero(mean_functions):
+def test_mean_functions_A_minus_A_equals_zero(mean_functions: Sequence[MeanFunction]) -> None:
     """
     Tests that the addition the inverse of a mean function to itself is equivalent to having a
     Zero mean function: A + (-A) = 0
@@ -145,7 +162,7 @@ def test_mean_functions_A_minus_A_equals_zero(mean_functions):
 
 
 @pytest.mark.parametrize("mean_functions", [_linear_functions])
-def test_linear_mean_functions_associative_property(mean_functions):
+def test_linear_mean_functions_associative_property(mean_functions: Sequence[MeanFunction]) -> None:
     """
     Tests that associative property of addition holds for linear mean functions:
     A + (B + (-A)) = B = (A + B) + (-A)
@@ -172,7 +189,7 @@ def test_linear_mean_functions_associative_property(mean_functions):
 
 
 @pytest.mark.parametrize("N, D", [[10, 3]])
-def test_switched_mean_function(N, D):
+def test_switched_mean_function(N: int, D: int) -> None:
     """
     Test for the SwitchedMeanFunction.
     """
@@ -187,7 +204,7 @@ def test_switched_mean_function(N, D):
     assert_allclose(result, result_ref)
 
 
-def test_bug_277_regression():
+def test_bug_277_regression() -> None:
     """
     See github issue #277. This is a regression test.
     """
@@ -209,7 +226,7 @@ _model_classes = [
 
 
 @pytest.mark.parametrize("model_class", _model_classes)
-def test_models_with_mean_functions_changes(model_class):
+def test_models_with_mean_functions_changes(model_class: Type[Any]) -> None:
     """
     Simply check that all models have a higher prediction with a constant mean
     function than with a zero mean function.

--- a/tests/gpflow/test_monitor.py
+++ b/tests/gpflow/test_monitor.py
@@ -1,10 +1,15 @@
-import os
+from pathlib import Path
+from typing import Any, List, Optional, Sequence, Union
 
 import numpy as np
 import pytest
 import tensorflow as tf
+from _pytest.capture import CaptureFixture
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 import gpflow
+from gpflow.models import GPR, GPModel
 from gpflow.monitor import (
     ExecuteCallback,
     ImageToTensorBoard,
@@ -22,42 +27,44 @@ class Data:
 
 
 class DummyTask(MonitorTask):
-    def run(self, **kwargs):
+    def run(self, **kwargs: Any) -> None:
         pass
 
 
 class DummyStepCallback:
     current_step = 0
 
-    def callback(self, step, variables, values):
+    def callback(
+        self, step: int, variables: Sequence[tf.Variable], values: Sequence[tf.Tensor]
+    ) -> None:
         self.current_step = step
 
 
 @pytest.fixture
-def model():
+def model() -> GPModel:
     data = (
         np.random.randn(Data.num_data, 2),  # [N, 2]
         np.random.randn(Data.num_data, 2),  # [N, 1]
     )
     kernel = gpflow.kernels.SquaredExponential(lengthscales=[1.0, 2.0])
-    return gpflow.models.GPR(data, kernel, noise_variance=0.01)
+    return GPR(data, kernel, noise_variance=0.01)
 
 
 @pytest.fixture
-def monitor(model, tmp_path):
-    tmp_path = str(tmp_path)
+def monitor(model: GPModel, tmp_path: Path) -> Monitor:
+    tmp_path_str = str(tmp_path)
 
-    def lml_callback():
+    def lml_callback() -> float:
         return model.log_marginal_likelihood()
 
-    def print_callback():
+    def print_callback() -> None:
         print("foo")
 
     return Monitor(
         MonitorTaskGroup(
             [
-                ModelToTensorBoard(tmp_path, model),
-                ScalarToTensorBoard(tmp_path, lml_callback, "lml"),
+                ModelToTensorBoard(tmp_path_str, model),
+                ScalarToTensorBoard(tmp_path_str, lml_callback, "lml"),
             ],
             period=2,
         ),
@@ -65,17 +72,17 @@ def monitor(model, tmp_path):
     )
 
 
-def _get_size_directory(dir):
+def _get_size_directory(d: Path) -> int:
     """Calculating the size of a directory (in Bytes)."""
-    return sum(d.stat().st_size for d in os.scandir(dir) if d.is_file())
+    return sum(f.stat().st_size for f in d.glob("**/*"))
 
 
 # Smoke tests for the individual tasks
 # #####################################
 
 
-def test_ExecuteCallback():
-    def callback():
+def test_ExecuteCallback() -> None:
+    def callback() -> None:
         print("ExecuteCallback test")
 
     task = ExecuteCallback(callback)
@@ -84,11 +91,11 @@ def test_ExecuteCallback():
     compiled_task(0)
 
 
-def test_ImageToTensorBoard(tmp_path):
+def test_ImageToTensorBoard(tmp_path: Path) -> None:
     """Smoke test `ImageToTensorBoard` in Eager and Compiled mode."""
-    tmp_path = str(tmp_path)
+    tmp_path_str = str(tmp_path)
 
-    def plotting_cb(fig, axes):
+    def plotting_cb(fig: Figure, axes: Axes) -> None:
         axes[0, 0].plot(np.random.randn(2), np.random.randn(2))
         axes[1, 0].plot(np.random.randn(2), np.random.randn(2))
         axes[0, 1].plot(np.random.randn(2), np.random.randn(2))
@@ -97,7 +104,7 @@ def test_ImageToTensorBoard(tmp_path):
     fig_kwargs = dict(figsize=(10, 10))
     subplots_kwargs = dict(sharex=True, nrows=2, ncols=2)
     task = ImageToTensorBoard(
-        tmp_path, plotting_cb, "image", fig_kw=fig_kwargs, subplots_kw=subplots_kwargs
+        tmp_path_str, plotting_cb, "image", fig_kw=fig_kwargs, subplots_kw=subplots_kwargs
     )
 
     task(0)
@@ -105,39 +112,41 @@ def test_ImageToTensorBoard(tmp_path):
     compiled_task(0)
 
 
-def test_ScalarToTensorBoard(tmp_path):
+def test_ScalarToTensorBoard(tmp_path: Path) -> None:
     """Smoke test `ScalarToTensorBoard` in Eager and Compiled mode."""
-    tmp_path = str(tmp_path)
+    tmp_path_str = str(tmp_path)
 
-    def scalar_cb():
+    def scalar_cb() -> float:
         return 0.0
 
-    task = ScalarToTensorBoard(tmp_path, scalar_cb, "scalar")
+    task = ScalarToTensorBoard(tmp_path_str, scalar_cb, "scalar")
     task(0)
     compiled_task = tf.function(task)
     compiled_task(0)
 
 
-def test_ScalarToTensorBoard_with_argument(tmp_path):
+def test_ScalarToTensorBoard_with_argument(tmp_path: Path) -> None:
     """Smoke test `ScalarToTensorBoard` in Eager and Compiled mode."""
-    tmp_path = str(tmp_path)
+    tmp_path_str = str(tmp_path)
 
-    def scalar_cb(x=None):
+    def scalar_cb(x: Optional[float] = None) -> float:
+        assert x is not None
         return 2 * x
 
-    task = ScalarToTensorBoard(tmp_path, scalar_cb, "scalar")
+    task = ScalarToTensorBoard(tmp_path_str, scalar_cb, "scalar")
     compiled_task = tf.function(task)
     task(0, x=1.0)
     compiled_task(0, x=1.0)
 
 
-def test_ScalarToTensorBoard_with_wrong_keyword_argument(tmp_path):
-    tmp_path = str(tmp_path)
+def test_ScalarToTensorBoard_with_wrong_keyword_argument(tmp_path: Path) -> None:
+    tmp_path_str = str(tmp_path)
 
-    def scalar_cb(x=None):
+    def scalar_cb(x: Optional[float] = None) -> float:
+        assert x is not None
         return 2 * x
 
-    task = ScalarToTensorBoard(tmp_path, scalar_cb, "scalar")
+    task = ScalarToTensorBoard(tmp_path_str, scalar_cb, "scalar")
     compiled_task = tf.function(task)
 
     with pytest.raises(TypeError, match=r"got an unexpected keyword argument 'y'"):
@@ -147,24 +156,24 @@ def test_ScalarToTensorBoard_with_wrong_keyword_argument(tmp_path):
         compiled_task(0, y=1.0)
 
 
-def test_ModelToTensorboard(model, tmp_path):
+def test_ModelToTensorboard(model: GPModel, tmp_path: Path) -> None:
     """Smoke test `ModelToTensorBoard` in Eager and Compiled mode."""
-    tmp_path = str(tmp_path)
-    task = ModelToTensorBoard(tmp_path, model)
+    tmp_path_str = str(tmp_path)
+    task = ModelToTensorBoard(tmp_path_str, model)
     task(0)
     compiled_task = tf.function(task)
     compiled_task(0)
 
 
-def test_ExecuteCallback_arguments(capsys):
-    def cb1(x=None, **_):
+def test_ExecuteCallback_arguments(capsys: CaptureFixture[str]) -> None:
+    def cb1(x: Optional[int] = None, **_: Any) -> None:
         assert x is not None
         print(x)
 
-    def cb2(**_):
+    def cb2(**_: Any) -> None:
         print(2)
 
-    def cb3(y=None, **_):
+    def cb3(y: Optional[int] = None, **_: Any) -> None:
         assert y is not None
         print(y)
 
@@ -183,12 +192,12 @@ def test_ExecuteCallback_arguments(capsys):
 @pytest.mark.parametrize(
     "task_or_tasks",
     [
-        ExecuteCallback(lambda: 0.0),
-        [ExecuteCallback(lambda: 0.0)],
-        [ExecuteCallback(lambda: 0.0), ExecuteCallback(lambda: 0.0)],
+        ExecuteCallback(lambda: None),
+        [ExecuteCallback(lambda: None)],
+        [ExecuteCallback(lambda: None), ExecuteCallback(lambda: None)],
     ],
 )
-def test_MonitorTaskGroup_and_Monitor(task_or_tasks):
+def test_MonitorTaskGroup_and_Monitor(task_or_tasks: Union[MonitorTask, List[MonitorTask]]) -> None:
     group = MonitorTaskGroup(task_or_tasks, period=2)
 
     # check that the tasks is actually a list (custom setter)
@@ -206,7 +215,7 @@ def test_MonitorTaskGroup_and_Monitor(task_or_tasks):
     compiled_monitor(0)
 
 
-def test_Monitor(monitor):
+def test_Monitor(monitor: Monitor) -> None:
     monitor(0)
     compiled_monitor = tf.function(monitor)
     compiled_monitor(0)
@@ -216,14 +225,14 @@ def test_Monitor(monitor):
 # ###################
 
 
-def test_compiled_execute_callable(capsys):
+def test_compiled_execute_callable(capsys: CaptureFixture[str]) -> None:
     """
     Test that the `ExecuteCallback` when compiled behaves as expected.
     We test that python prints are not executed anymore.
     """
     string_to_print = "Eager mode"
 
-    def callback():
+    def callback() -> None:
         print(string_to_print)
 
     task = ExecuteCallback(callback)
@@ -244,7 +253,7 @@ def test_compiled_execute_callable(capsys):
     assert out == f"{string_to_print}\n"
 
 
-def test_periodicity_group(capsys):
+def test_periodicity_group(capsys: CaptureFixture[str]) -> None:
     """Test that groups are called at different periods."""
 
     task_a = ExecuteCallback(lambda: print("a", end=" "))
@@ -271,14 +280,12 @@ def test_periodicity_group(capsys):
     assert "a b X"
 
 
-def test_logdir_created(monitor, model, tmp_path):
+def test_logdir_created(monitor: Monitor, model: GPModel, tmp_path: Path) -> None:
     """
     Check that TensorFlow summaries are written.
     """
-    tmp_path = str(tmp_path)
-
     # check existence
-    assert os.path.exists(tmp_path) and os.path.isdir(tmp_path)
+    assert tmp_path.is_dir()
     size_before = _get_size_directory(tmp_path)
     assert size_before > 0
 
@@ -291,11 +298,11 @@ def test_logdir_created(monitor, model, tmp_path):
     assert size_after > size_before
 
 
-def test_compile_monitor(monitor, model):
+def test_compile_monitor(monitor: Monitor, model: GPModel) -> None:
     opt = tf.optimizers.Adam()
 
     @tf.function
-    def tf_func(step):
+    def tf_func(step: tf.Tensor) -> None:
         opt.minimize(model.training_loss, model.trainable_variables)
         monitor(step)
 
@@ -303,13 +310,13 @@ def test_compile_monitor(monitor, model):
         tf_func(step)
 
 
-def test_scipy_monitor(monitor, model):
+def test_scipy_monitor(monitor: Monitor, model: GPModel) -> None:
     opt = gpflow.optimizers.Scipy()
 
     opt.minimize(model.training_loss, model.trainable_variables, step_callback=monitor)
 
 
-def test_scipy_monitor_called(model):
+def test_scipy_monitor_called(model: GPModel) -> None:
     task = DummyTask()
     monitor = Monitor(MonitorTaskGroup(task, period=1))
     opt = gpflow.optimizers.Scipy()
@@ -317,7 +324,7 @@ def test_scipy_monitor_called(model):
     assert task.current_step > 1
 
 
-def test_scipy_step_callback_called(model):
+def test_scipy_step_callback_called(model: GPModel) -> None:
     dsc = DummyStepCallback()
     opt = gpflow.optimizers.Scipy()
     opt.minimize(model.training_loss, model.trainable_variables, step_callback=dsc.callback)


### PR DESCRIPTION
Mostly adding type hints to some tests.
More completely:

1. Add type hints to some tests.
2. Replace some use of `os.` with `pathlib.Path.`, where we were already using `pathlib`.
3. Removed some unused imports.
4. Reformatted `mypy.ini`.