### PR TITLE
Include the .lark files when installing GPflow.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "Documentation": "https://gpflow.readthedocs.io",
     },
     packages=packages,
+    package_data={"": ["*.lark"]},
     include_package_data=True,
     install_requires=requirements,
     extras_require={"ImageToTensorBoard": ["matplotlib"]},


### PR DESCRIPTION
Include the .lark files when installing GPflow.

The current version of GPflow is broken when installed.