### PR TITLE
Fix new version of click breaking old version of black.

### DIFF
--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -1,13 +1,12 @@
 mypy
-black==20.8b1
+black==20.8b1  # Use old version of black, because newer version is incompatible with our TF 2.4.
 isort>=5.1
 pytest>=3.5.0
 pytest-cov
 pytest-random-order
-pytest-xdist  # for local tests only
+pytest-xdist
 codecov
-types-dataclasses
-types-pkg_resources  # for mypy check of gpflow/versions.py
+types-pkg_resources
 types-tabulate
 types-Deprecated
 
@@ -34,5 +33,7 @@ sphinx-autoapi
 sphinxcontrib-bibtex
 sphinx_autodoc_typehints
 
-# Not used directly, but at the time of this writing Jinja2 3.1.0 breaks our notebooks.
+# Not used directly, but at the time of this writing `Jinja2` 3.1.0 breaks our notebooks.
 Jinja2<3.1.0
+# Not used directly, but at the time of this writing `click` 8.1.0 breaks `black` 20.8b1.
+click<8.1.0


### PR DESCRIPTION
Newer versions of `black` are incompatible with TensorFlow 2.4, which we must support, so we've pinned `black` to an old version.
There's just been a new release of `click`, 8.1.0, which now breaks our old version of `black`, so now we have to pin `click` as well...