### PR TITLE
Improved confusing scoping of method

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -82,5 +82,6 @@ Because GitHub's [graph of contributors](http://github.com/GPflow/GPflow/graphs/
 [@avullo](https://github.com/avullo)
 [@jesnie](https://github.com/jesnie)
 [@tmct](https://github.com/tmct)
+[@ltiao](https://github.com/ltiao)
 
 Add yourself when you first contribute to GPflow's code, tests, or documentation!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,15 +55,13 @@ This release contains contributions from:
 
 ## Bug Fixes and Other Changes
 
-* <SIMILAR TO ABOVE SECTION, BUT FOR OTHER IMPORTANT CHANGES / BUG FIXES>
-* <IF A CHANGE CLOSES A GITHUB ISSUE, IT SHOULD BE DOCUMENTED HERE>
-* <NOTES SHOULD BE GROUPED PER AREA>
+* Minor improvement to code clarity (variable scoping) in SVGP model (#1800)
 
 ## Thanks to our Contributors
 
 This release contains contributions from:
 
-<INSERT>, <NAME>, <HERE>, <USING>, <GITHUB>, <HANDLE>
+ltiao
 
 
 # Release 2.4.0

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -74,7 +74,6 @@ class SVGP_deprecated(GPModel, ExternalDataTrainingLossMixin):
         # init the super class, accept args
         super().__init__(kernel, likelihood, mean_function, num_latent_gps)
         self.num_data = num_data
-        self.q_diag = q_diag
         self.whiten = whiten
         self.inducing_variable = inducingpoint_wrapper(inducing_variable)
 
@@ -120,7 +119,7 @@ class SVGP_deprecated(GPModel, ExternalDataTrainingLossMixin):
         self.q_mu = Parameter(q_mu, dtype=default_float())  # [M, P]
 
         if q_sqrt is None:
-            if self.q_diag:
+            if q_diag:
                 ones = np.ones((num_inducing, self.num_latent_gps), dtype=default_float())
                 self.q_sqrt = Parameter(ones, transform=positive())  # [M, P]
             else:


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** enhancement

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->

The `_init_variational_parameters` method was using the instance attribute (`self.q_diag`) as well as input argument `q_diag` which refer to the same thing and should never diverge. In fact, `self.diag` is never used anywhere else so does not have to be an attribute.


**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```python
# Put your example code in here
```

### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** yes

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [x] New features: code is well-documented
  - [x] detailed docstrings (API documentation)
  - [x] notebook examples (usage demonstration)
- [x] The bug case / new feature is covered by unit tests
- [x] Code has type annotations
- [x] Build checks
  - [x] I ran the black+isort formatter (`make format`)
  - [x] I locally tested that the tests pass (`make check-all`)
- [x] Release management
  - [x] RELEASE.md updated with entry for this change
  - [x] New contributors: I've added myself to CONTRIBUTORS.md

