### PR TITLE
Make the VGP support variable-shaped data.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -61,6 +61,8 @@ This release contains contributions from:
 ## Major Features and Improvements
 
 * Add new posterior class to enable faster predictions from the VGP model. (#1761)
+* VGP class bug-fixed to work with variable-sized data. Note you can use
+  `gpflow.models.vgp.update_vgp_data` to ensure variational parameters are updated sanely. (#1774).
 
 * Added `experimental` sub-package for features that are still under developmet.
   * Added `gpflow.experimental.check_shapes` for checking tensor shapes. (#1760)

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -114,20 +114,23 @@ class Parameter(tfp.util.TransformedVariable):
         trainable: Optional[bool] = None,
         dtype: Optional[DType] = None,
         name: Optional[str] = None,
-        pretransformed_shape: Optional[Sequence[Optional[int]]] = None,
-        transformed_shape: Optional[Sequence[Optional[int]]] = None,
+        unconstrained_shape: Optional[Sequence[Optional[int]]] = None,
+        constrained_shape: Optional[Sequence[Optional[int]]] = None,
         shape: Optional[Sequence[Optional[int]]] = None,
     ):
-        """
-        A parameter retains both constrained and unconstrained
-        representations. If no transform is provided, these two values will be the same.
-        It is often challenging to operate with unconstrained parameters. For example, a variance cannot be negative,
-        therefore we need a positive constraint and it is natural to use constrained values.
-        A prior can be imposed either on the constrained version (default) or on the unconstrained version of the parameter.
+        """A parameter retains both constrained and unconstrained representations. If no transform
+        is provided, these two values will be the same.  It is often challenging to operate with
+        unconstrained parameters. For example, a variance cannot be negative, therefore we need a
+        positive constraint and it is natural to use constrained values.  A prior can be imposed
+        either on the constrained version (default) or on the unconstrained version of the
+        parameter.
 
-        :param pretransformed_shape: Declare the shape of the pretransformed values. Useful for setting dynamic shapes.
-        :param transformed_shape: Declare the shape of the transformed values. Useful for setting dynamic shapes.
-        :param shape: Convenience shortcut for setting both `pretransformed_shape` and `transformed_shape`.
+        :param unconstrained_shape: Declare the shape of the unconstrained / pre-transformed values.
+            Useful for setting dynamic shapes.
+        :param constrained_shape: Declare the shape of the constrained / transformed values. Useful
+            for setting dynamic shapes.
+        :param shape: Convenience shortcut for setting both `unconstrained_shape` and
+            `constrained_shape` to the same value.
         """
         if isinstance(value, Parameter):
             transform = transform or value.transform
@@ -150,12 +153,10 @@ class Parameter(tfp.util.TransformedVariable):
         _validate_unconstrained_value(value, transform, dtype)
 
         if shape is not None:
-            assert (
-                pretransformed_shape is None
-            ), "Cannot set both `shape` and `pretransformed_shape`."
-            assert transformed_shape is None, "Cannot set both `shape` and `transformed_shape`."
-            pretransformed_shape = shape
-            transformed_shape = shape
+            assert unconstrained_shape is None, "Cannot set both `shape` and `unconstrained_shape`."
+            assert constrained_shape is None, "Cannot set both `shape` and `constrained_shape`."
+            unconstrained_shape = shape
+            constrained_shape = shape
 
         super().__init__(
             value,
@@ -163,13 +164,13 @@ class Parameter(tfp.util.TransformedVariable):
             dtype=value.dtype,
             trainable=trainable,
             name=name,
-            shape=pretransformed_shape,
+            shape=unconstrained_shape,
         )
 
-        # TransformedVariable.__init__ doesn't allow us to pass a pre-transformed shape, so we
-        # manually override it.
-        if transformed_shape is not None:
-            self._shape = tf.TensorShape(transformed_shape)
+        # TransformedVariable.__init__ doesn't allow us to pass an unconstrained / pre-transformed
+        # shape, so we manually override it.
+        if constrained_shape is not None:
+            self._shape = tf.TensorShape(constrained_shape)
 
         self.prior: Optional[Prior] = prior
         self.prior_on = prior_on  # type: ignore  # see https://github.com/python/mypy/issues/3004

--- a/gpflow/models/vgp.py
+++ b/gpflow/models/vgp.py
@@ -73,9 +73,9 @@ class VGP_deprecated(GPModel, InternalDataTrainingLossMixin):
 
         static_num_data = X_data.shape[0]
         if static_num_data is None:
-            q_sqrt_pretransformed_shape = (self.num_latent_gps, None)
+            q_sqrt_unconstrained_shape = (self.num_latent_gps, None)
         else:
-            q_sqrt_pretransformed_shape = (self.num_latent_gps, triangular_size(static_num_data))
+            q_sqrt_unconstrained_shape = (self.num_latent_gps, triangular_size(static_num_data))
         self.num_data = Parameter(tf.shape(X_data)[0], shape=[], dtype=tf.int32, trainable=False)
 
         # Many functions below don't like `Parameter`s:
@@ -89,8 +89,8 @@ class VGP_deprecated(GPModel, InternalDataTrainingLossMixin):
         self.q_sqrt = Parameter(
             q_sqrt,
             transform=triangular(),
-            pretransformed_shape=q_sqrt_pretransformed_shape,
-            transformed_shape=(num_latent_gps, static_num_data, static_num_data),
+            unconstrained_shape=q_sqrt_unconstrained_shape,
+            constrained_shape=(num_latent_gps, static_num_data, static_num_data),
         )
 
     def maximum_log_likelihood_objective(self) -> tf.Tensor:

--- a/gpflow/models/vgp.py
+++ b/gpflow/models/vgp.py
@@ -27,7 +27,7 @@ from ..kernels import Kernel
 from ..kullback_leiblers import gauss_kl
 from ..likelihoods import Likelihood
 from ..mean_functions import MeanFunction
-from ..utilities import triangular
+from ..utilities import is_variable, triangular, triangular_size
 from .model import GPModel
 from .training_mixins import InternalDataTrainingLossMixin
 from .util import data_input_to_tensor
@@ -69,13 +69,29 @@ class VGP_deprecated(GPModel, InternalDataTrainingLossMixin):
         super().__init__(kernel, likelihood, mean_function, num_latent_gps)
 
         self.data = data_input_to_tensor(data)
-        X_data, Y_data = self.data
-        num_data = X_data.shape[0]
-        self.num_data = num_data
+        X_data, _Y_data = self.data
 
-        self.q_mu = Parameter(np.zeros((num_data, self.num_latent_gps)))
-        q_sqrt = np.array([np.eye(num_data) for _ in range(self.num_latent_gps)])
-        self.q_sqrt = Parameter(q_sqrt, transform=triangular())
+        static_num_data = X_data.shape[0]
+        if static_num_data is None:
+            q_sqrt_pretransformed_shape = (self.num_latent_gps, None)
+        else:
+            q_sqrt_pretransformed_shape = (self.num_latent_gps, triangular_size(static_num_data))
+        self.num_data = Parameter(tf.shape(X_data)[0], shape=[], dtype=tf.int32, trainable=False)
+
+        # Many functions below don't like `Parameter`s:
+        dynamic_num_data = tf.convert_to_tensor(self.num_data)
+
+        self.q_mu = Parameter(
+            tf.zeros((dynamic_num_data, self.num_latent_gps)),
+            shape=(static_num_data, num_latent_gps),
+        )
+        q_sqrt = tf.eye(dynamic_num_data, batch_shape=[self.num_latent_gps])
+        self.q_sqrt = Parameter(
+            q_sqrt,
+            transform=triangular(),
+            pretransformed_shape=q_sqrt_pretransformed_shape,
+            transformed_shape=(num_latent_gps, static_num_data, static_num_data),
+        )
 
     def maximum_log_likelihood_objective(self) -> tf.Tensor:
         return self.elbo()
@@ -93,11 +109,13 @@ class VGP_deprecated(GPModel, InternalDataTrainingLossMixin):
 
         """
         X_data, Y_data = self.data
+        num_data = tf.convert_to_tensor(self.num_data)
+
         # Get prior KL.
         KL = gauss_kl(self.q_mu, self.q_sqrt)
 
         # Get conditionals
-        K = self.kernel(X_data) + tf.eye(self.num_data, dtype=default_float()) * default_jitter()
+        K = self.kernel(X_data) + tf.eye(num_data, dtype=default_float()) * default_jitter()
         L = tf.linalg.cholesky(K)
         fmean = tf.linalg.matmul(L, self.q_mu) + self.mean_function(X_data)  # [NN, ND] -> ND
         q_sqrt_dnn = tf.linalg.band_part(self.q_sqrt, -1, 0)  # [D, N, N]
@@ -115,7 +133,7 @@ class VGP_deprecated(GPModel, InternalDataTrainingLossMixin):
     def predict_f(
         self, Xnew: InputData, full_cov: bool = False, full_output_cov: bool = False
     ) -> MeanAndVariance:
-        X_data, _ = self.data
+        X_data, _Y_data = self.data
         mu, var = conditional(
             Xnew,
             X_data,
@@ -153,10 +171,10 @@ class VGP_with_posterior(VGP_deprecated):
           computations when you only want to call the posterior's
           `fused_predict_f` method.
         """
-        X, _ = self.data
+        X_data, _Y_data = self.data
         return posteriors.VGPPosterior(
             self.kernel,
-            X,
+            X_data,
             self.q_mu,
             self.q_sqrt,
             mean_function=self.mean_function,
@@ -179,6 +197,44 @@ class VGP_with_posterior(VGP_deprecated):
 class VGP(VGP_with_posterior):
     # subclassed to ensure __class__ == "VGP"
     pass
+
+
+def update_vgp_data(vgp: VGP_deprecated, new_data: RegressionData) -> None:
+    """
+    Set the data on the given VGP model, and update its variational parameters.
+
+    As opposed to many of the other models the VGP has internal parameters whose shape depends on
+    the shape of the data. This functions updates the internal data of the given vgp, and updates
+    the variational parameters to fit.
+
+    This function requires that the input :param:`vgp` were create with :class:`tf.Variable`s for
+    :param:`data`.
+    """
+    old_X_data, old_Y_data = vgp.data
+    assert is_variable(old_X_data) and is_variable(
+        old_Y_data
+    ), "update_vgp_data requires the model to have been created with variable data."
+
+    new_X_data, new_Y_data = new_data
+    new_num_data = tf.shape(new_X_data)[0]
+    f_mu, f_cov = vgp.predict_f(new_X_data, full_cov=True)  # [N, L], [L, N, N]
+
+    # This model is hard-coded to use the whitened representation, i.e.  q_mu and q_sqrt
+    # parametrize q(v), and u = f(X) = L v, where L = cholesky(K(X, X)) Hence we need to
+    # back-transform from f_mu and f_cov to obtain the updated new_q_mu and new_q_sqrt:
+    Knn = vgp.kernel(new_X_data, full_cov=True)  # [N, N]
+    jitter_mat = default_jitter() * tf.eye(new_num_data, dtype=Knn.dtype)
+    Lnn = tf.linalg.cholesky(Knn + jitter_mat)  # [N, N]
+    new_q_mu = tf.linalg.triangular_solve(Lnn, f_mu)  # [N, L]
+    tmp = tf.linalg.triangular_solve(Lnn[None], f_cov)  # [L, N, N], L⁻¹ f_cov
+    S_v = tf.linalg.triangular_solve(Lnn[None], tf.linalg.matrix_transpose(tmp))  # [L, N, N]
+    new_q_sqrt = tf.linalg.cholesky(S_v + jitter_mat)  # [L, N, N]
+
+    old_X_data.assign(new_X_data)
+    old_Y_data.assign(new_Y_data)
+    vgp.num_data.assign(new_num_data)
+    vgp.q_mu.assign(new_q_mu)
+    vgp.q_sqrt.assign(new_q_sqrt)
 
 
 class VGPOpperArchambeau(GPModel, InternalDataTrainingLossMixin):

--- a/gpflow/utilities/bijectors.py
+++ b/gpflow/utilities/bijectors.py
@@ -14,12 +14,13 @@
 
 from typing import Optional
 
+import tensorflow as tf
 import tensorflow_probability as tfp
 
 from .. import config
 from .misc import to_default_float
 
-__all__ = ["positive", "triangular"]
+__all__ = ["positive", "triangular", "triangular_size"]
 
 
 def positive(lower: Optional[float] = None, base: Optional[str] = None) -> tfp.bijectors.Bijector:
@@ -48,3 +49,10 @@ def triangular() -> tfp.bijectors.Bijector:
     Returns instance of a triangular bijector.
     """
     return tfp.bijectors.FillTriangular()
+
+
+def triangular_size(n: tf.Tensor) -> tf.Tensor:
+    """
+    Returns the number of non-zero elements in an `n` by `n` triangular matrix.
+    """
+    return n * (n + 1) // 2

--- a/gpflow/utilities/misc.py
+++ b/gpflow/utilities/misc.py
@@ -15,7 +15,9 @@
 from typing import Callable, Iterable, List, Optional, Union
 
 import tensorflow as tf
+import tensorflow_probability as tfp
 
+from ..base import TensorData
 from ..config import default_float, default_int
 from .ops import cast
 
@@ -23,6 +25,7 @@ __all__ = [
     "to_default_float",
     "to_default_int",
     "set_trainable",
+    "is_variable",
     "training_loop",
 ]
 
@@ -45,6 +48,13 @@ def set_trainable(model: Union[tf.Module, Iterable[tf.Module]], flag: bool) -> N
     for mod in modules:
         for variable in mod.variables:
             variable._trainable = flag
+
+
+def is_variable(t: TensorData) -> bool:
+    """
+    Returns whether the `t` is a TensorFlow variable.
+    """
+    return isinstance(t, (tf.Variable, tfp.util.TransformedVariable))
 
 
 def training_loop(

--- a/tests/gpflow/models/test_vgp.py
+++ b/tests/gpflow/models/test_vgp.py
@@ -1,0 +1,61 @@
+# Copyright 2022 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+import tensorflow as tf
+
+import gpflow
+from gpflow.config import default_float
+
+
+def test_update_vgp_data():
+    rng = np.random.default_rng(20220223)
+    sample = lambda *shape: tf.convert_to_tensor(rng.standard_normal(shape), dtype=default_float())
+
+    n_inputs = 2
+    n_outputs = 1
+    n_data_1 = 3
+    n_data_2 = 2
+
+    X_1 = tf.Variable(sample(n_data_1, n_inputs), shape=(None, n_inputs), trainable=False)
+    Y_1 = tf.Variable(sample(n_data_1, n_outputs), shape=(None, n_outputs), trainable=False)
+
+    model = gpflow.models.VGP(
+        (X_1, Y_1),
+        gpflow.kernels.SquaredExponential(),
+        gpflow.likelihoods.Gaussian(),
+        num_latent_gps=n_outputs,
+    )
+    gpflow.optimizers.Scipy().minimize(
+        model.training_loss_closure(),
+        variables=model.trainable_variables,
+        options=dict(maxiter=25),
+        compile=True,
+    )
+
+    X_test = tf.constant(tf.convert_to_tensor(X_1))
+    mean_before, var_before = model.predict_f(X_test)
+
+    X_2 = sample(n_data_2, n_inputs)
+    Y_2 = sample(n_data_2, n_outputs)
+    gpflow.models.vgp.update_vgp_data(
+        model, (tf.concat([X_1, X_2], axis=0), tf.concat([Y_1, Y_2], axis=0))
+    )
+
+    (
+        mean_after,
+        var_after,
+    ) = model.predict_f(X_test)
+
+    np.testing.assert_allclose(mean_before, mean_after, atol=1e-5)
+    np.testing.assert_allclose(var_before, var_after, atol=1e-6)

--- a/tests/gpflow/test_base.py
+++ b/tests/gpflow/test_base.py
@@ -231,12 +231,12 @@ def test_construct_parameter_with_variable_shape() -> None:
         np.testing.assert_equal(value, parameter.numpy())
 
 
-def test_construct_parameter_with_variable_shape__different_transformed_shape() -> None:
+def test_construct_parameter_with_variable_shape__different_constrained_shape() -> None:
     parameter = gpflow.Parameter(
         [[1, 0], [2, 3]],
         transform=triangular(),
-        pretransformed_shape=[None],
-        transformed_shape=[None, None],
+        unconstrained_shape=[None],
+        constrained_shape=[None, None],
     )
 
     values = [

--- a/tests/gpflow/utilities/test_bijectors.py
+++ b/tests/gpflow/utilities/test_bijectors.py
@@ -1,9 +1,10 @@
 import numpy as np
 import pytest
+import tensorflow as tf
 import tensorflow_probability as tfp
 
 from gpflow.config import Config, as_context
-from gpflow.utilities import positive, triangular
+from gpflow.utilities import positive, triangular, triangular_size
 
 
 @pytest.mark.parametrize(
@@ -48,3 +49,19 @@ def test_positive_calculation_order():
 
 def test_triangular():
     assert isinstance(triangular(), tfp.bijectors.FillTriangular)
+
+
+@pytest.mark.parametrize(
+    "n,expected",
+    [
+        (0, 0),
+        (1, 1),
+        (2, 3),
+        (3, 6),
+        (4, 10),
+    ],
+)
+def test_triangular_size(n: int, expected: int) -> None:
+    actual = triangular_size(tf.constant(n))
+    assert actual.dtype.is_integer
+    assert expected == actual

--- a/tests/gpflow/utilities/test_misc.py
+++ b/tests/gpflow/utilities/test_misc.py
@@ -1,0 +1,38 @@
+# Copyright 2017-2021 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any
+
+import numpy as np
+import pytest
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+from gpflow.base import Parameter
+from gpflow.utilities import is_variable
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ([[0.1, 0.2], [0.3, 0.4]], False),
+        (np.array(5), False),
+        (tf.constant(5), False),
+        (tf.Variable(5), True),
+        (tfp.util.TransformedVariable(5, tfp.bijectors.Identity()), True),
+        (Parameter(5), True),
+    ],
+    ids=lambda x: x if isinstance(x, bool) else type(x).__name__,
+)
+def test_is_variable(value: Any, expected: bool) -> None:
+    assert expected == is_variable(value)

--- a/tests/integration/test_dynamic_shapes.py
+++ b/tests/integration/test_dynamic_shapes.py
@@ -23,15 +23,52 @@ rng = np.random.RandomState(0)
 
 
 class Datum:
-    X = rng.rand(20, 1) * 10
+    n_inputs = 1
+    n_outputs = 2
+    n_outputs_c = 1
+
+    X = rng.rand(20, n_inputs) * 10
     Y = np.sin(X) + 0.9 * np.cos(X * 1.6) + rng.randn(*X.shape) * 0.8
-    Y = np.tile(Y, 2)  # two identical columns
-    Xtest = rng.rand(10, 1) * 10
+    Y = np.tile(Y, n_outputs)  # identical columns
+    Xtest = rng.rand(10, n_outputs) * 10
     data = (X, Y)
 
     # for classification:
-    Yc = Y[:, :1]
+    Yc = Y[:, :n_outputs_c]
     cdata = (X, Yc)
+
+
+def test_vgp():
+    X = tf.Variable(
+        tf.zeros((1, Datum.n_inputs), dtype=default_float()), shape=(None, None), trainable=False
+    )
+    Y = tf.Variable(
+        tf.zeros((1, Datum.n_outputs), dtype=default_float()), shape=(None, None), trainable=False
+    )
+
+    model = gpflow.models.VGP(
+        (X, Y),
+        gpflow.kernels.SquaredExponential(),
+        gpflow.likelihoods.Gaussian(),
+        num_latent_gps=Datum.n_outputs,
+    )
+
+    @tf.function
+    def model_closure():
+        return -model.elbo()
+
+    model_closure()  # Trigger compilation.
+
+    gpflow.models.vgp.update_vgp_data(model, (Datum.X, Datum.Y))
+    opt = gpflow.optimizers.Scipy()
+
+    # simply test whether it runs without erroring...:
+    opt.minimize(
+        model_closure,
+        variables=model.trainable_variables,
+        options=dict(maxiter=3),
+        compile=True,
+    )
 
 
 @pytest.mark.parametrize("whiten", [True, False])
@@ -44,7 +81,7 @@ def test_svgp(whiten, q_diag):
         q_diag=q_diag,
         whiten=whiten,
         mean_function=gpflow.mean_functions.Constant(),
-        num_latent_gps=Datum.Y.shape[1],
+        num_latent_gps=Datum.n_outputs,
     )
     gpflow.set_trainable(model.inducing_variable, False)
 
@@ -59,6 +96,8 @@ def test_svgp(whiten, q_diag):
     def model_closure():
         return -elbo(Datum.data)
 
+    model_closure()  # Trigger compilation.
+
     opt = gpflow.optimizers.Scipy()
 
     # simply test whether it runs without erroring...:
@@ -70,7 +109,41 @@ def test_svgp(whiten, q_diag):
     )
 
 
-def test_multiclass():
+def test_vgp_multiclass():
+    X = tf.Variable(
+        tf.zeros((1, Datum.n_inputs), dtype=default_float()), shape=(None, None), trainable=False
+    )
+    Yc = tf.Variable(
+        tf.zeros((1, Datum.n_outputs_c), dtype=default_float()), shape=(None, None), trainable=False
+    )
+
+    num_classes = 3
+    model = gpflow.models.VGP(
+        (X, Yc),
+        gpflow.kernels.SquaredExponential(),
+        gpflow.likelihoods.MultiClass(num_classes=num_classes),
+        num_latent_gps=num_classes,
+    )
+
+    @tf.function
+    def model_closure():
+        return -model.elbo()
+
+    model_closure()  # Trigger compilation.
+
+    gpflow.models.vgp.update_vgp_data(model, (Datum.X, Datum.Yc))
+    opt = gpflow.optimizers.Scipy()
+
+    # simply test whether it runs without erroring...:
+    opt.minimize(
+        model_closure,
+        variables=model.trainable_variables,
+        options=dict(maxiter=3),
+        compile=True,
+    )
+
+
+def test_svgp_multiclass():
     num_classes = 3
     model = gpflow.models.SVGP(
         gpflow.kernels.SquaredExponential(),
@@ -90,6 +163,8 @@ def test_multiclass():
     @tf.function
     def model_closure():
         return -elbo(Datum.cdata)
+
+    model_closure()  # Trigger compilation.
 
     opt = gpflow.optimizers.Scipy()
 

--- a/tests/integration/test_method_equivalence.py
+++ b/tests/integration/test_method_equivalence.py
@@ -19,7 +19,7 @@ from numpy.testing import assert_allclose
 import gpflow
 from gpflow.config import default_jitter
 from gpflow.mean_functions import Constant
-from gpflow.models import ExternalDataTrainingLossMixin, maximum_log_likelihood_objective
+from gpflow.models import maximum_log_likelihood_objective, training_loss_closure
 
 rng = np.random.RandomState(0)
 
@@ -158,11 +158,7 @@ def test_equivalence(approximate_model):
 
     def optimize(model):
         opt = gpflow.optimizers.Scipy()
-        loss = (
-            model.training_loss_closure(Datum.data)
-            if isinstance(model, ExternalDataTrainingLossMixin)
-            else model.training_loss
-        )
+        loss = training_loss_closure(model, Datum.data)
         opt.minimize(loss, model.trainable_variables, options=dict(maxiter=3000))
         if isinstance(model, gpflow.models.SVGP) and not model.whiten:
             # The (S)VGP model in non-whitened representation has significantly


### PR DESCRIPTION
Make the VGP support variable-shaped data.

This includes:
1. Adding `shape` parameters to the `Parameter` class, to allow it to have dynamic shapes.
2. Adding an `after_data_changed` method to `InternalDataTrainingLossMixin` to allow the model to update internal values after data has changed.
3. Updating the `VGP` class itself.