### PR TITLE
Trigger the doc build corresponding to the current branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
             curl \
               -u ${DOCS_TOKEN}: \
               -d 'build_parameters[CIRCLE_JOB]=build' \
-              https://circleci.com/api/v1.1/project/github/GPflow/docs/tree/develop
+              https://circleci.com/api/v1.1/project/github/GPflow/docs/tree/<< pipeline.git.branch >>
 
   deploy:
     docker:


### PR DESCRIPTION
Trigger the doc build corresponding to the current branch.
 - This is so that the `master` docs are built when we push to the `master` branch, instead of it only being the `develop` docs that are built.