### PR TITLE
Add back a len(inducing_points) to break our users less.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,7 +49,7 @@ This release contains contributions from:
   You should no longer override `gpflow.inducing_variables.InducingVariables.__len__`. Override
   `gpflow.inducing_variables.InducingVariables.num_inducing` instead. `num_inducing` should return a
   `tf.Tensor` which is consistent with previous behaviour, although the type previously was
-  annotated as `int`. `__len__` has been removed. (#1766)
+  annotated as `int`. `__len__` has been deprecated. (#1766)
 
 
 ## Known Caveats

--- a/gpflow/inducing_variables/inducing_variables.py
+++ b/gpflow/inducing_variables/inducing_variables.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 import tensorflow as tf
 import tensorflow_probability as tfp
+from deprecated import deprecated
 
 from ..base import Module, Parameter, TensorData, TensorType
 from ..utilities import positive
@@ -35,6 +36,13 @@ class InducingVariables(Module):
         variational distribution.
         """
         raise NotImplementedError
+
+    @deprecated(
+        reason="len(iv) should return an `int`, but this actually returns a `tf.Tensor`."
+        " Use `iv.num_inducing` instead."
+    )
+    def __len__(self) -> tf.Tensor:
+        return self.num_inducing
 
 
 class InducingPointsBase(InducingVariables):

--- a/tests/gpflow/test_inducing_variables.py
+++ b/tests/gpflow/test_inducing_variables.py
@@ -48,3 +48,16 @@ def test_inducing_points_with_variable_shape() -> None:
 
     # Check 3: that we can also optimize with changed Z tensor
     optimization_step()
+
+
+def test_num_inducing() -> None:
+    M = 7
+    D = 3
+    Z = np.random.randn(M, D)
+
+    iv = gpflow.inducing_variables.InducingPoints(
+        tf.Variable(Z, trainable=False, dtype=gpflow.default_float())
+    )
+
+    assert M == iv.num_inducing
+    assert M == len(iv)


### PR DESCRIPTION
Add back a `len(inducing_points)` to break our users less.

`len(inducing_points)` was removed because its typing was weird/confusing/misleading. However this turns out to cause breakages downstream. Add it back, but marked as `deprecated`.