### PR TITLE
Add support for user notes on shapes.

### DIFF
--- a/gpflow/experimental/check_shapes/__init__.py
+++ b/gpflow/experimental/check_shapes/__init__.py
@@ -40,7 +40,7 @@ Check specification
 The shapes to check are specified by the arguments to :func:`check_shapes`. Each argument is a
 string of the format::
 
-    <argument specifier>: <shape specifier>
+    <argument specifier>: <shape specifier> [# <note>]
 
 
 Argument specification
@@ -102,6 +102,29 @@ For example::
         "...: [batch..., 2]",
         "...: [n_samples, *]",
         "...: [..., 2]",
+    )
+    def f(...):
+        ...
+
+
+Note specification
+------------------
+
+You can add notes to your specifications using a `#` followed by the note. These notes will be
+appended to relevant error messages and appear in rewritten docstrings. You can add notes in two
+places:
+
+    * After the specification of a single argument, to add a note to that argument only.
+    * On a single line by itself, to add a note to the entire function.
+
+For example::
+
+    @tf.function
+    @check_shapes(
+        "features: [batch_shape..., n_features]",
+        "weights: [n_features]  # A note about the shape of `weights`.",
+        "return: [batch_shape...]",
+        "# A note about `f`.",
     )
     def f(...):
         ...

--- a/gpflow/experimental/check_shapes/check_shapes.lark
+++ b/gpflow/experimental/check_shapes/check_shapes.lark
@@ -1,6 +1,9 @@
 // Definition of the Lark grammar of the domain specific language for specifying tensors.
 
-argument_spec: argument_name argument_refs ":" shape_spec
+?argument_or_note_spec: argument_spec
+                      | note_spec
+
+argument_spec: argument_name argument_refs ":" shape_spec note_spec?
 
 argument_name: CNAME
 
@@ -25,10 +28,15 @@ dimension_spec_anonymous: DOT | NONE
 dimension_spec_variable_rank: (STAR CNAME) | (CNAME ELLIPSIS)
 dimension_spec_anonymous_variable_rank: STAR | ELLIPSIS
 
+note_spec: HASH NOTE_TEXT*
+
+HASH: "#"
 DOT: "."
 NONE: "None"
 STAR: "*"
 ELLIPSIS: "..."
+
+NOTE_TEXT: /.+/
 
 %import common.CNAME
 %import common.INT

--- a/gpflow/experimental/check_shapes/check_shapes.py
+++ b/gpflow/experimental/check_shapes/check_shapes.py
@@ -24,18 +24,18 @@ from .argument_ref import RESULT_TOKEN
 from .base_types import C, Shape
 from .config import get_enable_check_shapes
 from .error_contexts import (
-    ArgumentContext,
     ErrorContext,
     FunctionCallContext,
     FunctionDefinitionContext,
+    NoteContext,
     ParallelContext,
     ShapeContext,
     StackContext,
 )
 from .exceptions import ShapeMismatchError
-from .parser import parse_and_rewrite_docstring, parse_argument_spec
+from .parser import parse_and_rewrite_docstring, parse_function_spec
 from .shapes import get_shape
-from .specs import ParsedArgumentSpec
+from .specs import ParsedArgumentSpec, ParsedNoteSpec
 
 
 def null_check_shapes(func: C) -> C:
@@ -63,13 +63,11 @@ def check_shapes(*specs: str) -> Callable[[C], C]:
 
     unbound_error_context = FunctionCallContext(check_shapes)
 
-    parsed_specs = tuple(
-        parse_argument_spec(spec, StackContext(unbound_error_context, ArgumentContext(i)))
-        for i, spec in enumerate(specs)
-    )
+    func_spec = parse_function_spec(specs, unbound_error_context)
 
-    pre_specs = [spec for spec in parsed_specs if not spec.argument_ref.is_result]
-    post_specs = [spec for spec in parsed_specs if spec.argument_ref.is_result]
+    pre_specs = [spec for spec in func_spec.arguments if not spec.argument_ref.is_result]
+    post_specs = [spec for spec in func_spec.arguments if spec.argument_ref.is_result]
+    note_specs = func_spec.notes
 
     def _check_shapes(func: C) -> C:
         bound_error_context = FunctionDefinitionContext(func)
@@ -94,15 +92,19 @@ def check_shapes(*specs: str) -> Callable[[C], C]:
             arg_map = bound_arguments.arguments
             shape_context: List[Tuple[ParsedArgumentSpec, Shape]] = []
             dim_context: Dict[str, Union[int, List[Optional[int]]]] = {}
-            _assert_shapes(pre_specs, arg_map, shape_context, dim_context, bound_error_context)
+            _assert_shapes(
+                pre_specs, note_specs, arg_map, shape_context, dim_context, bound_error_context
+            )
             result = func(*args, **kwargs)
             arg_map[RESULT_TOKEN] = result
-            _assert_shapes(post_specs, arg_map, shape_context, dim_context, bound_error_context)
+            _assert_shapes(
+                post_specs, note_specs, arg_map, shape_context, dim_context, bound_error_context
+            )
             return result
 
         set_check_shapes(wrapped, _check_shapes)
         wrapped.__doc__ = parse_and_rewrite_docstring(
-            wrapped.__doc__, parsed_specs, bound_error_context
+            wrapped.__doc__, func_spec, bound_error_context
         )
         return cast(C, wrapped)
 
@@ -110,7 +112,8 @@ def check_shapes(*specs: str) -> Callable[[C], C]:
 
 
 def _assert_shapes(
-    specs: Sequence[ParsedArgumentSpec],
+    arg_specs: Sequence[ParsedArgumentSpec],
+    note_specs: Sequence[ParsedNoteSpec],
     arg_map: Mapping[str, Any],
     shape_context: List[Tuple[ParsedArgumentSpec, Shape]],
     dim_context: Dict[str, Union[int, List[Optional[int]]]],
@@ -118,22 +121,19 @@ def _assert_shapes(
 ) -> None:
     def _assert(condition: bool) -> None:
         if not condition:
-            raise ShapeMismatchError(
-                StackContext(
-                    error_context,
-                    ParallelContext(
-                        [
-                            StackContext(
-                                spec.argument_ref.error_context, ShapeContext(spec.shape, actual)
-                            )
-                            for spec, actual in shape_context
-                        ]
-                    ),
-                )
-            )
+            contexts: List[ErrorContext] = []
+            contexts.extend(NoteContext(note) for note in note_specs)
+            for spec, actual in shape_context:
+                shape_error_context: ErrorContext = ShapeContext(spec.shape, actual)
+                if spec.note is not None:
+                    shape_error_context = ParallelContext(
+                        [NoteContext(spec.note), shape_error_context]
+                    )
+                contexts.append(StackContext(spec.argument_ref.error_context, shape_error_context))
+            raise ShapeMismatchError(StackContext(error_context, ParallelContext(contexts)))
 
     new_shape_context = []
-    for arg_spec in specs:
+    for arg_spec in arg_specs:
         arg_value = arg_spec.argument_ref.get(arg_map, error_context)
         actual: Shape
         if arg_value is None:

--- a/gpflow/experimental/check_shapes/error_contexts.py
+++ b/gpflow/experimental/check_shapes/error_contexts.py
@@ -50,7 +50,7 @@ from .base_types import Shape
 
 if TYPE_CHECKING:
     from .argument_ref import ArgumentRef
-    from .specs import ParsedShapeSpec
+    from .specs import ParsedNoteSpec, ParsedShapeSpec
 
 _UNKNOWN_FILE = "<Unknown file>"
 _UNKNOWN_LINE = "<Unknown line>"
@@ -372,6 +372,18 @@ class ShapeContext(ErrorContext):
             actual_str = f"[{', '.join(str(dim) for dim in self.actual)}]"
         builder.add_columned_line("Expected:", self.expected)
         builder.add_columned_line("Actual:", actual_str)
+
+
+@dataclass(frozen=True)
+class NoteContext(ErrorContext):
+    """
+    An error occurred in a context where a user has added a note.
+    """
+
+    note: "ParsedNoteSpec"
+
+    def print(self, builder: MessageBuilder) -> None:
+        builder.add_columned_line("Note:", self.note.note)
 
 
 @dataclass(frozen=True)

--- a/gpflow/experimental/check_shapes/specs.py
+++ b/gpflow/experimental/check_shapes/specs.py
@@ -21,6 +21,14 @@ from .argument_ref import ArgumentRef
 
 
 @dataclass(frozen=True)
+class ParsedNoteSpec:
+    note: str
+
+    def __repr__(self) -> str:
+        return f"# {self.note}"
+
+
+@dataclass(frozen=True)
 class ParsedDimensionSpec:
     constant: Optional[int]
     variable_name: Optional[str]
@@ -62,6 +70,20 @@ class ParsedShapeSpec:
 class ParsedArgumentSpec:
     argument_ref: ArgumentRef
     shape: ParsedShapeSpec
+    note: Optional[ParsedNoteSpec]
 
     def __repr__(self) -> str:
-        return f"{self.argument_ref}: {self.shape}"
+        note_str = f"  {self.note}" if self.note is not None else ""
+        return f"{self.argument_ref}: {self.shape}{note_str}"
+
+
+@dataclass(frozen=True)
+class ParsedFunctionSpec:
+    arguments: Tuple[ParsedArgumentSpec, ...]
+    notes: Tuple[ParsedNoteSpec, ...]
+
+    def __repr__(self) -> str:
+        lines = [repr(argument) for argument in self.arguments] + [
+            repr(note) for note in self.notes
+        ]
+        return "\n".join(lines)

--- a/tests/gpflow/experimental/check_shapes/test_check_shapes.py
+++ b/tests/gpflow/experimental/check_shapes/test_check_shapes.py
@@ -425,12 +425,14 @@ def test_check_shapes__disable() -> None:
 
 def test_check_shapes__error_message() -> None:
     # Here we're just testing that error message formatting is wired together sanely. For more
-    # thorough tests of error formatting, see test_errors.py
+    # thorough tests of error formatting, see test_error_contexts.py and test_exceptions.py
 
     @check_shapes(
         "a: [d1, d2]",
-        "b: [d1, d3]",
+        "b: [d1, d3]  # Some note on b",
         "return: [d2, d3]",
+        "# Some note on f",
+        "# Some other note on f",
     )
     def f(a: TestShaped, b: TestShaped) -> TestShaped:
         return t(3, 4)
@@ -444,10 +446,13 @@ def test_check_shapes__error_message() -> None:
 Tensor shape mismatch in call to function.
   Function: test_check_shapes__error_message.<locals>.f
     Declared: {__file__}:430
+    Note:     Some note on f
+    Note:     Some other note on f
     Argument: a
       Expected: [d1, d2]
       Actual:   [2, 3]
     Argument: b
+      Note:     Some note on b
       Expected: [d1, d3]
       Actual:   [3, 4]
 """

--- a/tests/gpflow/experimental/check_shapes/test_error_contexts.py
+++ b/tests/gpflow/experimental/check_shapes/test_error_contexts.py
@@ -26,11 +26,13 @@ from gpflow.experimental.check_shapes.error_contexts import (
     IndexContext,
     LarkUnexpectedInputContext,
     MessageBuilder,
+    NoteContext,
     ObjectTypeContext,
     ParallelContext,
     ShapeContext,
     StackContext,
 )
+from gpflow.experimental.check_shapes.specs import ParsedNoteSpec
 
 from .utils import TestContext, make_shape_spec
 
@@ -304,7 +306,7 @@ def test_function_call_context() -> None:
 
     assert (
         f"""
-f called at: {__file__}:305
+f called at: {__file__}:307
 """
         == f()
     )
@@ -324,7 +326,7 @@ def test_function_call_context__wrapping() -> None:
 
     assert (
         f"""
-f called at: {__file__}:325
+f called at: {__file__}:327
 """
         == f3()
     )
@@ -336,7 +338,7 @@ def test_function_definition_context() -> None:
 
     assert f"""
 Function: test_function_definition_context.<locals>.f
-  Declared: {__file__}:334
+  Declared: {__file__}:336
 """ == to_str(
         FunctionDefinitionContext(f)
     )
@@ -472,6 +474,14 @@ Actual:   <Tensor has unknown shape>
 )
 def test_shape_context(context: ErrorContext, expected: str) -> None:
     assert expected == to_str(context)
+
+
+def test_note_context() -> None:
+    assert """
+Note: Some note.
+""" == to_str(
+        NoteContext(ParsedNoteSpec("Some note."))
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/gpflow/experimental/check_shapes/test_parser.py
+++ b/tests/gpflow/experimental/check_shapes/test_parser.py
@@ -22,8 +22,12 @@ import pytest
 from gpflow.experimental.check_shapes import check_shapes
 from gpflow.experimental.check_shapes.config import set_rewrite_docstrings
 from gpflow.experimental.check_shapes.exceptions import SpecificationParseError
-from gpflow.experimental.check_shapes.parser import parse_and_rewrite_docstring, parse_argument_spec
-from gpflow.experimental.check_shapes.specs import ParsedArgumentSpec
+from gpflow.experimental.check_shapes.parser import parse_and_rewrite_docstring, parse_function_spec
+from gpflow.experimental.check_shapes.specs import (
+    ParsedArgumentSpec,
+    ParsedFunctionSpec,
+    ParsedNoteSpec,
+)
 
 from .utils import TestContext, make_argument_ref, make_shape_spec, varrank
 
@@ -31,8 +35,8 @@ from .utils import TestContext, make_argument_ref, make_shape_spec, varrank
 @dataclass
 class TestData:
     test_id: str
-    argument_spec_strs: Tuple[str, ...]
-    expected_specs: Tuple[ParsedArgumentSpec, ...]
+    function_spec_strs: Tuple[str, ...]
+    expected_function_spec: ParsedFunctionSpec
     doc: Optional[str]
     expected_doc: Optional[str]
 
@@ -48,19 +52,25 @@ _TEST_DATA = [
             "b: [2, 4]",
             "return: [3, 4]",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("a"),
-                make_shape_spec(2, 3),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("a"),
+                    make_shape_spec(2, 3),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("b"),
+                    make_shape_spec(2, 4),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return"),
+                    make_shape_spec(3, 4),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("b"),
-                make_shape_spec(2, 4),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return"),
-                make_shape_spec(3, 4),
-            ),
+            (),
         ),
         """
         :param a: Parameter a.
@@ -89,19 +99,25 @@ _TEST_DATA = [
             "b: [d1, d3]",
             "return: [d2, d3]",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("a"),
-                make_shape_spec("d1", "d2"),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("a"),
+                    make_shape_spec("d1", "d2"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("b"),
+                    make_shape_spec("d1", "d3"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return"),
+                    make_shape_spec("d2", "d3"),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("b"),
-                make_shape_spec("d1", "d3"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return"),
-                make_shape_spec("d2", "d3"),
-            ),
+            (),
         ),
         """
         :param a: Parameter a.
@@ -132,27 +148,35 @@ _TEST_DATA = [
             "d: [d1, ds...]",
             "return: [*ds, d1, d2]",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("a"),
-                make_shape_spec(varrank("ds")),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("a"),
+                    make_shape_spec(varrank("ds")),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("b"),
+                    make_shape_spec(varrank("ds"), "d1"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("c"),
+                    make_shape_spec("d1", varrank("ds"), "d2"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("d"),
+                    make_shape_spec("d1", varrank("ds")),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return"),
+                    make_shape_spec(varrank("ds"), "d1", "d2"),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("b"),
-                make_shape_spec(varrank("ds"), "d1"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("c"),
-                make_shape_spec("d1", varrank("ds"), "d2"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("d"),
-                make_shape_spec("d1", varrank("ds")),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return"),
-                make_shape_spec(varrank("ds"), "d1", "d2"),
-            ),
+            (),
         ),
         """
         :param a: Parameter a.
@@ -193,27 +217,35 @@ _TEST_DATA = [
             "d: [*, d2]",
             "return: [..., d1, d2]",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("a"),
-                make_shape_spec(None, "d1"),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("a"),
+                    make_shape_spec(None, "d1"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("b"),
+                    make_shape_spec(None, "d2"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("c"),
+                    make_shape_spec(varrank(None), "d1"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("d"),
+                    make_shape_spec(varrank(None), "d2"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return"),
+                    make_shape_spec(varrank(None), "d1", "d2"),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("b"),
-                make_shape_spec(None, "d2"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("c"),
-                make_shape_spec(varrank(None), "d1"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("d"),
-                make_shape_spec(varrank(None), "d2"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return"),
-                make_shape_spec(varrank(None), "d1", "d2"),
-            ),
+            (),
         ),
         """
         :param a: Parameter a.
@@ -252,19 +284,25 @@ _TEST_DATA = [
             "b: []",
             "return: []",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("a"),
-                make_shape_spec(),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("a"),
+                    make_shape_spec(),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("b"),
+                    make_shape_spec(),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return"),
+                    make_shape_spec(),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("b"),
-                make_shape_spec(),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return"),
-                make_shape_spec(),
-            ),
+            (),
         ),
         """
         :param a: Parameter a.
@@ -294,23 +332,30 @@ _TEST_DATA = [
             "return[0].out: [a_batch..., 3]",
             "return[1].out: [b_batch..., 4]",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("x", "ins", 0),
-                make_shape_spec(varrank("a_batch"), 1),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("x", "ins", 0),
+                    make_shape_spec(varrank("a_batch"), 1),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("x", "ins", 1),
+                    make_shape_spec(varrank("b_batch"), 2),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return", 0, "out"),
+                    make_shape_spec(varrank("a_batch"), 3),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return", 1, "out"),
+                    make_shape_spec(varrank("b_batch"), 4),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("x", "ins", 1),
-                make_shape_spec(varrank("b_batch"), 2),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return", 0, "out"),
-                make_shape_spec(varrank("a_batch"), 3),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return", 1, "out"),
-                make_shape_spec(varrank("b_batch"), 4),
-            ),
+            (),
         ),
         """
         :param x: Parameter x.
@@ -330,25 +375,91 @@ _TEST_DATA = [
         """,
     ),
     TestData(
+        "notes",
+        (
+            "a: [d1, d2]",
+            "# Some generic note.",
+            "b: [d1, d3]  #   Some note \n on B. \n  ",
+            "return: [d2, d3]#Some note on the result.",
+            "# Some other\ngeneric note.",
+        ),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("a"),
+                    make_shape_spec("d1", "d2"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("b"),
+                    make_shape_spec("d1", "d3"),
+                    note=ParsedNoteSpec("Some note on B."),
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return"),
+                    make_shape_spec("d2", "d3"),
+                    note=ParsedNoteSpec("Some note on the result."),
+                ),
+            ),
+            (
+                ParsedNoteSpec("Some generic note."),
+                ParsedNoteSpec("Some other generic note."),
+            ),
+        ),
+        """
+        Some doctring.
+
+        :param a: Parameter a.
+        :param b: Parameter b.
+        :returns: Return value.
+        """,
+        """
+        Some doctring.
+
+        Some generic note.
+
+        Some other generic note.
+
+        :param a:
+            * **a** has shape [*d1*, *d2*].
+
+            Parameter a.
+        :param b:
+            * **b** has shape [*d1*, *d3*]. Some note on B.
+
+            Parameter b.
+        :returns:
+            * **return** has shape [*d2*, *d3*]. Some note on the result.
+
+            Return value.
+        """,
+    ),
+    TestData(
         "no_docstring",
         (
             "a: [d1, d2]",
             "b: [d1, d3]",
             "return: [d2, d3]",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("a"),
-                make_shape_spec("d1", "d2"),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("a"),
+                    make_shape_spec("d1", "d2"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("b"),
+                    make_shape_spec("d1", "d3"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return"),
+                    make_shape_spec("d2", "d3"),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("b"),
-                make_shape_spec("d1", "d3"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return"),
-                make_shape_spec("d2", "d3"),
-            ),
+            (),
         ),
         None,
         None,
@@ -360,19 +471,25 @@ _TEST_DATA = [
             "b: [d1, d3]",
             "return: [d2, d3]",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("a"),
-                make_shape_spec("d1", "d2"),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("a"),
+                    make_shape_spec("d1", "d2"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("b"),
+                    make_shape_spec("d1", "d3"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return"),
+                    make_shape_spec("d2", "d3"),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("b"),
-                make_shape_spec("d1", "d3"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return"),
-                make_shape_spec("d2", "d3"),
-            ),
+            (),
         ),
         """
         :param b: Parameter b.
@@ -391,19 +508,25 @@ _TEST_DATA = [
             "b: [d1, d3]",
             "return: [d2, d3]",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("a"),
-                make_shape_spec("d1", "d2"),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("a"),
+                    make_shape_spec("d1", "d2"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("b"),
+                    make_shape_spec("d1", "d3"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return"),
+                    make_shape_spec("d2", "d3"),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("b"),
-                make_shape_spec("d1", "d3"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return"),
-                make_shape_spec("d2", "d3"),
-            ),
+            (),
         ),
         """:param b: Parameter b.""",
         """:param b:
@@ -417,15 +540,20 @@ _TEST_DATA = [
             "a: [batch..., n_features]",
             "return: [batch..., 1]",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("a"),
-                make_shape_spec(varrank("batch"), "n_features"),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("a"),
+                    make_shape_spec(varrank("batch"), "n_features"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return"),
+                    make_shape_spec(varrank("batch"), 1),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("return"),
-                make_shape_spec(varrank("batch"), 1),
-            ),
+            (),
         ),
         """
         This is a boring docstring.
@@ -460,15 +588,20 @@ _TEST_DATA = [
             "a: [batch..., n_features]",
             "return: [batch..., 1]",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("a"),
-                make_shape_spec(varrank("batch"), "n_features"),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("a"),
+                    make_shape_spec(varrank("batch"), "n_features"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return"),
+                    make_shape_spec(varrank("batch"), 1),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("return"),
-                make_shape_spec(varrank("batch"), 1),
-            ),
+            (),
         ),
         """
         This: is a docstring, :: with some extra :s in it.
@@ -497,32 +630,41 @@ _TEST_DATA = [
         "funny_formatting_1",
         (
             "train.features: [train_batch..., n_features]",
-            "train.labels: [train_batch..., n_labels]",
+            "train.labels: [train_batch..., n_labels]  # Label note.",
             "test_features: [test_batch..., n_features]",
             "return[0]: [test_batch..., n_labels]",
             "return[1]: [test_batch..., n_labels]",
+            "# Function note.",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("train", "features"),
-                make_shape_spec(varrank("train_batch"), "n_features"),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("train", "features"),
+                    make_shape_spec(varrank("train_batch"), "n_features"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("train", "labels"),
+                    make_shape_spec(varrank("train_batch"), "n_labels"),
+                    note=ParsedNoteSpec("Label note."),
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("test_features"),
+                    make_shape_spec(varrank("test_batch"), "n_features"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return", 0),
+                    make_shape_spec(varrank("test_batch"), "n_labels"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return", 1),
+                    make_shape_spec(varrank("test_batch"), "n_labels"),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("train", "labels"),
-                make_shape_spec(varrank("train_batch"), "n_labels"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("test_features"),
-                make_shape_spec(varrank("test_batch"), "n_features"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return", 0),
-                make_shape_spec(varrank("test_batch"), "n_labels"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return", 1),
-                make_shape_spec(varrank("test_batch"), "n_labels"),
-            ),
+            (ParsedNoteSpec("Function note."),),
         ),
         """
         Predict mean and variance from some test features.
@@ -543,9 +685,11 @@ _TEST_DATA = [
 
         First trains a model an `train`, then makes a prediction from the model and `test`.
 
+        Function note.
+
         :param train:
             * **train.features** has shape [*train_batch*..., *n_features*].
-            * **train.labels** has shape [*train_batch*..., *n_labels*].
+            * **train.labels** has shape [*train_batch*..., *n_labels*]. Label note.
 
             Data to train on.
 
@@ -565,32 +709,41 @@ _TEST_DATA = [
         "funny_formatting_2",
         (
             "train.features: [train_batch..., n_features]",
-            "train.labels: [train_batch..., n_labels]",
+            "train.labels: [train_batch..., n_labels]  # Label note.",
             "test_features: [test_batch..., n_features]",
             "return[0]: [test_batch..., n_labels]",
             "return[1]: [test_batch..., n_labels]",
+            "# Function note.",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("train", "features"),
-                make_shape_spec(varrank("train_batch"), "n_features"),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("train", "features"),
+                    make_shape_spec(varrank("train_batch"), "n_features"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("train", "labels"),
+                    make_shape_spec(varrank("train_batch"), "n_labels"),
+                    note=ParsedNoteSpec("Label note."),
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("test_features"),
+                    make_shape_spec(varrank("test_batch"), "n_features"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return", 0),
+                    make_shape_spec(varrank("test_batch"), "n_labels"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return", 1),
+                    make_shape_spec(varrank("test_batch"), "n_labels"),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("train", "labels"),
-                make_shape_spec(varrank("train_batch"), "n_labels"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("test_features"),
-                make_shape_spec(varrank("test_batch"), "n_features"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return", 0),
-                make_shape_spec(varrank("test_batch"), "n_labels"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return", 1),
-                make_shape_spec(varrank("test_batch"), "n_labels"),
-            ),
+            (ParsedNoteSpec("Function note."),),
         ),
         """
         Predict mean and variance from some test features.
@@ -602,9 +755,11 @@ _TEST_DATA = [
         """
         Predict mean and variance from some test features.
         First trains a model an `train`, then makes a prediction from the model and `test`.
+
+        Function note.
         :param train:
             * **train.features** has shape [*train_batch*..., *n_features*].
-            * **train.labels** has shape [*train_batch*..., *n_labels*].
+            * **train.labels** has shape [*train_batch*..., *n_labels*]. Label note.
 
             Data to train on.
         :param test_features:
@@ -622,32 +777,41 @@ _TEST_DATA = [
         "funny_formatting_3",
         (
             "train.features: [train_batch..., n_features]",
-            "train.labels: [train_batch..., n_labels]",
+            "train.labels: [train_batch..., n_labels]  # Label note.",
             "test_features: [test_batch..., n_features]",
             "return[0]: [test_batch..., n_labels]",
             "return[1]: [test_batch..., n_labels]",
+            "# Function note.",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("train", "features"),
-                make_shape_spec(varrank("train_batch"), "n_features"),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("train", "features"),
+                    make_shape_spec(varrank("train_batch"), "n_features"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("train", "labels"),
+                    make_shape_spec(varrank("train_batch"), "n_labels"),
+                    note=ParsedNoteSpec("Label note."),
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("test_features"),
+                    make_shape_spec(varrank("test_batch"), "n_features"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return", 0),
+                    make_shape_spec(varrank("test_batch"), "n_labels"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return", 1),
+                    make_shape_spec(varrank("test_batch"), "n_labels"),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("train", "labels"),
-                make_shape_spec(varrank("train_batch"), "n_labels"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("test_features"),
-                make_shape_spec(varrank("test_batch"), "n_features"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return", 0),
-                make_shape_spec(varrank("test_batch"), "n_labels"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return", 1),
-                make_shape_spec(varrank("test_batch"), "n_labels"),
-            ),
+            (ParsedNoteSpec("Function note."),),
         ),
         """Predict mean and variance from some test features.
 
@@ -663,9 +827,11 @@ _TEST_DATA = [
         """Predict mean and variance from some test features.
 
         First trains a model an `train`, then makes a prediction from the model and `test`.
+
+        Function note.
         :param train:
         * **train.features** has shape [*train_batch*..., *n_features*].
-        * **train.labels** has shape [*train_batch*..., *n_labels*].
+        * **train.labels** has shape [*train_batch*..., *n_labels*]. Label note.
 
         Data to train on.
         And another line.
@@ -684,32 +850,41 @@ _TEST_DATA = [
         "funny_formatting_4",
         (
             "train.features: [train_batch..., n_features]",
-            "train.labels: [train_batch..., n_labels]",
+            "train.labels: [train_batch..., n_labels]  # Label note.",
             "test_features: [test_batch..., n_features]",
             "return[0]: [test_batch..., n_labels]",
             "return[1]: [test_batch..., n_labels]",
+            "# Function note.",
         ),
-        (
-            ParsedArgumentSpec(
-                make_argument_ref("train", "features"),
-                make_shape_spec(varrank("train_batch"), "n_features"),
+        ParsedFunctionSpec(
+            (
+                ParsedArgumentSpec(
+                    make_argument_ref("train", "features"),
+                    make_shape_spec(varrank("train_batch"), "n_features"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("train", "labels"),
+                    make_shape_spec(varrank("train_batch"), "n_labels"),
+                    note=ParsedNoteSpec("Label note."),
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("test_features"),
+                    make_shape_spec(varrank("test_batch"), "n_features"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return", 0),
+                    make_shape_spec(varrank("test_batch"), "n_labels"),
+                    note=None,
+                ),
+                ParsedArgumentSpec(
+                    make_argument_ref("return", 1),
+                    make_shape_spec(varrank("test_batch"), "n_labels"),
+                    note=None,
+                ),
             ),
-            ParsedArgumentSpec(
-                make_argument_ref("train", "labels"),
-                make_shape_spec(varrank("train_batch"), "n_labels"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("test_features"),
-                make_shape_spec(varrank("test_batch"), "n_features"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return", 0),
-                make_shape_spec(varrank("test_batch"), "n_labels"),
-            ),
-            ParsedArgumentSpec(
-                make_argument_ref("return", 1),
-                make_shape_spec(varrank("test_batch"), "n_labels"),
-            ),
+            (ParsedNoteSpec("Function note."),),
         ),
         """Predict mean and variance from some test features.
 
@@ -725,9 +900,11 @@ Model mean and variance prediction.""",
         """Predict mean and variance from some test features.
 
 First trains a model an `train`, then makes a prediction from the model and `test`.
+
+Function note.
 :param train:
 * **train.features** has shape [*train_batch*..., *n_features*].
-* **train.labels** has shape [*train_batch*..., *n_labels*].
+* **train.labels** has shape [*train_batch*..., *n_labels*]. Label note.
 
 Data to train on.
 And another line.
@@ -746,14 +923,16 @@ Model mean and variance prediction.""",
 
 
 @pytest.mark.parametrize("data", _TEST_DATA, ids=str)
-def test_parse_argument_spec(data: TestData) -> None:
-    actual_specs = tuple(parse_argument_spec(s, TestContext()) for s in data.argument_spec_strs)
-    assert data.expected_specs == actual_specs
+def test_parse_function_spec(data: TestData) -> None:
+    actual_spec = parse_function_spec(data.function_spec_strs, TestContext())
+    assert data.expected_function_spec == actual_spec
 
 
 @pytest.mark.parametrize("data", _TEST_DATA, ids=str)
 def test_parse_and_rewrite_docstring(data: TestData) -> None:
-    rewritten_docstring = parse_and_rewrite_docstring(data.doc, data.expected_specs, TestContext())
+    rewritten_docstring = parse_and_rewrite_docstring(
+        data.doc, data.expected_function_spec, TestContext()
+    )
     assert data.expected_doc == rewritten_docstring
 
 
@@ -761,11 +940,13 @@ def test_parse_and_rewrite_docstring(data: TestData) -> None:
 def test_parse_and_rewrite_docstring__disable(data: TestData) -> None:
     set_rewrite_docstrings(None)
 
-    rewritten_docstring = parse_and_rewrite_docstring(data.doc, data.expected_specs, TestContext())
+    rewritten_docstring = parse_and_rewrite_docstring(
+        data.doc, data.expected_function_spec, TestContext()
+    )
     assert data.doc == rewritten_docstring
 
 
-_CHECK_SHAPES_LINE = 892
+_CHECK_SHAPES_LINE = 1076
 
 
 @pytest.mark.parametrize(
@@ -788,9 +969,11 @@ Unable to parse shape specification.
 Unable to parse shape specification.
   check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
     Argument number (0-indexed): 0
-      Line: "a= [batch..., x]"
-              ^
-      Found unexpected character.
+      Line:            "a= [batch..., x]"
+                         ^
+      Expected one of: ":"
+                       "."
+                       "["
 """,
         ),
         (
@@ -799,9 +982,9 @@ Unable to parse shape specification.
 Unable to parse shape specification.
   check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
     Argument number (0-indexed): 0
-      Line: "a: (batch..., x)"
-                ^
-      Found unexpected character.
+      Line:     "a: (batch..., x)"
+                    ^
+      Expected: "["
 """,
         ),
         (
@@ -863,9 +1046,10 @@ Unable to parse shape specification.
 Unable to parse shape specification.
   check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
     Argument number (0-indexed): 0
-      Line:     ""
-                 ^
-      Expected: variable name (re=(?:(?:[A-Z]|[a-z])|_)(?:(?:(?:[A-Z]|[a-z])|[0-9]|_))*)
+      Line:            ""
+                        ^
+      Expected one of: variable name (re=(?:(?:[A-Z]|[a-z])|_)(?:(?:(?:[A-Z]|[a-z])|[0-9]|_))*)
+                       "#"
 """,
         ),
         (

--- a/tests/gpflow/experimental/check_shapes/test_specs.py
+++ b/tests/gpflow/experimental/check_shapes/test_specs.py
@@ -13,9 +13,18 @@
 # limitations under the License.
 import pytest
 
-from gpflow.experimental.check_shapes.specs import ParsedArgumentSpec
+from gpflow.experimental.check_shapes.specs import (
+    ParsedArgumentSpec,
+    ParsedFunctionSpec,
+    ParsedNoteSpec,
+)
 
 from .utils import make_argument_ref, make_shape_spec, varrank
+
+
+def test_note_spec() -> None:
+    note_spec = ParsedNoteSpec("foo")
+    assert "# foo" == repr(note_spec)
 
 
 @pytest.mark.parametrize(
@@ -25,6 +34,7 @@ from .utils import make_argument_ref, make_shape_spec, varrank
             ParsedArgumentSpec(
                 make_argument_ref("foo"),
                 make_shape_spec(),
+                note=None,
             ),
             "foo: []",
         ),
@@ -32,6 +42,7 @@ from .utils import make_argument_ref, make_shape_spec, varrank
             ParsedArgumentSpec(
                 make_argument_ref("foo"),
                 make_shape_spec(1, 2),
+                note=None,
             ),
             "foo: [1, 2]",
         ),
@@ -39,6 +50,7 @@ from .utils import make_argument_ref, make_shape_spec, varrank
             ParsedArgumentSpec(
                 make_argument_ref("foo"),
                 make_shape_spec("x", "y"),
+                note=None,
             ),
             "foo: [x, y]",
         ),
@@ -46,6 +58,7 @@ from .utils import make_argument_ref, make_shape_spec, varrank
             ParsedArgumentSpec(
                 make_argument_ref("foo"),
                 make_shape_spec(varrank("x"), "y"),
+                note=None,
             ),
             "foo: [x..., y]",
         ),
@@ -53,6 +66,7 @@ from .utils import make_argument_ref, make_shape_spec, varrank
             ParsedArgumentSpec(
                 make_argument_ref("foo"),
                 make_shape_spec("x", varrank("y"), "z"),
+                note=None,
             ),
             "foo: [x, y..., z]",
         ),
@@ -60,10 +74,66 @@ from .utils import make_argument_ref, make_shape_spec, varrank
             ParsedArgumentSpec(
                 make_argument_ref("foo"),
                 make_shape_spec(None, varrank(None), None),
+                note=None,
             ),
             "foo: [., ..., .]",
         ),
+        (
+            ParsedArgumentSpec(
+                make_argument_ref("foo"),
+                make_shape_spec("x", "y"),
+                note=ParsedNoteSpec("bar"),
+            ),
+            "foo: [x, y]  # bar",
+        ),
     ],
 )
-def test_specs(argument_spec: ParsedArgumentSpec, expected_repr: str) -> None:
+def test_argument_spec(argument_spec: ParsedArgumentSpec, expected_repr: str) -> None:
     assert expected_repr == repr(argument_spec)
+
+
+@pytest.mark.parametrize(
+    "function_spec,expected_repr",
+    [
+        (ParsedFunctionSpec((), ()), ""),
+        (
+            ParsedFunctionSpec(
+                (
+                    ParsedArgumentSpec(
+                        make_argument_ref("foo"),
+                        make_shape_spec("x", "y"),
+                        note=None,
+                    ),
+                ),
+                (ParsedNoteSpec("note 1"),),
+            ),
+            "foo: [x, y]\n# note 1",
+        ),
+        (
+            ParsedFunctionSpec(
+                (
+                    ParsedArgumentSpec(
+                        make_argument_ref("foo"),
+                        make_shape_spec("x", "y"),
+                        note=None,
+                    ),
+                    ParsedArgumentSpec(
+                        make_argument_ref("bar"),
+                        make_shape_spec("x", "z"),
+                        note=ParsedNoteSpec("bar note"),
+                    ),
+                ),
+                (
+                    ParsedNoteSpec("note 1"),
+                    ParsedNoteSpec("note 2"),
+                ),
+            ),
+            """foo: [x, y]
+bar: [x, z]  # bar note
+# note 1
+# note 2""",
+        ),
+    ],
+)
+def test_function_spec(function_spec: ParsedFunctionSpec, expected_repr: str) -> None:
+    assert expected_repr == repr(function_spec)


### PR DESCRIPTION
Add support for user notes on shapes.

This includes:

1. Add new types `ParsedNoteSpec` to store the notes, and `ParsedFunctionSpec`, which wraps both notes and argument specs.
2. Update the grammar to let the user specify notes.
3. Update error messages to display the notes.
4. Update the docstring rewriting to display the notes.