### PR TITLE
Add configuration of check_shapes.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -132,6 +132,7 @@ disable=missing-docstring,
         fixme,
         too-many-branches,
         ungrouped-imports,
+        global-statement,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/gpflow/experimental/check_shapes/__init__.py
+++ b/gpflow/experimental/check_shapes/__init__.py
@@ -191,6 +191,20 @@ actual graphs.  This is considered a feature as that means that :func:`check_sha
 the execution speed of compiled functions. However, it also means that tensor dimensions of dynamic
 size are not verified in compiled mode.
 
+If your code is very performance sensitive and :mod:`check_shapes` is causing an unacceptable
+slowdown it can be disabled. Preferably use :func:`disable_check_shapes`::
+
+    with disable_check_shapes():
+        function_that_is_performance_sensitive()
+
+Alternatively :mod:`check_shapes` can also be disable globally with
+:func:`set_enable_check_shapes`::
+
+    set_enable_check_shapes(False)
+
+Beware that any function declared while shape checking is disabled, will continue not to check
+shapes, even if shape checking is otherwise enabled again.
+
 
 Documenting shapes
 ++++++++++++++++++
@@ -237,6 +251,11 @@ will have `.__doc__`::
 
         Model predictions.
     \"\"\"
+
+if you do not wish to have your docstrings rewritten, you can disable it with
+:func:`set_rewrite_docstrings`::
+
+    set_rewrite_docstrings(None)
 
 
 Shapes of custom objects
@@ -288,6 +307,14 @@ For example::
 from .accessors import get_check_shapes, maybe_get_check_shapes
 from .base_types import Dimension, Shape
 from .check_shapes import check_shapes
+from .config import (
+    DocstringFormat,
+    disable_check_shapes,
+    get_enable_check_shapes,
+    get_rewrite_docstrings,
+    set_enable_check_shapes,
+    set_rewrite_docstrings,
+)
 from .errors import ArgumentReferenceError, ShapeMismatchError
 from .inheritance import inherit_check_shapes
 from .shapes import get_shape
@@ -295,19 +322,26 @@ from .shapes import get_shape
 __all__ = [
     "ArgumentReferenceError",
     "Dimension",
+    "DocstringFormat",
     "Shape",
     "ShapeMismatchError",
     "accessors",
     "argument_ref",
     "base_types",
     "check_shapes",
+    "config",
+    "disable_check_shapes",
     "errors",
     "get_check_shapes",
+    "get_enable_check_shapes",
+    "get_rewrite_docstrings",
     "get_shape",
     "inherit_check_shapes",
     "inheritance",
     "maybe_get_check_shapes",
     "parser",
+    "set_enable_check_shapes",
+    "set_rewrite_docstrings",
     "shapes",
     "specs",
 ]

--- a/gpflow/experimental/check_shapes/config.py
+++ b/gpflow/experimental/check_shapes/config.py
@@ -1,0 +1,97 @@
+# Copyright 2022 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Code for configuring check_shapes."
+"""
+from contextlib import contextmanager
+from enum import Enum
+from typing import Iterator, Union
+
+_enabled = True
+
+
+class DocstringFormat(Enum):
+    SPHINX = "sphinx"
+    """
+    Rewrite docstrings in the `Sphinx <https://www.sphinx-doc.org/en/master/>`_ format.
+    """
+
+    NONE = "none"
+    """
+    Do not rewrite docstrings.
+    """
+
+
+_docstring_format = DocstringFormat.SPHINX
+
+
+def set_enable_check_shapes(enabled: bool) -> None:
+    """
+    Set whether to enable :mod:`check_shapes`.
+
+    Check shapes has a non-zero impact on performance. If this is unacceptable to you, you can
+    disable it.
+
+    See also :func:`disable_check_shapes`.
+    """
+    global _enabled
+    _enabled = enabled
+
+
+def get_enable_check_shapes() -> bool:
+    """
+    Get whether to enable :mod:`check_shapes`.
+    """
+    return _enabled
+
+
+@contextmanager
+def disable_check_shapes() -> Iterator[None]:
+    """
+    Context manager that temporarily disables shape checking.
+
+    Example::
+
+        with disable_check_shapes():
+            function_that_is_performance_sensitive()
+    """
+    old_value = get_enable_check_shapes()
+    set_enable_check_shapes(False)
+    try:
+        yield
+    finally:
+        set_enable_check_shapes(old_value)
+
+
+def set_rewrite_docstrings(docstring_format: Union[DocstringFormat, str, None]) -> None:
+    """
+    Set how :mod:`check_shapes` should rewrite docstrings.
+
+    See :class:`DocstringFormat` for valid choices.
+    """
+    global _docstring_format
+    if docstring_format is None:
+        _docstring_format = DocstringFormat.NONE
+    elif isinstance(docstring_format, str):
+        _docstring_format = DocstringFormat(docstring_format)
+    else:
+        assert isinstance(docstring_format, DocstringFormat), type(docstring_format)
+        _docstring_format = docstring_format
+
+
+def get_rewrite_docstrings() -> DocstringFormat:
+    """
+    Get how :mod:`check_shapes` should rewrite docstrings.
+    """
+    return _docstring_format

--- a/gpflow/experimental/check_shapes/inheritance.py
+++ b/gpflow/experimental/check_shapes/inheritance.py
@@ -17,6 +17,9 @@ Code for inheriting shape checks from a super class.
 import inspect
 from typing import Callable, Optional, cast
 
+from gpflow.experimental.check_shapes.check_shapes import null_check_shapes
+from gpflow.experimental.check_shapes.config import get_enable_check_shapes
+
 from ..utils import experimental
 from .accessors import maybe_get_check_shapes
 from .base_types import C
@@ -30,6 +33,9 @@ def inherit_check_shapes(func: C) -> C:
 
     See: `Class inheritance`_.
     """
+    if not get_enable_check_shapes():
+        return null_check_shapes(func)
+
     return cast(C, _InheritCheckShapes(func))
 
 

--- a/tests/gpflow/experimental/check_shapes/conftest.py
+++ b/tests/gpflow/experimental/check_shapes/conftest.py
@@ -1,0 +1,38 @@
+# Copyright 2022 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Iterable
+
+import pytest
+
+from gpflow.experimental.check_shapes.config import (
+    DocstringFormat,
+    get_enable_check_shapes,
+    get_rewrite_docstrings,
+    set_enable_check_shapes,
+    set_rewrite_docstrings,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_settings() -> Iterable[None]:
+    # Ensure that:
+    # 1: `check_shapes` is enabled when running these tests.
+    # 2: If a test manipulates `check_shapes` settings, they are reset after the test.
+    old_enable = get_enable_check_shapes()
+    old_rewrite_docstrings = get_rewrite_docstrings()
+    set_enable_check_shapes(True)
+    set_rewrite_docstrings(DocstringFormat.SPHINX)
+    yield
+    set_rewrite_docstrings(old_rewrite_docstrings)
+    set_enable_check_shapes(old_enable)

--- a/tests/gpflow/experimental/check_shapes/test_config.py
+++ b/tests/gpflow/experimental/check_shapes/test_config.py
@@ -1,0 +1,64 @@
+# Copyright 2022 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from gpflow.experimental.check_shapes.config import (
+    DocstringFormat,
+    disable_check_shapes,
+    get_enable_check_shapes,
+    get_rewrite_docstrings,
+    set_enable_check_shapes,
+    set_rewrite_docstrings,
+)
+
+
+def test_get_set_enable_check_shapes() -> None:
+    assert get_enable_check_shapes()
+    set_enable_check_shapes(False)
+    assert not get_enable_check_shapes()
+    set_enable_check_shapes(True)
+    assert get_enable_check_shapes()
+
+
+def test_disable_check_shapes() -> None:
+    assert get_enable_check_shapes()
+
+    with disable_check_shapes():
+        assert not get_enable_check_shapes()
+        with disable_check_shapes():
+            assert not get_enable_check_shapes()
+        assert not get_enable_check_shapes()
+
+    assert get_enable_check_shapes()
+
+    with pytest.raises(ValueError):
+        with disable_check_shapes():
+            assert not get_enable_check_shapes()
+            raise ValueError("test error")
+
+    assert get_enable_check_shapes()
+
+
+def test_get_set_rewrite_docstrings() -> None:
+    assert DocstringFormat.SPHINX == get_rewrite_docstrings()
+    set_rewrite_docstrings(None)
+    assert DocstringFormat.NONE == get_rewrite_docstrings()
+    set_rewrite_docstrings("sphinx")
+    assert DocstringFormat.SPHINX == get_rewrite_docstrings()
+    set_rewrite_docstrings("none")
+    assert DocstringFormat.NONE == get_rewrite_docstrings()
+    set_rewrite_docstrings(DocstringFormat.SPHINX)
+    assert DocstringFormat.SPHINX == get_rewrite_docstrings()
+    set_rewrite_docstrings(DocstringFormat.NONE)
+    assert DocstringFormat.NONE == get_rewrite_docstrings()

--- a/tests/gpflow/experimental/check_shapes/test_parser.py
+++ b/tests/gpflow/experimental/check_shapes/test_parser.py
@@ -19,6 +19,7 @@ from typing import Optional, Tuple
 
 import pytest
 
+from gpflow.experimental.check_shapes.config import set_rewrite_docstrings
 from gpflow.experimental.check_shapes.parser import parse_and_rewrite_docstring, parse_argument_spec
 from gpflow.experimental.check_shapes.specs import ParsedArgumentSpec
 
@@ -752,3 +753,11 @@ def test_parse_argument_spec(data: TestData) -> None:
 def test_parse_and_rewrite_docstring(data: TestData) -> None:
     rewritten_docstring = parse_and_rewrite_docstring(data.doc, data.expected_specs)
     assert data.expected_doc == rewritten_docstring
+
+
+@pytest.mark.parametrize("data", _TEST_DATA, ids=str)
+def test_parse_and_rewrite_docstring__disable(data: TestData) -> None:
+    set_rewrite_docstrings(None)
+
+    rewritten_docstring = parse_and_rewrite_docstring(data.doc, data.expected_specs)
+    assert data.doc == rewritten_docstring


### PR DESCRIPTION
Add configuration of check_shapes.
1. Allow people to disable shape checking.
2. Allow people to set the format of docstrings, though right now we only support "Sphinx" and "None".