### PR TITLE
Add a hook to let the user register shapes for custom types.

### DIFF
--- a/gpflow/experimental/check_shapes/__init__.py
+++ b/gpflow/experimental/check_shapes/__init__.py
@@ -203,7 +203,7 @@ For example::
 
     import numpy as np
 
-    from gpflow.experimental.check_shapes import ActualShape, check_shapes, get_shape
+    from gpflow.experimental.check_shapes import Shape, check_shapes, get_shape
 
 
     class LinearModel:
@@ -220,7 +220,7 @@ For example::
 
 
     @get_shape.register(LinearModel)
-    def get_linear_model_shape(model: LinearModel) -> ActualShape:
+    def get_linear_model_shape(model: LinearModel) -> Shape:
         return model._weights.shape
 
 
@@ -236,7 +236,7 @@ For example::
         return np.mean(np.sqrt(np.mean((prediction - test_labels) ** 2, axis=-1)))
 """
 
-from .base_types import ActualDimension, ActualShape
+from .base_types import Dimension, Shape
 from .check_shapes import check_shapes
 from .errors import ArgumentReferenceError, ShapeMismatchError
 from .inheritance import inherit_check_shapes

--- a/gpflow/experimental/check_shapes/__init__.py
+++ b/gpflow/experimental/check_shapes/__init__.py
@@ -189,10 +189,57 @@ will have `.__doc__`::
 
         Model predictions.
     \"\"\"
+
+
+Shapes of custom objects
+++++++++++++++++++++++++
+
+:mod:`check_shapes` uses the function :func:`get_shape` to extract the shape of an object.
+
+:func:`get_shape` uses :func:`functools.singledispatch` to branch on the type of object to the shape
+from, and you can extend this to extract shapes for you own custom types.
+
+For example::
+
+    import numpy as np
+
+    from gpflow.experimental.check_shapes import ActualShape, check_shapes, get_shape
+
+
+    class LinearModel:
+        def __init__(self, weights: np.ndarray) -> None:
+            self._weights = weights
+
+        @check_shapes(
+            "self: [n_features, n_labels]",
+            "features: [n_rows, n_features]",
+            "return: [n_rows, n_labels]",
+        )
+        def predict(self, features: np.ndarray) -> None:
+            return features @ self._weights
+
+
+    @get_shape.register(LinearModel)
+    def get_linear_model_shape(model: LinearModel) -> ActualShape:
+        return model._weights.shape
+
+
+    @check_shapes(
+        "model: [n_features, n_labels]",
+        "test_features: [n_rows, n_features]",
+        "test_labels: [n_rows, n_labels]",
+    )
+    def loss(
+        model: LinearModel, test_features: np.ndarray, test_labels: np.ndarray
+    ) -> None:
+        prediction = model.predict(test_features)
+        return np.mean(np.sqrt(np.mean((prediction - test_labels) ** 2, axis=-1)))
 """
 
+from .base_types import ActualDimension, ActualShape
 from .check_shapes import check_shapes
 from .errors import ArgumentReferenceError, ShapeMismatchError
 from .inheritance import inherit_check_shapes
+from .shapes import get_shape
 
 __all__ = list(dir())

--- a/gpflow/experimental/check_shapes/base_types.py
+++ b/gpflow/experimental/check_shapes/base_types.py
@@ -14,6 +14,22 @@
 """
 Definitions of commonly used types.
 """
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Optional, Tuple, TypeVar
 
 C = TypeVar("C", bound=Callable[..., Any])
+
+ActualDimension = Optional[int]
+"""
+The size of a single observed dimension.
+
+Use `None` if the size of that dimension is unknown.
+"""
+
+ActualShape = Optional[Tuple[ActualDimension, ...]]
+"""
+The complete shape of an observed object.
+
+Use `None` if the object has a shape, but the shape is unknown.
+
+Raise an exception if objects of that type can never have a shape.
+"""

--- a/gpflow/experimental/check_shapes/base_types.py
+++ b/gpflow/experimental/check_shapes/base_types.py
@@ -18,14 +18,14 @@ from typing import Any, Callable, Optional, Tuple, TypeVar
 
 C = TypeVar("C", bound=Callable[..., Any])
 
-ActualDimension = Optional[int]
+Dimension = Optional[int]
 """
 The size of a single observed dimension.
 
 Use `None` if the size of that dimension is unknown.
 """
 
-ActualShape = Optional[Tuple[ActualDimension, ...]]
+Shape = Optional[Tuple[Dimension, ...]]
 """
 The complete shape of an observed object.
 

--- a/gpflow/experimental/check_shapes/check_shapes.py
+++ b/gpflow/experimental/check_shapes/check_shapes.py
@@ -18,13 +18,12 @@ import inspect
 from functools import wraps
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union, cast
 
-import tensorflow as tf
-
 from ..utils import experimental
 from .argument_ref import RESULT_TOKEN
 from .base_types import C
 from .errors import ShapeMismatchError
 from .parser import parse_and_rewrite_docstring, parse_argument_spec
+from .shapes import get_shape
 from .specs import ParsedArgumentSpec
 
 
@@ -90,8 +89,8 @@ def _assert_shapes(
             raise ShapeMismatchError(func, print_specs, arg_map)
 
     for arg_spec in check_specs:
-        actual_shape = arg_spec.argument_ref.get(func, arg_map).shape
-        if isinstance(actual_shape, tf.TensorShape) and actual_shape.rank is None:
+        actual_shape = get_shape(arg_spec.argument_ref.get(func, arg_map))
+        if actual_shape is None:
             continue
 
         actual = list(actual_shape)

--- a/gpflow/experimental/check_shapes/errors.py
+++ b/gpflow/experimental/check_shapes/errors.py
@@ -21,9 +21,8 @@ import inspect
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
-import tensorflow as tf
-
 from .base_types import C
+from .shapes import get_shape
 
 if TYPE_CHECKING:
     from .argument_ref import ArgumentRef
@@ -65,9 +64,9 @@ class ShapeMismatchError(Exception):
             f"    Declared: {func_info.path_and_line}",
         ]
         for spec in specs:
-            actual_shape = spec.argument_ref.get(func, arg_map).shape
-            if isinstance(actual_shape, tf.TensorShape) and actual_shape.rank is None:
-                actual_str = "<Unknown>"
+            actual_shape = get_shape(spec.argument_ref.get(func, arg_map))
+            if actual_shape is None:
+                actual_str = "<Tensor has unknown shape>"
             else:
                 actual_str = f"({', '.join(str(dim) for dim in actual_shape)})"
             lines.append(

--- a/gpflow/experimental/check_shapes/shapes.py
+++ b/gpflow/experimental/check_shapes/shapes.py
@@ -1,0 +1,74 @@
+# Copyright 2022 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Code for extracting shapes from object.
+"""
+from functools import singledispatch
+from typing import Any, Sequence, Union
+
+import numpy as np
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+from .base_types import ActualShape
+
+
+@singledispatch
+def get_shape(shaped: Any) -> ActualShape:
+    """
+    Returns the shape of the given object.
+
+    Returns `None` if the object has as shape, but it is unknown.
+
+    Raises an exception if objects of that type do not have shapes.
+    """
+    raise NotImplementedError(f"Do not know how to get shape of object of type {type(shaped)}.")
+
+
+@get_shape.register(bool)
+@get_shape.register(int)
+@get_shape.register(float)
+def get_scalar_shape(shaped: Any) -> ActualShape:
+    return ()
+
+
+@get_shape.register(Sequence)
+def get_sequence_shape(shaped: Sequence[Any]) -> ActualShape:
+    if isinstance(shaped, str):
+        raise NotImplementedError("Strings do not have shapes.")
+    if len(shaped) == 0:
+        # If the sequence doesn't have any elements we cannot use the first element to determine the
+        # shape, and the shape is unknown.
+        return None
+    child_shape = get_shape(shaped[0])
+    if child_shape is None:
+        return None
+    return (len(shaped),) + child_shape
+
+
+@get_shape.register(np.ndarray)
+def get_ndarray_shape(shaped: np.ndarray) -> ActualShape:
+    return shaped.shape
+
+
+@get_shape.register(tf.Tensor)
+@get_shape.register(tf.Variable)
+@get_shape.register(tfp.util.DeferredTensor)
+def get_tensorflow_shape(
+    shaped: Union[tf.Tensor, tf.Variable, tfp.util.DeferredTensor]
+) -> ActualShape:
+    shape = shaped.shape
+    if not shape:
+        return None
+    return tuple(shape)

--- a/gpflow/experimental/check_shapes/shapes.py
+++ b/gpflow/experimental/check_shapes/shapes.py
@@ -22,6 +22,7 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 
+from ...base import AnyNDArray
 from .base_types import Shape
 
 
@@ -58,7 +59,7 @@ def get_sequence_shape(shaped: Sequence[Any]) -> Shape:
 
 
 @get_shape.register(np.ndarray)
-def get_ndarray_shape(shaped: np.ndarray) -> Shape:
+def get_ndarray_shape(shaped: AnyNDArray) -> Shape:
     return shaped.shape
 
 

--- a/tests/gpflow/experimental/check_shapes/test_check_shapes.py
+++ b/tests/gpflow/experimental/check_shapes/test_check_shapes.py
@@ -22,7 +22,7 @@ import pytest
 from gpflow.base import TensorType
 from gpflow.experimental.check_shapes import ShapeMismatchError, check_shapes
 
-from .utils import t
+from .utils import t, t_unk
 
 
 def test_check_shapes__constant() -> None:
@@ -39,6 +39,8 @@ def test_check_shapes__constant() -> None:
     f(t(None, 3), t(2, 4))
     f(t(2, None), t(2, 4))
     f(t(2, 3), t(None, 4))
+    f(t_unk(), t(2, 4))
+    f(t(2, 3), t_unk())
 
 
 def test_check_shapes__constant__bad_input() -> None:
@@ -81,6 +83,9 @@ def test_check_shapes__var_dim() -> None:
     f(t(None, 3), t(2, 4))
     f(t(2, None), t(2, 4))
     f(t(2, 3), t(None, 4))
+    f(t(2, 3), t(2, None))
+    f(t_unk(), t(2, 4))
+    f(t(2, 3), t_unk())
 
 
 def test_check_shapes__var_dim__bad_input() -> None:
@@ -131,6 +136,10 @@ def test_check_shapes__var_rank() -> None:
     f(t(2, None), t(2, 2, 3), t(3, 2, 2, 4), t(3, 2, 2), leading_dims=2)
     f(t(2, 2), t(None, 2, 3), t(3, 2, 2, 4), t(3, 2, 2), leading_dims=2)
     f(t(2, 2), t(2, 2, None), t(3, 2, 2, 4), t(3, 2, 2), leading_dims=2)
+    f(t_unk(), t(2, 2, 3), t(3, 2, 2, 4), t(3, 2, 2), leading_dims=2)
+    f(t(2, 2), t_unk(), t(3, 2, 2, 4), t(3, 2, 2), leading_dims=2)
+    f(t(2, 2), t(2, 2, 3), t_unk(), t(3, 2, 2), leading_dims=2)
+    f(t(2, 2), t(2, 2, 3), t(3, 2, 2, 4), t_unk(), leading_dims=2)
 
 
 def test_check_shapes__var_rank__bad_input() -> None:

--- a/tests/gpflow/experimental/check_shapes/test_check_shapes.py
+++ b/tests/gpflow/experimental/check_shapes/test_check_shapes.py
@@ -20,7 +20,7 @@ from typing import Tuple
 import pytest
 
 from gpflow.base import TensorType
-from gpflow.experimental.check_shapes import ShapeMismatchError, check_shapes
+from gpflow.experimental.check_shapes import ShapeMismatchError, check_shapes, get_shape
 
 from .utils import t, t_unk
 
@@ -181,7 +181,7 @@ def test_check_shapes__anonymous() -> None:
         "return: [..., d1, d2]",
     )
     def f(a: TensorType, b: TensorType, c: TensorType, d: TensorType) -> TensorType:
-        return t(*c.shape[:-1], a.shape[-1], b.shape[-1])
+        return t(*get_shape(c)[:-1], get_shape(a)[-1], get_shape(b)[-1])  # type: ignore
 
     f(t(1, 2), t(1, 3), t(2), t(3))
     f(t(1, 2), t(1, 3), t(1, 2), t(1, 3))
@@ -203,7 +203,7 @@ def test_check_shapes__anonymous__bad_imput() -> None:
         "return: [..., d1, d2]",
     )
     def f(a: TensorType, b: TensorType, c: TensorType, d: TensorType) -> TensorType:
-        return t(*c.shape[:-1], a.shape[-1], b.shape[-1])
+        return t(*get_shape(c)[:-1], get_shape(a)[-1], get_shape(b)[-1])  # type: ignore
 
     with pytest.raises(ShapeMismatchError):
         f(t(2), t(1, 3), t(2), t(3))
@@ -233,7 +233,7 @@ def test_check_shapes__anonymous__bad_return() -> None:
         "return: [..., d1, d2]",
     )
     def f(a: TensorType, b: TensorType, c: TensorType, d: TensorType) -> TensorType:
-        return t(*c.shape[:-1], a.shape[-1] + 1, b.shape[-1])
+        return t(*get_shape(c)[:-1], get_shape(a)[-1] + 1, get_shape(b)[-1])  # type: ignore
 
     with pytest.raises(ShapeMismatchError):
         f(t(1, 2), t(1, 3), t(2), t(3))

--- a/tests/gpflow/experimental/check_shapes/test_errors.py
+++ b/tests/gpflow/experimental/check_shapes/test_errors.py
@@ -17,7 +17,7 @@ from gpflow.experimental.check_shapes.argument_ref import RESULT_TOKEN
 from gpflow.experimental.check_shapes.errors import ArgumentReferenceError, ShapeMismatchError
 from gpflow.experimental.check_shapes.parser import parse_argument_spec
 
-from .utils import t
+from .utils import t, t_unk
 
 
 def context_func() -> None:
@@ -46,11 +46,13 @@ def test_shape_mismatch_error() -> None:
     specs = [
         parse_argument_spec("a: [x, 3]"),
         parse_argument_spec("b: [5, y]"),
+        parse_argument_spec("c: [x, y]"),
         parse_argument_spec("return: [x, y]"),
     ]
     arg_map = {
         "a": t(2, 3),
         "b": t(5, 6),
+        "c": t_unk(),
         RESULT_TOKEN: t(2, 6),
     }
     error = ShapeMismatchError(context_func, specs, arg_map)
@@ -65,5 +67,6 @@ def test_shape_mismatch_error() -> None:
     Declared: {__file__}:23
     Argument: a, expected: (x, 3), actual: (2, 3)
     Argument: b, expected: (5, y), actual: (5, 6)
+    Argument: c, expected: (x, y), actual: <Tensor has unknown shape>
     Argument: return, expected: (x, y), actual: (2, 6)"""
     )

--- a/tests/gpflow/experimental/check_shapes/test_shapes.py
+++ b/tests/gpflow/experimental/check_shapes/test_shapes.py
@@ -1,0 +1,63 @@
+# Copyright 2022 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any, Type, Union
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from gpflow.base import Parameter
+from gpflow.experimental.check_shapes import ActualShape, get_shape
+
+
+@pytest.mark.parametrize(
+    "shaped,expected_shape",
+    [
+        (object(), NotImplementedError),
+        (True, ()),
+        (0, ()),
+        (0.0, ()),
+        ("foo", NotImplementedError),
+        ((), None),
+        ((0,), (1,)),
+        ([[0.1, 0.2]], (1, 2)),
+        ([[[], []]], None),
+        (np.zeros((3, 4)), (3, 4)),
+        (tf.zeros((4, 3)), (4, 3)),
+        (tf.Variable(np.zeros((2, 4))), (2, 4)),
+        (tf.Variable(np.zeros((2, 4)), shape=[2, None]), (2, None)),
+        (tf.Variable(np.zeros((2, 4)), shape=tf.TensorShape(None)), None),
+        (Parameter(3), ()),
+        (Parameter(np.zeros((4, 2))), (4, 2)),
+    ],
+)
+def test_get_shape(shaped: Any, expected_shape: Union[ActualShape, Type[Exception]]) -> None:
+    if isinstance(expected_shape, type) and issubclass(expected_shape, Exception):
+
+        with pytest.raises(expected_shape):
+            get_shape(shaped)
+
+    else:
+
+        actual_shape = get_shape(shaped)
+
+        # Numpy and tensorflow sometimes like to pretend that objects have another type than they
+        # actually do. Make sure the result actually has the right types:
+        if actual_shape is not None:
+            assert tuple == type(actual_shape)
+            assert all(
+                (actual_dim is None) or (int == type(actual_dim)) for actual_dim in actual_shape
+            )
+
+        assert expected_shape == actual_shape

--- a/tests/gpflow/experimental/check_shapes/test_shapes.py
+++ b/tests/gpflow/experimental/check_shapes/test_shapes.py
@@ -18,7 +18,7 @@ import pytest
 import tensorflow as tf
 
 from gpflow.base import Parameter
-from gpflow.experimental.check_shapes import ActualShape, get_shape
+from gpflow.experimental.check_shapes import Shape, get_shape
 
 
 @pytest.mark.parametrize(
@@ -28,7 +28,7 @@ from gpflow.experimental.check_shapes import ActualShape, get_shape
         (True, ()),
         (0, ()),
         (0.0, ()),
-        ("foo", NotImplementedError),
+        ("foo", ()),
         ((), None),
         ((0,), (1,)),
         ([[0.1, 0.2]], (1, 2)),
@@ -42,7 +42,7 @@ from gpflow.experimental.check_shapes import ActualShape, get_shape
         (Parameter(np.zeros((4, 2))), (4, 2)),
     ],
 )
-def test_get_shape(shaped: Any, expected_shape: Union[ActualShape, Type[Exception]]) -> None:
+def test_get_shape(shaped: Any, expected_shape: Union[Shape, Type[Exception]]) -> None:
     if isinstance(expected_shape, type) and issubclass(expected_shape, Exception):
 
         with pytest.raises(expected_shape):

--- a/tests/gpflow/experimental/check_shapes/utils.py
+++ b/tests/gpflow/experimental/check_shapes/utils.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import Union
 
 from gpflow.base import TensorType
-from gpflow.experimental.check_shapes import ActualDimension, ActualShape, get_shape
+from gpflow.experimental.check_shapes import Dimension, Shape, get_shape
 from gpflow.experimental.check_shapes.argument_ref import (
     ArgumentRef,
     AttributeArgumentRef,
@@ -31,11 +31,11 @@ from gpflow.experimental.check_shapes.specs import ParsedDimensionSpec, ParsedSh
 @dataclass(frozen=True)
 class TestShaped:
 
-    test_shape: ActualShape
+    test_shape: Shape
 
 
 @get_shape.register(TestShaped)
-def get_test_shaped_shape(shaped: TestShaped) -> ActualShape:
+def get_test_shaped_shape(shaped: TestShaped) -> Shape:
     return shaped.test_shape
 
 
@@ -46,7 +46,7 @@ def t_unk() -> TestShaped:
     return TestShaped(None)
 
 
-def t(*shape: ActualDimension) -> TensorType:
+def t(*shape: Dimension) -> TensorType:
     """
     Creates an object with the given shape, for testing.
     """

--- a/tests/gpflow/experimental/check_shapes/utils.py
+++ b/tests/gpflow/experimental/check_shapes/utils.py
@@ -15,7 +15,7 @@
 Utilities for testing the `check_shapes` library.
 """
 from dataclasses import dataclass
-from typing import Union
+from typing import Optional, Union
 
 from gpflow.base import TensorType
 from gpflow.experimental.check_shapes import Dimension, Shape, get_shape

--- a/tests/gpflow/experimental/check_shapes/utils.py
+++ b/tests/gpflow/experimental/check_shapes/utils.py
@@ -15,10 +15,10 @@
 Utilities for testing the `check_shapes` library.
 """
 from dataclasses import dataclass
-from typing import Optional, Union
-from unittest.mock import MagicMock
+from typing import Union
 
 from gpflow.base import TensorType
+from gpflow.experimental.check_shapes import ActualDimension, ActualShape, get_shape
 from gpflow.experimental.check_shapes.argument_ref import (
     ArgumentRef,
     AttributeArgumentRef,
@@ -28,16 +28,32 @@ from gpflow.experimental.check_shapes.argument_ref import (
 from gpflow.experimental.check_shapes.specs import ParsedDimensionSpec, ParsedShapeSpec
 
 
-def t(*shape: Optional[int]) -> TensorType:
-    """
-    Creates a mock tensor of the given shape.
-    """
-    mock_tensor = MagicMock()
-    mock_tensor.shape = shape
-    return mock_tensor
+@dataclass(frozen=True)
+class TestShaped:
+
+    test_shape: ActualShape
 
 
-@dataclass
+@get_shape.register(TestShaped)
+def get_test_shaped_shape(shaped: TestShaped) -> ActualShape:
+    return shaped.test_shape
+
+
+def t_unk() -> TestShaped:
+    """
+    Creates an object with an unknown shape, for testing.
+    """
+    return TestShaped(None)
+
+
+def t(*shape: ActualDimension) -> TensorType:
+    """
+    Creates an object with the given shape, for testing.
+    """
+    return TestShaped(shape)
+
+
+@dataclass(frozen=True)
 class varrank:
     name: Optional[str]
 


### PR DESCRIPTION
Add a hook to let the user register shapes for custom types.

Honestly I'm mostly doing this to better be able to handle / test object with shape `None`.