### PR TITLE
Fixed formatting of matrices in SGPR notebook

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -56,6 +56,7 @@ This release contains contributions from:
 ## Bug Fixes and Other Changes
 
 * Minor improvement to code clarity (variable scoping) in SVGP model (#1800)
+* Improving mathematical formatting in docs (SGPR derivations) (#1806)
 
 ## Thanks to our Contributors
 

--- a/doc/source/notebooks/theory/SGPR_notes.md
+++ b/doc/source/notebooks/theory/SGPR_notes.md
@@ -45,17 +45,17 @@ To obtain an efficient and stable evaluation on the bound $\mathcal L$, we first
 Now, to obtain a better conditioned matrix for inversion, we rotate by $\mathbf L$, where $\mathbf L\mathbf L^\top = \mathbf K_{uu}$:
 
 \begin{equation}
-[\mathbf Q_{ff} + \sigma^2 \mathbf I ]^{-1} = \sigma^{-2} \mathbf I - \sigma^{-4} \mathbf K_{fu}\color{red}{\mathbf L^{-\top} \mathbf L^\top}[\mathbf K_{uu} + \mathbf K_{uf}K_{fu}\sigma^{-2}]^{-1}\color{red}{\mathbf L \mathbf L^{-1}}\mathbf K_{uf}
+[\mathbf Q_{ff} + \sigma^2 \mathbf I ]^{-1} = \sigma^{-2} \mathbf I - \sigma^{-4} \mathbf K_{fu}\color{red}{\mathbf L^{-\top} \mathbf L^\top}[\mathbf K_{uu} + \mathbf K_{uf} \mathbf K_{fu}\sigma^{-2}]^{-1}\color{red}{\mathbf L \mathbf L^{-1}}\mathbf K_{uf}
 \end{equation}
 
 This matrix is better conditioned because, for many kernels, it has eigenvalues bounded above and below. For more details, see section 3.4.3 of [Gaussian Processes for Machine Learning](http://www.gaussianprocess.org/gpml/chapters/RW.pdf).
 
 \begin{equation}
-\phantom{[\mathbf Q_{ff} + \sigma^2 \mathbf I ]^{-1}} = \sigma^{-2} \mathbf I - \sigma^{-4} \mathbf K_{fu}\color{red}{\mathbf L^{-\top}} [\color{red}{\mathbf L^{-1}}\mathbf (K_{uu} + \mathbf K_{uf}K_{fu}\sigma^{-2})\color{red}{\mathbf L^{-\top}}]^{-1}\color{red}{ \mathbf L^{-1}}\mathbf K_{uf}
+\phantom{[\mathbf Q_{ff} + \sigma^2 \mathbf I ]^{-1}} = \sigma^{-2} \mathbf I - \sigma^{-4} \mathbf K_{fu}\color{red}{\mathbf L^{-\top}} [\color{red}{\mathbf L^{-1}}(\mathbf K_{uu} + \mathbf K_{uf} \mathbf K_{fu}\sigma^{-2})\color{red}{\mathbf L^{-\top}}]^{-1}\color{red}{ \mathbf L^{-1}}\mathbf K_{uf}
 \end{equation}
 
 \begin{equation}
-\phantom{[\mathbf Q_{ff} + \sigma^2 \mathbf I ]^{-1} }= \sigma^{-2} \mathbf I - \sigma^{-4} \mathbf K_{fu}\color{red}{\mathbf L^{-\top}} [\mathbf I + \color{red}{\mathbf L^{-1}}\mathbf (\mathbf K_{uf}K_{fu})\color{red}{\mathbf L^{-\top}}\sigma^{-2}]^{-1}\color{red}{ \mathbf L^{-1}}\mathbf K_{uf}
+\phantom{[\mathbf Q_{ff} + \sigma^2 \mathbf I ]^{-1} }= \sigma^{-2} \mathbf I - \sigma^{-4} \mathbf K_{fu}\color{red}{\mathbf L^{-\top}} [\mathbf I + \color{red}{\mathbf L^{-1}}\mathbf (\mathbf K_{uf} \mathbf K_{fu})\color{red}{\mathbf L^{-\top}}\sigma^{-2}]^{-1}\color{red}{ \mathbf L^{-1}}\mathbf K_{uf}
 \end{equation}
 
 For notational convenience, we'll define $\mathbf L^{-1}\mathbf K_{uf}\sigma^{-1} \triangleq \mathbf A$, and  $[\mathbf I + \mathbf A\mathbf A^\top]\triangleq \mathbf B$:


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** doc improvement

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->

Fixed several instances of matrices in this notebook that are not appropriately bolded.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

No alternative need be considered.

### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** yes

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

