### PR TITLE
Fixed problem in docs derivation

### DIFF
--- a/doc/source/notebooks/theory/SGPR_notes.md
+++ b/doc/source/notebooks/theory/SGPR_notes.md
@@ -167,7 +167,7 @@ p(\mathbf f^\star) = \mathcal N(\mathbf f^\star\,|\, \mathbf K_{\star u}\mathbf 
 Note from our above definitions we have:
 
 \begin{equation}
-\mathbf K_{uu}^{-1}\mathbf \Lambda \mathbf K_{uu}^{-1} = 
+\mathbf K_{uu}^{-1}\mathbf \Lambda^{-1} \mathbf K_{uu}^{-1} = 
 \mathbf L^{-\top}\mathbf B^{-1}\mathbf L^{-1}
 \end{equation}
 


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** doc improvement

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->
resolves #1753 

## Summary
I believe there is a typo in the third to the last equation of this [GPflow note](https://gpflow.readthedocs.io/en/master/notebooks/theory/SGPR_notes.html). The right hand side of this equation should contain <img src="https://render.githubusercontent.com/render/math?math=\Lambda^{-1}"> instead of <img src="https://render.githubusercontent.com/render/math?math=\Lambda">, as proven [here](http://www.gatsby.ucl.ac.uk/~rapela/gpflow/proofPredictionCov.pdf). 