### PR TITLE
Fix broken docs build (again).

### DIFF
--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -33,3 +33,6 @@ sphinx
 sphinx-autoapi
 sphinxcontrib-bibtex
 sphinx_autodoc_typehints
+
+# Not used directly, but at the time of this writing Jinja2 3.1.0 breaks our notebooks.
+Jinja2<3.1.0


### PR DESCRIPTION
The docs build already broke again, but at least this time it's obvious.
It seems a new release of Jinja2 broke something in our Jupyter notebooks.