### PR TITLE
test_utils to make it easier for downstream implementations to check correctness

### DIFF
--- a/gpflow/test_utils.py
+++ b/gpflow/test_utils.py
@@ -1,0 +1,26 @@
+import numpy as np
+from .kernels import Kernel
+
+def test_kernel(kernel: Kernel, X: np.ndarray, X2: np.ndarray):
+    N, D = X.shape
+    N2, D2 = X2.shape
+    assert D == D2
+    assert N1 != N2
+
+    kX = kernel(X).numpy()
+    assert kX.shape == (N, N)
+    kXX = kernel(X, X).numpy()
+    assert kXX.shape == (N, N)
+    np.testing.assert_allclose(kX, kXX)
+    np.testing.assert_allclose(kX, kX.T)
+    assert np.linalg.eigvals(kX).min() > -1e-6, "kernel matrix should be positive definite"
+
+    kXX2 = kernel(X, X2).numpy()
+    assert kXX2.shape == (N, N2)
+
+    kX2X = kernel(X2, X).numpy()
+    np.testing.assert_allclose(kXX2, kX2X.T)
+
+    kXdiag = kernel(X, full_cov=False).numpy()
+    assert kXdiag.shape == (N,)
+    np.testing.assert_allclose(np.diag(kX), kXdiag)


### PR DESCRIPTION
**PR type:** new feature

## Summary

A common use-case of GPflow is to implement your own down-stream kernels / models / likelihoods / etc.
We should make it easy for such users to check their implementation for basic correctness (e.g. kernel is pos-def on test inputs) and adherence to interfaces (accepts tensors of appropriate shapes & returns the right things).

**Proposed changes**
* Provide a `test_utils` submodule with basic checks for interfaces.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```python
# Put your example code in here
```

### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** yes / no

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

