### PR TITLE
Enable warnings when returning 'Any'.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -131,6 +131,7 @@ disable=missing-docstring,
         too-many-lines,
         fixme,
         too-many-branches,
+        ungrouped-imports,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -232,7 +232,7 @@ class Parameter(tfp.util.TransformedVariable):
 
         This attribute cannot be set directly. Use :func:`gpflow.set_trainable`.
         """
-        return self.unconstrained_variable.trainable
+        return self.unconstrained_variable.trainable  # type: ignore
 
     def assign(
         self,

--- a/gpflow/conditionals/conditionals.py
+++ b/gpflow/conditionals/conditionals.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 from ..base import MeanAndVariance
 from ..inducing_variables import InducingVariables
 from ..kernels import Kernel
-from ..posteriors import VGPPosterior, get_posterior_class
+from ..posteriors import BasePosterior, VGPPosterior, get_posterior_class
 from .dispatch import conditional
 
 
@@ -68,7 +68,7 @@ def _sparse_conditional(
     """
     posterior_class = get_posterior_class(kernel, inducing_variable)
 
-    posterior = posterior_class(
+    posterior: BasePosterior = posterior_class(
         kernel,
         inducing_variable,
         f,

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -107,9 +107,10 @@ def _default(value: _Values) -> Any:
 def _default_numeric_type_factory(
     valid_types: Mapping[str, type], enum_key: _Values, type_name: str
 ) -> type:
-    value = _default(enum_key)
-    if value in valid_types.values():
+    value: Union[str, type] = _default(enum_key)
+    if isinstance(value, type) and (value in valid_types.values()):
         return value
+    assert isinstance(value, str)  # Hint for mypy
     if value not in valid_types:
         raise TypeError(f"Config cannot recognize {type_name} type.")
     return valid_types[value]
@@ -128,14 +129,13 @@ def _default_float_factory() -> type:
 def _default_jitter_factory() -> float:
     value = _default(_Values.JITTER)
     try:
-        value = float(value)
+        return float(value)
     except ValueError:
         raise TypeError("Config cannot set the jitter value with non float type.")
-    return value
 
 
 def _default_positive_bijector_factory() -> str:
-    bijector_type = _default(_Values.POSITIVE_BIJECTOR)
+    bijector_type: str = _default(_Values.POSITIVE_BIJECTOR)
     if bijector_type not in positive_bijector_type_map().keys():
         raise TypeError(
             "Config cannot set the passed value as a default positive bijector."
@@ -147,14 +147,14 @@ def _default_positive_bijector_factory() -> str:
 def _default_positive_minimum_factory() -> float:
     value = _default(_Values.POSITIVE_MINIMUM)
     try:
-        value = float(value)
+        return float(value)
     except ValueError:
         raise TypeError("Config cannot set the positive_minimum value with non float type.")
-    return value
 
 
 def _default_summary_fmt_factory() -> Optional[str]:
-    return _default(_Values.SUMMARY_FMT)
+    result: Optional[str] = _default(_Values.SUMMARY_FMT)
+    return result
 
 
 # The following type alias is for the Config class, to help a static analyser distinguish

--- a/gpflow/experimental/check_shapes/parser.py
+++ b/gpflow/experimental/check_shapes/parser.py
@@ -262,7 +262,7 @@ def parse_argument_spec(argument_spec: str) -> ParsedArgumentSpec:
     Parse a `check_shapes` argument specification.
     """
     tree = _ARGUMENT_SPEC_PARSER.parse(argument_spec)
-    specs = _ParseArgumentSpec().visit(tree)
+    specs: ParsedArgumentSpec = _ParseArgumentSpec().visit(tree)
     return specs
 
 
@@ -277,4 +277,5 @@ def parse_and_rewrite_docstring(
         return None
 
     tree = _DOCSTRING_PARSER.parse(docstring)
-    return _RewriteDocString(docstring, argument_specs).visit(tree)
+    rewritten_docstring: str = _RewriteDocString(docstring, argument_specs).visit(tree)
+    return rewritten_docstring

--- a/gpflow/experimental/check_shapes/shapes.py
+++ b/gpflow/experimental/check_shapes/shapes.py
@@ -16,7 +16,7 @@ Code for extracting shapes from object.
 """
 import collections.abc as cabc
 from functools import singledispatch
-from typing import Any, Sequence, Union
+from typing import Any, Sequence, Tuple, Union
 
 import numpy as np
 import tensorflow as tf
@@ -60,7 +60,8 @@ def get_sequence_shape(shaped: Sequence[Any]) -> Shape:
 
 @get_shape.register(np.ndarray)
 def get_ndarray_shape(shaped: AnyNDArray) -> Shape:
-    return shaped.shape
+    result: Tuple[int, ...] = shaped.shape
+    return result
 
 
 @get_shape.register(tf.Tensor)

--- a/gpflow/kernels/base.py
+++ b/gpflow/kernels/base.py
@@ -277,7 +277,7 @@ class ReducingCombination(Combination):
 class Sum(ReducingCombination):
     @property
     def _reduce(self) -> Callable[[Sequence[TensorType]], TensorType]:
-        return tf.add_n
+        return tf.add_n  # type: ignore
 
 
 class Product(ReducingCombination):

--- a/gpflow/kernels/convolutional.py
+++ b/gpflow/kernels/convolutional.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Sequence
+from typing import Optional, Sequence, cast
 
 import numpy as np
 import tensorflow as tf
 
-from ..base import AnyNDArray, Parameter, TensorType
+from ..base import Parameter, TensorType
 from ..config import default_float
 from ..utilities import to_default_float
 from .base import Kernel
@@ -60,7 +60,9 @@ class Convolutional(Kernel):
     # @lru_cache() -- Can we do some kind of memoizing with TF2?
     def get_patches(self, X: TensorType) -> tf.Tensor:
         """
-        Extracts patches from the images X. Patches are extracted separately for each of the colour channels.
+        Extracts patches from the images X. Patches are extracted separately for each of the colour
+        channels.
+
         :param X: (N x input_dim)
         :return: Patches (N, num_patches, patch_shape)
         """
@@ -100,8 +102,8 @@ class Convolutional(Kernel):
         return tf.reduce_sum(bigK * W2[None, :, :], [1, 2]) / self.num_patches ** 2.0
 
     @property
-    def patch_len(self) -> AnyNDArray:
-        return np.prod(self.patch_shape)
+    def patch_len(self) -> int:
+        return cast(int, np.prod(self.patch_shape))
 
     @property
     def num_patches(self) -> int:

--- a/gpflow/kernels/linears.py
+++ b/gpflow/kernels/linears.py
@@ -49,7 +49,8 @@ class Linear(Kernel):
         """
         Whether ARD behaviour is active.
         """
-        return self.variance.shape.ndims > 0
+        ndims: int = self.variance.shape.ndims
+        return ndims > 0
 
     def K(self, X: TensorType, X2: Optional[TensorType] = None) -> tf.Tensor:
         if X2 is None:

--- a/gpflow/kernels/misc.py
+++ b/gpflow/kernels/misc.py
@@ -79,7 +79,8 @@ class ArcCosine(Kernel):
         """
         Whether ARD behaviour is active.
         """
-        return self.weight_variances.shape.ndims > 0
+        ndims: int = self.weight_variances.shape.ndims
+        return ndims > 0
 
     def _weighted_product(self, X: TensorType, X2: Optional[TensorType] = None) -> tf.Tensor:
         if X2 is None:

--- a/gpflow/kernels/multioutput/kernels.py
+++ b/gpflow/kernels/multioutput/kernels.py
@@ -197,7 +197,7 @@ class LinearCoregionalization(IndependentLatent, Combination):
 
     @property
     def num_latent_gps(self) -> int:
-        return self.W.shape[-1]  # L
+        return self.W.shape[-1]  # type: ignore # L
 
     @property
     def latent_kernels(self) -> Tuple[Kernel, ...]:

--- a/gpflow/kernels/stationaries.py
+++ b/gpflow/kernels/stationaries.py
@@ -62,7 +62,8 @@ class Stationary(Kernel):
         """
         Whether ARD behaviour is active.
         """
-        return self.lengthscales.shape.ndims > 0
+        ndims: int = self.lengthscales.shape.ndims
+        return ndims > 0
 
     def scale(self, X: TensorType) -> TensorType:
         X_scaled = X / self.lengthscales if X is not None else X

--- a/gpflow/models/cglb.py
+++ b/gpflow/models/cglb.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import namedtuple
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, NamedTuple, Optional, Tuple
 
 import tensorflow as tf
 
@@ -365,9 +364,15 @@ def cglb_conjugate_gradient(
 
     :return: `v` where `v` approximately satisfies :math:`Kv = b`.
     """
-    CGState = namedtuple("CGState", ["i", "v", "r", "p", "rz"])
 
-    def stopping_criterion(state: CGState) -> bool:
+    class CGState(NamedTuple):
+        i: tf.Tensor
+        v: tf.Tensor
+        r: tf.Tensor
+        p: tf.Tensor
+        rz: tf.Tensor
+
+    def stopping_criterion(state: CGState) -> tf.Tensor:
         return (0.5 * state.rz > cg_tolerance) and (state.i < max_steps)
 
     def cg_step(state: CGState) -> List[CGState]:

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -133,6 +133,7 @@ class GPModel(BayesianModel):
         problematic assumptions re the output dimensions of mean_function.
         See https://github.com/GPflow/GPflow/issues/1343
         """
+        num_latent_gps: int
         if isinstance(kernel, MultioutputKernel):
             # MultioutputKernels already have num_latent_gps attributes
             num_latent_gps = kernel.num_latent_gps

--- a/gpflow/models/training_mixins.py
+++ b/gpflow/models/training_mixins.py
@@ -68,9 +68,10 @@ class InternalDataTrainingLossMixin:
         :param compile: If `True` (default), compile the training loss function in a TensorFlow
             graph by wrapping it in tf.function()
         """
+        closure = self.training_loss
         if compile:
-            return tf.function(self.training_loss)
-        return self.training_loss
+            closure = tf.function(closure)
+        return closure
 
 
 class ExternalDataTrainingLossMixin:

--- a/gpflow/models/util.py
+++ b/gpflow/models/util.py
@@ -51,10 +51,10 @@ def training_loss_closure(
     model: BayesianModel, data: Data, **closure_kwargs: Any
 ) -> Callable[[], tf.Tensor]:
     if isinstance(model, ExternalDataTrainingLossMixin):
-        return model.training_loss_closure(data, **closure_kwargs)
+        return model.training_loss_closure(data, **closure_kwargs)  # type: ignore
     else:
         _assert_equal_data(model.data, data)
-        return model.training_loss_closure(**closure_kwargs)
+        return model.training_loss_closure(**closure_kwargs)  # type: ignore
 
 
 def training_loss(model: BayesianModel, data: Data) -> tf.Tensor:

--- a/gpflow/optimizers/mcmc.py
+++ b/gpflow/optimizers/mcmc.py
@@ -110,7 +110,7 @@ class SamplingHelper:
 
             return log_prob, grad_fn
 
-        return _target_log_prob_fn_closure
+        return _target_log_prob_fn_closure  # type: ignore
 
     def convert_to_constrained_values(
         self, hmc_samples: Sequence[tf.Tensor]

--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -321,7 +321,7 @@ class NaturalGradient(tf.optimizers.Optimizer):
         q_sqrt.assign(varsqrt_new)
 
     def get_config(self) -> Dict[str, Any]:
-        config = super().get_config()
+        config: Dict[str, Any] = super().get_config()
         config.update({"gamma": self._serialize_hyperparameter("gamma")})
         return config
 

--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -696,7 +696,7 @@ class BasePosterior(AbstractPosterior):
 class IndependentPosterior(BasePosterior):
     def _post_process_mean_and_cov(
         self, mean: TensorType, cov: TensorType, full_cov: bool, full_output_cov: bool
-    ) -> tf.Tensor:
+    ) -> MeanAndVariance:
         return mean, expand_independent_outputs(cov, full_cov, full_output_cov)
 
     def _get_Kff(self, Xnew: TensorType, full_cov: bool) -> tf.Tensor:
@@ -1017,7 +1017,7 @@ def create_posterior(
 ) -> BasePosterior:
     posterior_class = get_posterior_class(kernel, inducing_variable)
     precompute_cache = _validate_precompute_cache_type(precompute_cache)
-    return posterior_class(
+    return posterior_class(  # type: ignore
         kernel,
         inducing_variable,
         q_mu,

--- a/gpflow/utilities/multipledispatch.py
+++ b/gpflow/utilities/multipledispatch.py
@@ -21,7 +21,8 @@ from multipledispatch.variadic import isvariadic
 __all__ = ["Dispatcher"]
 
 
-_C = TypeVar("_C", bound=Callable[..., Any])
+AnyCallable = Callable[..., Any]
+_C = TypeVar("_C", bound=AnyCallable)
 Types = Union[Type[Any], Tuple[Type[Any], ...]]
 
 
@@ -38,18 +39,21 @@ class Dispatcher(GeneratorDispatcher):
 
     def register(self, *types: Types, **kwargs: Any) -> Callable[[_C], _C]:
         # Override to add type hints...
-        return super().register(*types, **kwargs)
+        result: Callable[[_C], _C] = super().register(*types, **kwargs)
+        return result
 
-    def dispatch(self, *types: Types) -> Optional[Callable[..., Any]]:
+    def dispatch(self, *types: Types) -> Optional[AnyCallable]:
         """
         Returns matching function for `types`; if not existing returns None.
         """
+        result: AnyCallable
         if types in self.funcs:
-            return self.funcs[types]
+            result = self.funcs[types]
+            return result
 
         return self.get_first_occurrence(*types)
 
-    def dispatch_or_raise(self, *types: Types) -> Callable[..., Any]:
+    def dispatch_or_raise(self, *types: Types) -> AnyCallable:
         """
         Returns matching function for `types`; if not existing raises an error.
         """
@@ -60,7 +64,7 @@ class Dispatcher(GeneratorDispatcher):
             )
         return f
 
-    def get_first_occurrence(self, *types: Types) -> Optional[Callable[..., Any]]:
+    def get_first_occurrence(self, *types: Types) -> Optional[AnyCallable]:
         """
         Returns the first occurrence of a matching function
 
@@ -71,6 +75,7 @@ class Dispatcher(GeneratorDispatcher):
         `None` is returned.
         """
         n = len(types)
+        result: AnyCallable
         for signature in self.ordering:
             if len(signature) == n and all(map(issubclass, types, signature)):  # type: ignore
                 result = self.funcs[signature]

--- a/gpflow/utilities/traversal.py
+++ b/gpflow/utilities/traversal.py
@@ -110,12 +110,12 @@ def tabulate_module_summary(module: tf.Module, tablefmt: Optional[str] = None) -
         if hasattr(var, "transform") and var.transform is not None:
             if isinstance(var.transform, tfp.bijectors.Chain):
                 return " + ".join(b.__class__.__name__ for b in var.transform.bijectors[::-1])
-            return var.transform.__class__.__name__
+            return var.transform.__class__.__name__  # type: ignore
         return None
 
     def get_prior(path: Path, var: LeafComponent) -> Optional[str]:
         if hasattr(var, "prior") and var.prior is not None:
-            return var.prior.name
+            return var.prior.name  # type: ignore
         return None
 
     # list of (column_name: str, column_getter: Callable[[tf.Variable], str]) tuples:
@@ -256,10 +256,11 @@ def deepcopy(input_module: M, memo: Optional[Dict[int, Any]] = None) -> M:
     tfp.bijectors.Bijector to allow the deepcopy of the tf.Module.
 
     :param input_module: tf.Module including keras.Model, keras.layers.Layer and gpflow.Module.
-    :param memo: passed through to func:`copy.deepcopy` (see https://docs.python.org/3/library/copy.html).
+    :param memo: passed through to func:`copy.deepcopy`
+        (see https://docs.python.org/3/library/copy.html).
     :return: Returns a deepcopy of an input object.
     """
-    return copy.deepcopy(reset_cache_bijectors(input_module), memo)
+    return copy.deepcopy(reset_cache_bijectors(input_module), memo)  # type: ignore
 
 
 def freeze(input_module: M) -> M:
@@ -282,8 +283,8 @@ def traverse_module(
     target_types: Tuple[Type[Any], ...],
 ) -> State:
     """
-    Recursively traverses `m`, accumulating in `acc` a path and a state until it finds an object of type
-    in `target_types` to apply `update_cb` to update the accumulator `acc` and/or the object.
+    Recursively traverses `m`, accumulating in `acc` a path and a state until it finds an object of
+    type in `target_types` to apply `update_cb` to update the accumulator `acc` and/or the object.
 
     :param m: tf.Module, tf.Variable or gpflow.Parameter
     :param acc: Tuple of path and state

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,5 +11,3 @@ warn_unused_ignores = False
 ; It would actually be good to disallow implicit reexport, but that will take some effort to be
 ; strict about our use of __all__.
 implicit_reexport = True
-; Remove this when we think we're done.
-warn_return_any = False

--- a/tests/gpflow/conditionals/test_broadcasted_conditionals.py
+++ b/tests/gpflow/conditionals/test_broadcasted_conditionals.py
@@ -16,6 +16,8 @@ This test suite will check if the conditionals broadcast correctly
 when the input tensors have leading dimensions.
 """
 
+from typing import cast
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -91,15 +93,18 @@ def test_conditional_broadcasting(full_cov: bool, white: bool, conditional_type:
     num_samples = 5
 
     def sample_conditional_fn(X: tf.Tensor) -> SamplesMeanAndVariance:
-        return sample_conditional(
-            X,
-            inducing_variable,
-            kernel,
-            tf.convert_to_tensor(q_mu),
-            q_sqrt=tf.convert_to_tensor(q_sqrt),
-            white=white,
-            full_cov=full_cov,
-            num_samples=num_samples,
+        return cast(
+            SamplesMeanAndVariance,
+            sample_conditional(
+                X,
+                inducing_variable,
+                kernel,
+                tf.convert_to_tensor(q_mu),
+                q_sqrt=tf.convert_to_tensor(q_sqrt),
+                white=white,
+                full_cov=full_cov,
+                num_samples=num_samples,
+            ),
         )
 
     samples = np.array([sample_conditional_fn(X)[0] for X in Data.SX])

--- a/tests/gpflow/conditionals/test_multioutput.py
+++ b/tests/gpflow/conditionals/test_multioutput.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Sequence, Tuple
+from typing import Callable, List, Sequence, Tuple, cast
 
 import numpy as np
 import pytest
@@ -327,7 +327,7 @@ QSqrtFactory = Callable[[tf.Tensor, int], tf.Tensor]
     params=[lambda _, __: None, lambda LM, R: tf.eye(LM, batch_shape=(R,))],
 )
 def _q_sqrt_factory_fixture(request: SubRequest) -> QSqrtFactory:
-    return request.param
+    return cast(QSqrtFactory, request.param)
 
 
 @pytest.mark.parametrize("R", [1, 2, 5])

--- a/tests/gpflow/conditionals/test_uncertain_conditional.py
+++ b/tests/gpflow/conditionals/test_uncertain_conditional.py
@@ -252,7 +252,7 @@ def test_quadrature(white: bool, mean: Optional[str]) -> None:
 
     effective_mean = mean_function or (lambda X: 0.0)
 
-    def conditional_fn(X: tf.Tensor) -> MeanAndVariance:
+    def conditional_fn(X: tf.Tensor) -> tf.Tensor:
         return conditional(
             X,
             inducing_variable,

--- a/tests/gpflow/conftest.py
+++ b/tests/gpflow/conftest.py
@@ -12,20 +12,22 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from typing import cast
+
 import pytest
 from _pytest.fixtures import SubRequest
 
 
 @pytest.fixture(name="full_cov", params=[True, False])
 def _full_cov_fixture(request: SubRequest) -> bool:
-    return request.param
+    return cast(bool, request.param)
 
 
 @pytest.fixture(name="full_output_cov", params=[True, False])
 def _full_output_cov_fixture(request: SubRequest) -> bool:
-    return request.param
+    return cast(bool, request.param)
 
 
 @pytest.fixture(name="whiten", params=[True, False])
 def _whiten_fixture(request: SubRequest) -> bool:
-    return request.param
+    return cast(bool, request.param)

--- a/tests/gpflow/experimental/check_shapes/test_integration.py
+++ b/tests/gpflow/experimental/check_shapes/test_integration.py
@@ -15,7 +15,7 @@
 # pylint: disable=unused-argument  # Bunch of fake functions below has unused arguments.
 # pylint: disable=no-member  # PyLint struggles with TensorFlow.
 
-from typing import Callable, Tuple
+from typing import Callable
 
 import numpy as np
 import pytest
@@ -88,7 +88,7 @@ def test_check_shapes__tensorflow_compilation(
         "x: [n]",
         "return: [n]",
     )
-    def f(x: tf.Tensor) -> Tuple[tf.Tensor]:
+    def f(x: tf.Tensor) -> tf.Tensor:
         return (x - target) ** 2
 
     v = tf.Variable(np.linspace(0.0, 1.0))

--- a/tests/gpflow/kernels/reference.py
+++ b/tests/gpflow/kernels/reference.py
@@ -71,6 +71,7 @@ def ref_periodic_kernel(
     """
     sine_arg = np.pi * (X[:, None, :] - X[None, :, :]) / period
     sine_base = np.sin(sine_arg) / lengthscales
+    exp_dist: AnyNDArray
     if base_name in {"RBF", "SquaredExponential"}:
         dist = 0.5 * np.sum(np.square(sine_base), axis=-1)
         exp_dist = np.exp(-dist)

--- a/tests/gpflow/kernels/test_kernels.py
+++ b/tests/gpflow/kernels/test_kernels.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Optional, Sequence, Tuple, Type, Union, cast
 
 import numpy as np
 import pytest
@@ -79,7 +79,8 @@ def _ref_changepoints(
     stoppers = np.concatenate([stoppers, ones], axis=2)
 
     kernel_stack = np.stack([k(X) for k in kernels], axis=2)
-    return (kernel_stack * starters * stoppers).sum(axis=2)
+
+    return cast(AnyNDArray, (kernel_stack * starters * stoppers).sum(axis=2))
 
 
 @pytest.mark.parametrize("variance, lengthscales", [[2.3, 1.4]])
@@ -318,6 +319,8 @@ def test_conv_diag() -> None:
     kernel_full = np.diagonal(kernel(X, full_cov=True))
     kernel_diag = kernel(X, full_cov=False)
     assert np.allclose(kernel_full, kernel_diag)
+    assert 4 == kernel.patch_len
+    assert 4 == kernel.num_patches
 
 
 # Add a rbf and linear kernel, make sure the result is the same as adding the result of

--- a/tests/gpflow/models/test_variational.py
+++ b/tests/gpflow/models/test_variational.py
@@ -34,7 +34,10 @@ rng = np.random.RandomState(1)
 def univariate_log_marginal_likelihood(
     y: AnyNDArray, K: AnyNDArray, noise_var: AnyNDArray
 ) -> AnyNDArray:
-    return -0.5 * y * y / (K + noise_var) - 0.5 * np.log(K + noise_var) - 0.5 * np.log(np.pi * 2.0)
+    return cast(
+        AnyNDArray,
+        -0.5 * y * y / (K + noise_var) - 0.5 * np.log(K + noise_var) - 0.5 * np.log(np.pi * 2.0),
+    )
 
 
 def univariate_posterior(
@@ -49,12 +52,16 @@ def univariate_prior_KL(
     meanA: AnyNDArray, meanB: AnyNDArray, varA: AnyNDArray, varB: AnyNDArray
 ) -> AnyNDArray:
     # KL[ qA | qB ] = E_{qA} \log [qA / qB] where qA and qB are univariate normal distributions.
-    return 0.5 * (
-        np.log(varB)
-        - np.log(varA)
-        - 1.0
-        + varA / varB
-        + cast(AnyNDArray, meanB - meanA) * cast(AnyNDArray, meanB - meanA) / varB
+    return cast(
+        AnyNDArray,
+        0.5
+        * (
+            np.log(varB)
+            - np.log(varA)
+            - 1.0
+            + varA / varB
+            + cast(AnyNDArray, meanB - meanA) * cast(AnyNDArray, meanB - meanA) / varB
+        ),
     )
 
 
@@ -73,12 +80,15 @@ def multivariate_prior_KL(
     constantTerm = -0.5 * K
     priorLogDeterminantTerm = 0.5 * np.linalg.slogdet(covB)[1]
     variationalLogDeterminantTerm = -0.5 * np.linalg.slogdet(covA)[1]
-    return (
-        traceTerm
-        + mahalanobisTerm
-        + constantTerm
-        + priorLogDeterminantTerm
-        + variationalLogDeterminantTerm
+    return cast(
+        AnyNDArray,
+        (
+            traceTerm
+            + mahalanobisTerm
+            + constantTerm
+            + priorLogDeterminantTerm
+            + variationalLogDeterminantTerm
+        ),
     )
 
 

--- a/tests/gpflow/posteriors/test_bo_integration.py
+++ b/tests/gpflow/posteriors/test_bo_integration.py
@@ -11,7 +11,19 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Any, Callable, DefaultDict, Dict, Iterator, Mapping, Set, Tuple, Type, TypeVar
+from typing import (
+    Any,
+    Callable,
+    DefaultDict,
+    Generic,
+    Iterator,
+    List,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    cast,
+)
 
 import numpy as np
 import pytest
@@ -28,11 +40,27 @@ from gpflow.models import GPR, SGPR, SVGP, VGP, GPModel, training_loss_closure
 from gpflow.models.vgp import update_vgp_data
 from gpflow.posteriors import AbstractPosterior, PrecomputeCacheType
 
-_CreateModel = Callable[[RegressionData], GPModel]
-_C = TypeVar("_C", bound=_CreateModel)
+_M = TypeVar("_M", bound=GPModel, covariant=True)
+_CreateModel = Callable[[RegressionData], _M]
 
-_MULTI_OUTPUT = "multi_output"
-_MODEL_FACTORIES: Dict[_CreateModel, Mapping[str, Any]] = {}
+
+# I'd like to make this a `dataclass`, but mypy get confused about `create_model` being a function
+# member, but that doesn't take `self`.
+class _ModelFactory(Generic[_M]):
+    def __init__(
+        self,
+        create_model: _CreateModel[_M],
+        multi_output: bool,
+        atol: float,
+        rtol: float,
+    ) -> None:
+        self.create_model = create_model
+        self.multi_output = multi_output
+        self.atol = atol
+        self.rtol = rtol
+
+
+_MODEL_FACTORIES: List[_ModelFactory[Any]] = []
 
 # This exists to make it easy to disable tf.function, for debugging.
 _COMPILE = True
@@ -53,19 +81,19 @@ def _register_posterior_bo_integration_test(
 
 
 def model_factory(
-    *flags: str, atol: float = _DEFAULT_ATOL, rtol: float = _DEFAULT_RTOL
-) -> Callable[[_C], _C]:
+    multi_output: bool = False, atol: float = _DEFAULT_ATOL, rtol: float = _DEFAULT_RTOL
+) -> Callable[[_CreateModel[_M]], _ModelFactory[_M]]:
     """ Decorator for adding a function to the `_MODEL_FACTORIES` list. """
 
-    properties = {
-        "atol": atol,
-        "rtol": rtol,
-        **{flag: True for flag in flags},
-    }
-
-    def register(create_model: _C) -> _C:
-        _MODEL_FACTORIES[create_model] = properties
-        return create_model
+    def register(create_model: _CreateModel[_M]) -> _ModelFactory[_M]:
+        model_factory = _ModelFactory(
+            create_model,
+            multi_output,
+            atol,
+            rtol,
+        )
+        _MODEL_FACTORIES.append(model_factory)
+        return model_factory
 
     return register
 
@@ -126,7 +154,7 @@ def create_svgp__independent_single_output(data: RegressionData) -> SVGP:
     )
 
 
-@model_factory(_MULTI_OUTPUT)
+@model_factory(multi_output=True)
 def create_svgp__fully_correlated_multi_output(data: RegressionData) -> SVGP:
     n_outputs = data[1].shape[1]
     kernel = gpflow.kernels.SharedIndependent(create_kernel(), output_dim=n_outputs)
@@ -142,7 +170,7 @@ def create_svgp__fully_correlated_multi_output(data: RegressionData) -> SVGP:
     )
 
 
-@model_factory(_MULTI_OUTPUT)
+@model_factory(multi_output=True)
 def create_svgp__independent_multi_output(data: RegressionData) -> SVGP:
     n_outputs = data[1].shape[1]
     kernel = gpflow.kernels.SharedIndependent(create_kernel(), output_dim=n_outputs)
@@ -160,7 +188,7 @@ def create_svgp__independent_multi_output(data: RegressionData) -> SVGP:
     )
 
 
-@model_factory(_MULTI_OUTPUT)
+@model_factory(multi_output=True)
 def create_svgp__fallback_independent_latent_posterior(data: RegressionData) -> SVGP:
     n_outputs = data[1].shape[1]
     rng = np.random.default_rng(20220131)
@@ -182,7 +210,7 @@ def create_svgp__fallback_independent_latent_posterior(data: RegressionData) -> 
     )
 
 
-@model_factory(_MULTI_OUTPUT)
+@model_factory(multi_output=True)
 def create_svgp__linear_coregionalization(data: RegressionData) -> SVGP:
     n_outputs = data[1].shape[1]
     rng = np.random.default_rng(20220131)
@@ -204,27 +232,12 @@ def create_svgp__linear_coregionalization(data: RegressionData) -> SVGP:
 
 
 @pytest.fixture(params=_MODEL_FACTORIES)
-def _create_model(request: SubRequest) -> _CreateModel:
-    return request.param
+def _model_factory(request: SubRequest) -> _ModelFactory[Any]:
+    return cast(_ModelFactory[Any], request.param)
 
 
 @pytest.fixture
-def _multi_output(_create_model: _CreateModel) -> bool:
-    return _MULTI_OUTPUT in _MODEL_FACTORIES[_create_model]
-
-
-@pytest.fixture
-def _rtol(_create_model: _CreateModel) -> float:
-    return _MODEL_FACTORIES[_create_model]["rtol"]
-
-
-@pytest.fixture
-def _atol(_create_model: _CreateModel) -> float:
-    return _MODEL_FACTORIES[_create_model]["atol"]
-
-
-@pytest.fixture
-def _f_minimum(_multi_output: bool) -> tf.Tensor:
+def _f_minimum(_model_factory: _ModelFactory[Any]) -> tf.Tensor:
     return (
         tf.constant(
             [
@@ -234,7 +247,7 @@ def _f_minimum(_multi_output: bool) -> tf.Tensor:
             ],
             dtype=default_float(),
         )
-        if _multi_output
+        if _model_factory.multi_output
         else tf.constant([[0.3, 0.5]], dtype=default_float())
     )
 
@@ -323,12 +336,10 @@ def _optimize(_data: Tuple[tf.Variable, tf.Variable]) -> Callable[[GPModel], Non
 
 def test_posterior_bo_integration__predict_f(
     register_posterior_bo_integration_test: Callable[[AbstractPosterior], None],
-    _create_model: _CreateModel,
+    _model_factory: _ModelFactory[Any],
     _data: Tuple[tf.Variable, tf.Variable],
     _extend_data: Callable[[GPModel], Iterator[int]],
     _X_new: tf.Tensor,
-    _rtol: float,
-    _atol: float,
 ) -> None:
     """
     Check that data added incrementally is correctly reflected in `predict_f`.
@@ -337,7 +348,7 @@ def test_posterior_bo_integration__predict_f(
     n_rows_new = _X_new.shape[0]
     n_outputs = Y.shape[1]
 
-    model = _create_model(_data)
+    model = _model_factory.create_model(_data)
     posterior = model.posterior(PrecomputeCacheType.VARIABLE)
     register_posterior_bo_integration_test(posterior)
     predict_f = posterior.predict_f
@@ -351,22 +362,24 @@ def test_posterior_bo_integration__predict_f(
         np.testing.assert_equal((n_rows_new, n_outputs), compiled_mean.shape)
         np.testing.assert_equal((n_rows_new, n_outputs), compiled_var.shape)
 
-        eager_model = _create_model(_data)
+        eager_model = _model_factory.create_model(_data)
         eager_mean, eager_var = eager_model.predict_f(_X_new)
 
-        np.testing.assert_allclose(eager_mean, compiled_mean, rtol=_rtol, atol=_atol)
-        np.testing.assert_allclose(eager_var, compiled_var, rtol=_rtol, atol=_atol)
+        np.testing.assert_allclose(
+            eager_mean, compiled_mean, rtol=_model_factory.rtol, atol=_model_factory.atol
+        )
+        np.testing.assert_allclose(
+            eager_var, compiled_var, rtol=_model_factory.rtol, atol=_model_factory.atol
+        )
 
 
 def test_posterior_bo_integration__optimization(
     register_posterior_bo_integration_test: Callable[[AbstractPosterior], None],
-    _create_model: _CreateModel,
+    _model_factory: _ModelFactory[Any],
     _data: Tuple[tf.Variable, tf.Variable],
     _extend_data: Callable[[GPModel], Iterator[int]],
     _X_new: tf.Tensor,
     _optimize: Callable[[GPModel], None],
-    _rtol: float,
-    _atol: float,
 ) -> None:
     """
     Check that data added incrementally is considered when optimizing a model.
@@ -375,7 +388,7 @@ def test_posterior_bo_integration__optimization(
     n_rows_new = _X_new.shape[0]
     n_outputs = Y.shape[1]
 
-    model = _create_model(_data)
+    model = _model_factory.create_model(_data)
     posterior = model.posterior(PrecomputeCacheType.VARIABLE)
     register_posterior_bo_integration_test(posterior)
     predict_f = posterior.predict_f
@@ -395,9 +408,13 @@ def test_posterior_bo_integration__optimization(
     np.testing.assert_equal((n_rows_new, n_outputs), compiled_mean.shape)
     np.testing.assert_equal((n_rows_new, n_outputs), compiled_var.shape)
 
-    eager_model = _create_model(_data)
+    eager_model = _model_factory.create_model(_data)
     _optimize(eager_model)
     eager_mean, eager_var = eager_model.predict_f(_X_new)
 
-    np.testing.assert_allclose(eager_mean, compiled_mean, rtol=_rtol, atol=_atol)
-    np.testing.assert_allclose(eager_var, compiled_var, rtol=_rtol, atol=_atol)
+    np.testing.assert_allclose(
+        eager_mean, compiled_mean, rtol=_model_factory.rtol, atol=_model_factory.atol
+    )
+    np.testing.assert_allclose(
+        eager_var, compiled_var, rtol=_model_factory.rtol, atol=_model_factory.atol
+    )

--- a/tests/gpflow/posteriors/test_posteriors.py
+++ b/tests/gpflow/posteriors/test_posteriors.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Any, Callable, DefaultDict, Optional, Set, Type
+from typing import Any, Callable, DefaultDict, Optional, Set, Type, cast
 
 import numpy as np
 import pytest
@@ -98,17 +98,17 @@ def _q_sqrt_factory_fixture(request: SubRequest) -> QSqrtFactory:
 
 @pytest.fixture(name="whiten", params=[False, True])
 def _whiten_fixture(request: SubRequest) -> bool:
-    return request.param
+    return cast(bool, request.param)
 
 
 @pytest.fixture(name="num_latent_gps", params=[1, 2])
 def _num_latent_gps_fixture(request: SubRequest) -> int:
-    return request.param
+    return cast(int, request.param)
 
 
 @pytest.fixture(name="output_dims", params=[1, 5])
 def _output_dims_fixture(request: SubRequest) -> int:
-    return request.param
+    return cast(int, request.param)
 
 
 ConditionalClosure = Callable[..., tf.Tensor]

--- a/tests/gpflow/quadrature/test_quadrature.py
+++ b/tests/gpflow/quadrature/test_quadrature.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import cast
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -115,7 +117,7 @@ def test_quadrature_autograph() -> None:
             )
 
         (result,) = func()
-        return result.numpy()
+        return cast(AnyNDArray, result.numpy())
 
     np.testing.assert_equal(
         compute(autograph=True),

--- a/tests/gpflow/test_monitor.py
+++ b/tests/gpflow/test_monitor.py
@@ -54,7 +54,7 @@ def model() -> GPModel:
 def monitor(model: GPModel, tmp_path: Path) -> Monitor:
     tmp_path_str = str(tmp_path)
 
-    def lml_callback() -> float:
+    def lml_callback() -> tf.Tensor:
         return model.log_marginal_likelihood()
 
     def print_callback() -> None:

--- a/tests/gpflow/utilities/test_ops.py
+++ b/tests/gpflow/utilities/test_ops.py
@@ -1,3 +1,5 @@
+from typing import Union, cast
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -7,7 +9,7 @@ from gpflow.base import AnyNDArray
 from gpflow.utilities.ops import difference_matrix
 
 
-def pca_reduce(X: AnyNDArray, Q: int) -> AnyNDArray:
+def pca_reduce(X: Union[AnyNDArray, tf.Tensor], Q: int) -> AnyNDArray:
     """
     A helpful function for linearly reducing the dimensionality of the data X
     to Q.
@@ -19,10 +21,11 @@ def pca_reduce(X: AnyNDArray, Q: int) -> AnyNDArray:
         raise ValueError("Cannot have more latent dimensions than observed")
     if isinstance(X, tf.Tensor):
         X = X.numpy()
-        # TODO why not use tf.linalg.eigh?
+    assert isinstance(X, np.ndarray)  # Hint for numpy
+    # TODO why not use tf.linalg.eigh?
     evals, evecs = np.linalg.eigh(np.cov(X.T))
     W = evecs[:, -Q:]
-    return (X - X.mean(0)).dot(W)
+    return cast(AnyNDArray, (X - X.mean(0)).dot(W))
 
 
 @pytest.mark.parametrize("N", [3, 7])


### PR DESCRIPTION
Enable warnings when returning 'Any'.
Most of the fixes are "type-ignores" or `cast`s, but in several places incorrect type annotations were discovered.