### PR TITLE
Add more type hints.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -16,58 +16,34 @@ warn_return_any = False
 ; modules that haven't had types added are passing anyway so may not appear below.
 ;
 ; remove modules from this skip list when types have been added
-[mypy-gpflow.conditionals.*]
-ignore_errors = True
-
-[mypy-gpflow.kernels.*]
-ignore_errors = True
-
-[mypy-gpflow.mean_functions]
-ignore_errors = True
-
-[mypy-gpflow.models.*]
-ignore_errors = True
-
-[mypy-gpflow.monitor.*]
-ignore_errors = True
-
-[mypy-gpflow.optimizers.mcmc]
-ignore_errors = True
-
-[mypy-gpflow.optimizers.natgrad]
-ignore_errors = True
-
-[mypy-gpflow.utilities.*]
-ignore_errors = True
-
-[mypy-tests.gpflow.conditionals.*]
-ignore_errors = True
-
-[mypy-tests.gpflow.covariances.*]
+[mypy-gpflow.conditionals.*,tests.gpflow.conditionals.*]
 ignore_errors = True
 
 [mypy-tests.gpflow.expectations.*]
 ignore_errors = True
 
-[mypy-tests.gpflow.experimental.*]
-ignore_errors = True
-
-[mypy-tests.gpflow.kernels.*]
+[mypy-gpflow.kernels.*,tests.gpflow.kernels.*]
 ignore_errors = True
 
 [mypy-tests.gpflow.likelihoods.*]
 ignore_errors = True
 
-[mypy-tests.gpflow.models.*]
+[mypy-gpflow.mean_functions]
 ignore_errors = True
 
-[mypy-tests.gpflow.optimizers.*]
+[mypy-gpflow.models.*,tests.gpflow.models.*]
+ignore_errors = True
+
+[mypy-gpflow.monitor.*]
+ignore_errors = True
+
+[mypy-gpflow.optimizers.mcmc,gpflow.optimizers.natgrad,tests.gpflow.optimizers.*]
 ignore_errors = True
 
 [mypy-tests.gpflow.posteriors.*]
 ignore_errors = True
 
-[mypy-tests.gpflow.utilities.*]
+[mypy-gpflow.utilities.*,tests.gpflow.utilities.*]
 ignore_errors = True
 
 [mypy-tests.integration.*]

--- a/tests/gpflow/covariances/test_base_covariances.py
+++ b/tests/gpflow/covariances/test_base_covariances.py
@@ -19,11 +19,12 @@ from numpy.testing import assert_allclose
 import gpflow
 from gpflow.config import default_jitter
 from gpflow.covariances import Kuf, Kuu
-from gpflow.inducing_variables import InducingPatches, InducingPoints, Multiscale
+from gpflow.inducing_variables import InducingPatches, InducingPoints, InducingVariables, Multiscale
+from gpflow.kernels import Kernel
 
 
 @pytest.mark.parametrize("N, D", [[17, 3], [10, 7]])
-def test_inducing_points_inducing_variable_len(N, D):
+def test_inducing_points_inducing_variable_len(N: int, D: int) -> None:
     Z = np.random.randn(N, D)
     inducing_variable = InducingPoints(Z)
     assert inducing_variable.num_inducing == N
@@ -39,7 +40,7 @@ _kernel_setups = [
 
 @pytest.mark.parametrize("N", [10, 101])
 @pytest.mark.parametrize("kernel", _kernel_setups)
-def test_inducing_equivalence(N, kernel):
+def test_inducing_equivalence(N: int, kernel: Kernel) -> None:
     # Inducing inducing must be the same as the kernel evaluations
     Z = np.random.randn(N, 5)
     inducing_variable = InducingPoints(Z)
@@ -47,7 +48,7 @@ def test_inducing_equivalence(N, kernel):
 
 
 @pytest.mark.parametrize("N, M, D", [[23, 13, 3], [10, 5, 7]])
-def test_multi_scale_inducing_equivalence_inducing_points(N, M, D):
+def test_multi_scale_inducing_equivalence_inducing_points(N: int, M: int, D: int) -> None:
     # Multiscale must be equivalent to inducing points when variance is zero
     Xnew, Z = np.random.randn(N, D), np.random.randn(M, D)
     rbf = gpflow.kernels.SquaredExponential(1.3441, lengthscales=np.random.uniform(0.5, 3.0, D))
@@ -96,7 +97,9 @@ _inducing_variables_and_kernels = [
 
 
 @pytest.mark.parametrize("input_dim, inducing_variable, kernel", _inducing_variables_and_kernels)
-def test_inducing_variables_psd_schur(input_dim, inducing_variable, kernel):
+def test_inducing_variables_psd_schur(
+    input_dim: int, inducing_variable: InducingVariables, kernel: Kernel
+) -> None:
     # Conditional variance must be PSD.
     X = np.random.randn(5, input_dim)
     Kuf_values = Kuf(inducing_variable, kernel, X)

--- a/tests/gpflow/covariances/test_multioutput.py
+++ b/tests/gpflow/covariances/test_multioutput.py
@@ -1,3 +1,5 @@
+from typing import Callable, Sequence
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -7,6 +9,8 @@ import gpflow.inducing_variables.multioutput as mf
 import gpflow.kernels.multioutput as mk
 from gpflow.covariances.multioutput import kufs as mo_kufs
 from gpflow.covariances.multioutput import kuus as mo_kuus
+from gpflow.inducing_variables import InducingVariables
+from gpflow.kernels import Kernel
 
 rng = np.random.RandomState(9911)
 
@@ -15,20 +19,20 @@ rng = np.random.RandomState(9911)
 # ------------------------------------------
 
 
-def make_kernel():
+def make_kernel() -> Kernel:
     return gpflow.kernels.SquaredExponential()
 
 
-def make_kernels(num):
+def make_kernels(num: int) -> Sequence[Kernel]:
     return [make_kernel() for _ in range(num)]
 
 
-def make_ip():
+def make_ip() -> InducingVariables:
     X = rng.permutation(Datum.X)
     return gpflow.inducing_variables.InducingPoints(X[: Datum.M, ...])
 
 
-def make_ips(num):
+def make_ips(num: int) -> Sequence[InducingVariables]:
     return [make_ip() for _ in range(num)]
 
 
@@ -67,7 +71,7 @@ multioutput_kernel_list = [
 
 @pytest.mark.parametrize("inducing_variable", multioutput_inducing_variable_list)
 @pytest.mark.parametrize("kernel", multioutput_kernel_list)
-def test_kuu_shape(inducing_variable, kernel):
+def test_kuu_shape(inducing_variable: InducingVariables, kernel: Kernel) -> None:
     Kuu = mo_kuus.Kuu(inducing_variable, kernel, jitter=1e-9)
     t = tf.linalg.cholesky(Kuu)
 
@@ -82,7 +86,7 @@ def test_kuu_shape(inducing_variable, kernel):
 
 @pytest.mark.parametrize("inducing_variable", multioutput_inducing_variable_list)
 @pytest.mark.parametrize("kernel", multioutput_kernel_list)
-def test_kuf_shape(inducing_variable, kernel):
+def test_kuf_shape(inducing_variable: InducingVariables, kernel: Kernel) -> None:
     Kuf = mo_kufs.Kuf(inducing_variable, kernel, Datum.Xnew)
 
     if isinstance(kernel, mk.SharedIndependent):
@@ -95,7 +99,7 @@ def test_kuf_shape(inducing_variable, kernel):
 
 
 @pytest.mark.parametrize("inducing_variable", multioutput_fallback_inducing_variable_list)
-def test_kuf_fallback_shared_inducing_variables_shape(inducing_variable):
+def test_kuf_fallback_shared_inducing_variables_shape(inducing_variable: InducingVariables) -> None:
     kernel = mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W)
     Kuf = mo_kufs.Kuf(inducing_variable, kernel, Datum.Xnew)
 
@@ -103,7 +107,7 @@ def test_kuf_fallback_shared_inducing_variables_shape(inducing_variable):
 
 
 @pytest.mark.parametrize("fun", [mo_kuus.Kuu, mo_kufs.Kuf])
-def test_mixed_shared_shape(fun):
+def test_mixed_shared_shape(fun: Callable[..., tf.Tensor]) -> None:
     inducing_variable = mf.SharedIndependentInducingVariables(make_ip())
     kernel = mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W)
     if fun is mo_kuus.Kuu:

--- a/tests/gpflow/experimental/check_shapes/test_check_shapes.py
+++ b/tests/gpflow/experimental/check_shapes/test_check_shapes.py
@@ -200,7 +200,7 @@ def test_check_shapes__invalid_argument() -> None:
         return t(3, 4)
 
     with pytest.raises(TypeError):
-        f(c=t(2, 3))
+        f(c=t(2, 3))  # type: ignore  # Intentionally invalid call.
 
 
 def test_check_shapes__argument_refs() -> None:

--- a/tests/gpflow/experimental/check_shapes/test_errors.py
+++ b/tests/gpflow/experimental/check_shapes/test_errors.py
@@ -26,8 +26,7 @@ def context_func() -> None:
 
 def test_argument_reference_error() -> None:
     arg_map = MagicMock()
-    arg_ref = MagicMock()
-    arg_ref.__str__.return_value = "my_argument_reference"
+    arg_ref = MagicMock(__str__=MagicMock(return_value="my_argument_reference"))
 
     error = ArgumentReferenceError(context_func, arg_map, arg_ref)
 

--- a/tests/gpflow/experimental/check_shapes/test_integration.py
+++ b/tests/gpflow/experimental/check_shapes/test_integration.py
@@ -44,6 +44,10 @@ def test_check_shapes__tensorflow() -> None:
     f(tf.zeros((2, 3)), tf.zeros((2, 4)))  # Don't crash...
 
 
+_F = Callable[[tf.Tensor], tf.Tensor]
+_Loss = Callable[[], tf.Tensor]
+
+
 @pytest.mark.parametrize(
     "f_wrapper,loss_wrapper",
     [
@@ -70,7 +74,7 @@ def test_check_shapes__tensorflow() -> None:
     ],
 )
 def test_check_shapes__tensorflow_compilation(
-    f_wrapper: Callable[[tf.Tensor], tf.Tensor], loss_wrapper: Callable[[], tf.Tensor]
+    f_wrapper: Callable[[_F], _F], loss_wrapper: Callable[[_Loss], _Loss]
 ) -> None:
     target = 0.5
 

--- a/tests/gpflow/experimental/check_shapes/test_specs.py
+++ b/tests/gpflow/experimental/check_shapes/test_specs.py
@@ -75,7 +75,9 @@ def match_argument_spec(expected: ParsedArgumentSpec, actual: ParsedArgumentSpec
         ),
     ],
 )
-def test_parse_specs(raw_spec: ArgumentSpec, expected: ParsedArgumentSpec, expected_repr) -> None:
+def test_parse_specs(
+    raw_spec: ArgumentSpec, expected: ParsedArgumentSpec, expected_repr: str
+) -> None:
     (parsed_spec,) = parse_specs([raw_spec])
     match_argument_spec(parsed_spec, expected)
     assert repr(parsed_spec) == expected_repr

--- a/tests/gpflow/experimental/test_utils.py
+++ b/tests/gpflow/experimental/test_utils.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from _pytest.recwarn import WarningsRecorder
+
 from gpflow.experimental.utils import experimental
 
 
-def test_experimental(recwarn) -> None:
+def test_experimental(recwarn: WarningsRecorder) -> None:
     @experimental
     def f() -> None:
         pass


### PR DESCRIPTION

1. Reformat `mypy.ini` (again), so that code and corresponding tests are grouped together.
2. Add type hints to covariances tests.
3. Add type hints to experimental tests.