### PR TITLE
Speed up posterior computation

### DIFF
--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -355,7 +355,7 @@ class GPRPosterior(AbstractPosterior):
             cov = tf.broadcast_to(tf.expand_dims(cov, -3), cov_shape)  # [..., R, N, N]
 
         else:
-            cov = Knn - tf.einsum("...ij,...jk,...ki->...i", Knm, Qinv, Kmn)  # [..., N]
+            cov = Knn - tf.einsum("...ij,...ji->...i", Knm @ Qinv, Kmn)  # [..., N]
             cov_shape = tf.concat([leading_dims, [num_func, N]], 0)  # [..., R, N]
             cov = tf.broadcast_to(tf.expand_dims(cov, -2), cov_shape)  # [..., R, N]
             cov = tf.linalg.adjoint(cov)


### PR DESCRIPTION
Turns out the recent change to posteriors to make computations more memory efficient also slowed them down slightly for small sample sizes. This version appears to be as fast as previously for small sample sizes (and significantly faster for large sample sizes).