### PR TITLE
Remove numpydoc and fix unexpected sections.

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -38,7 +38,6 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
-    "numpydoc",
     "nbsphinx",
     "sphinx_autodoc_typehints",
     "IPython.sphinxext.ipython_console_highlighting",
@@ -48,9 +47,6 @@ set_type_checking_flag = True
 typehints_fully_qualified = False
 always_document_param_types = True
 # autoclass_content = 'both'
-
-# numpydoc_show_class_members = True
-numpydoc_class_members_toctree = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/gpflow/conditionals/conditionals.py
+++ b/gpflow/conditionals/conditionals.py
@@ -43,14 +43,12 @@ def _sparse_conditional(
     - Kuf: [M, N]
     - Kff: [N, N]
 
-    Further reference
-    -----------------
+    Further reference:
+
     - See `gpflow.conditionals._dense_conditional` (below) for a detailed explanation of
       conditional in the single-output case.
     - See the multiouput notebook for more information about the multiouput framework.
 
-    Parameters
-    ----------
     :param Xnew: data matrix, size [N, D].
     :param f: data matrix, [M, R]
     :param full_cov: return the covariance between the datapoints

--- a/gpflow/conditionals/multioutput/conditionals.py
+++ b/gpflow/conditionals/multioutput/conditionals.py
@@ -62,13 +62,12 @@ def shared_independent_conditional(
     - Kuf: [M, N]
     - Kff: N or [N, N]
 
-    Further reference
-    -----------------
+    Further reference:
+
     - See `gpflow.conditionals._conditional` for a detailed explanation of
       conditional in the single-output case.
     - See the multioutput notebook for more information about the multioutput framework.
-    Parameters
-    ----------
+
     :param Xnew: data matrix, size [N, D].
     :param f: data matrix, [M, P]
     :param full_cov: return the covariance between the datapoints
@@ -151,8 +150,8 @@ def fallback_independent_latent_conditional(
     - Kuf: [M, L, N, P]
     - Kff: [N, P, N, P], [N, P, P], [N, P]
 
-    Further reference
-    -----------------
+    Further reference:
+
     - See `gpflow.conditionals._conditional` for a detailed explanation of
       conditional in the single-output case.
     - See the multioutput notebook for more information about the multioutput framework.
@@ -190,14 +189,12 @@ def inducing_point_conditional(
     - Kuf: [M, L, N, P]
     - Kff: [N, P, N, P], [N, P, P], [N, P]
 
-    Further reference
-    -----------------
+    Further reference:
+
     - See `gpflow.conditionals._conditional` for a detailed explanation of
       conditional in the single-output case.
     - See the multioutput notebook for more information about the multioutput framework.
 
-    Parameters
-    ----------
     :param f: variational mean, [L, 1]
     :param q_sqrt: standard-deviations or cholesky, [L, 1]  or  [1, L, L]
     """
@@ -237,8 +234,8 @@ def coregionalization_conditional(
     - Kuf: [L, M, N]
     - Kff: [L, N] or [L, N, N]
 
-    Further reference
-    -----------------
+    Further reference:
+
     - See `gpflow.conditionals._conditional` for a detailed explanation of
       conditional in the single-output case.
     - See the multioutput notebook for more information about the multioutput framework.

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -606,8 +606,8 @@ def separate_independent_conditional_implementation(
     - Kuf: [P, M, N]
     - Kff: [P, N] or [P, N, N]
 
-    Further reference
-    -----------------
+    Further reference:
+
     - See `gpflow.conditionals._conditional` for a detailed explanation of
       conditional in the single-output case.
     - See the multioutput notebook for more information about the multioutput framework.

--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -170,13 +170,13 @@ class NaturalGradient(tf.optimizers.Optimizer):
         :param var_list: List of pair tuples of variational parameters or
             triplet tuple with variational parameters and ξ transformation.
             If ξ is not specified, will use self.xi_transform.
-            For example, `var_list` could be
-            ```
-            var_list = [
-                (q_mu1, q_sqrt1),
-                (q_mu2, q_sqrt2, XiSqrtMeanVar())
-            ]
-            ```
+            For example, `var_list` could be::
+
+                var_list = [
+                    (q_mu1, q_sqrt1),
+                    (q_mu2, q_sqrt2, XiSqrtMeanVar())
+                ]
+
 
         GPflow implements the `XiNat` (default) and `XiSqrtMeanVar` transformations
         for parameters. Custom transformations that implement the `XiTransform`

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -27,7 +27,6 @@ ipywidgets  # Required by tensorflow-datasets
 ipython
 jupytext
 nbsphinx
-numpydoc
 pandoc
 pydata-sphinx-theme
 sphinx


### PR DESCRIPTION
`numpydoc`, and its associated subsections seems to be poorly used, and causing the majority of our documentation warnings.
This PR reduces the number of warnings from 462 to 142.