### PR TITLE
Programatically determine line numbers for tests.

### DIFF
--- a/tests/gpflow/experimental/check_shapes/test_check_shapes.py
+++ b/tests/gpflow/experimental/check_shapes/test_check_shapes.py
@@ -22,7 +22,7 @@ import pytest
 from gpflow.experimental.check_shapes import ShapeMismatchError, check_shapes, get_check_shapes
 from gpflow.experimental.check_shapes.config import disable_check_shapes
 
-from .utils import TestShaped, t, t_unk
+from .utils import TestShaped, current_line, t, t_unk
 
 
 def get_shape(x: TestShaped) -> Tuple[Optional[int], ...]:
@@ -427,6 +427,8 @@ def test_check_shapes__error_message() -> None:
     # Here we're just testing that error message formatting is wired together sanely. For more
     # thorough tests of error formatting, see test_error_contexts.py and test_exceptions.py
 
+    def_line = current_line() + 2
+
     @check_shapes(
         "a: [d1, d2]",
         "b: [d1, d3]  # Some note on b",
@@ -445,7 +447,7 @@ def test_check_shapes__error_message() -> None:
         f"""
 Tensor shape mismatch in call to function.
   Function: test_check_shapes__error_message.<locals>.f
-    Declared: {__file__}:430
+    Declared: {__file__}:{def_line}
     Note:     Some note on f
     Note:     Some other note on f
     Argument: a

--- a/tests/gpflow/experimental/check_shapes/test_error_contexts.py
+++ b/tests/gpflow/experimental/check_shapes/test_error_contexts.py
@@ -34,7 +34,7 @@ from gpflow.experimental.check_shapes.error_contexts import (
 )
 from gpflow.experimental.check_shapes.specs import ParsedNoteSpec
 
-from .utils import TestContext, make_shape_spec
+from .utils import TestContext, current_line, make_shape_spec
 
 
 def to_str(context: ErrorContext) -> str:
@@ -304,9 +304,10 @@ def test_function_call_context() -> None:
     def f() -> str:
         return to_str(FunctionCallContext(f))
 
+    call_line = current_line() + 1
     assert (
         f"""
-f called at: {__file__}:307
+f called at: {__file__}:{call_line}
 """
         == f()
     )
@@ -324,21 +325,24 @@ def test_function_call_context__wrapping() -> None:
     def f3() -> str:
         return f2()
 
+    call_line = current_line() + 1
     assert (
         f"""
-f called at: {__file__}:327
+f called at: {__file__}:{call_line}
 """
         == f3()
     )
 
 
 def test_function_definition_context() -> None:
+    def_line = current_line() + 2
+
     def f() -> None:
         ...
 
     assert f"""
 Function: test_function_definition_context.<locals>.f
-  Declared: {__file__}:336
+  Declared: {__file__}:{def_line}
 """ == to_str(
         FunctionDefinitionContext(f)
     )

--- a/tests/gpflow/experimental/check_shapes/test_parser.py
+++ b/tests/gpflow/experimental/check_shapes/test_parser.py
@@ -29,7 +29,7 @@ from gpflow.experimental.check_shapes.specs import (
     ParsedNoteSpec,
 )
 
-from .utils import TestContext, make_argument_ref, make_shape_spec, varrank
+from .utils import TestContext, current_line, make_argument_ref, make_shape_spec, varrank
 
 
 @dataclass
@@ -946,17 +946,14 @@ def test_parse_and_rewrite_docstring__disable(data: TestData) -> None:
     assert data.doc == rewritten_docstring
 
 
-_CHECK_SHAPES_LINE = 1076
-
-
 @pytest.mark.parametrize(
     "spec,expected_message",
     [
         (
             "a [batch..., x]",
-            f"""
+            """
 Unable to parse shape specification.
-  check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
+  check_shapes called at: __check_shapes_path_and_line__
     Argument number (0-indexed): 0
       Line:     "a [batch..., x]"
                     ^
@@ -965,9 +962,9 @@ Unable to parse shape specification.
         ),
         (
             "a= [batch..., x]",
-            f"""
+            """
 Unable to parse shape specification.
-  check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
+  check_shapes called at: __check_shapes_path_and_line__
     Argument number (0-indexed): 0
       Line:            "a= [batch..., x]"
                          ^
@@ -978,9 +975,9 @@ Unable to parse shape specification.
         ),
         (
             "a: (batch..., x)",
-            f"""
+            """
 Unable to parse shape specification.
-  check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
+  check_shapes called at: __check_shapes_path_and_line__
     Argument number (0-indexed): 0
       Line:     "a: (batch..., x)"
                     ^
@@ -989,9 +986,9 @@ Unable to parse shape specification.
         ),
         (
             "a: batch..., x]",
-            f"""
+            """
 Unable to parse shape specification.
-  check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
+  check_shapes called at: __check_shapes_path_and_line__
     Argument number (0-indexed): 0
       Line:     "a: batch..., x]"
                     ^
@@ -1000,9 +997,9 @@ Unable to parse shape specification.
         ),
         (
             "a: [batch... x]",
-            f"""
+            """
 Unable to parse shape specification.
-  check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
+  check_shapes called at: __check_shapes_path_and_line__
     Argument number (0-indexed): 0
       Line:            "a: [batch... x]"
                                      ^
@@ -1012,9 +1009,9 @@ Unable to parse shape specification.
         ),
         (
             "a: [batch..., x",
-            f"""
+            """
 Unable to parse shape specification.
-  check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
+  check_shapes called at: __check_shapes_path_and_line__
     Argument number (0-indexed): 0
       Line:            "a: [batch..., x"
                                       ^
@@ -1025,9 +1022,9 @@ Unable to parse shape specification.
         ),
         (
             "a: [, x]",
-            f"""
+            """
 Unable to parse shape specification.
-  check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
+  check_shapes called at: __check_shapes_path_and_line__
     Argument number (0-indexed): 0
       Line:            "a: [, x]"
                             ^
@@ -1042,9 +1039,9 @@ Unable to parse shape specification.
         ),
         (
             "",
-            f"""
+            """
 Unable to parse shape specification.
-  check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
+  check_shapes called at: __check_shapes_path_and_line__
     Argument number (0-indexed): 0
       Line:            ""
                         ^
@@ -1059,9 +1056,9 @@ Unable to parse shape specification.
     batch...
     x
   ]""",
-            f"""
+            """
 Unable to parse shape specification.
-  check_shapes called at: {__file__}:{_CHECK_SHAPES_LINE}
+  check_shapes called at: __check_shapes_path_and_line__
     Argument number (0-indexed): 0
       Line:            "    x"
                             ^
@@ -1072,9 +1069,13 @@ Unable to parse shape specification.
     ],
 )
 def test_parse_argument_spec__error(spec: str, expected_message: str) -> None:
+    check_shapes_path_and_line = f"{__file__}:{current_line() + 2}"
     with pytest.raises(SpecificationParseError) as e:
         check_shapes(spec)
     (message,) = e.value.args
+    expected_message = expected_message.replace(
+        "__check_shapes_path_and_line__", check_shapes_path_and_line
+    )
     assert expected_message == message
 
 

--- a/tests/gpflow/experimental/check_shapes/test_test_utils.py
+++ b/tests/gpflow/experimental/check_shapes/test_test_utils.py
@@ -1,0 +1,21 @@
+# Copyright 2022 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the test utils...
+"""
+from .utils import current_line
+
+
+def test_current_line() -> None:
+    assert 21 == current_line()

--- a/tests/gpflow/experimental/check_shapes/utils.py
+++ b/tests/gpflow/experimental/check_shapes/utils.py
@@ -14,6 +14,7 @@
 """
 Utilities for testing the `check_shapes` library.
 """
+import inspect
 from dataclasses import dataclass
 from typing import Optional, Union
 
@@ -90,3 +91,11 @@ def make_argument_ref(argument_name: str, *refs: Union[int, str]) -> ArgumentRef
         else:
             result = AttributeArgumentRef(result, ref)
     return result
+
+
+def current_line() -> int:
+    """
+    Returns the line number of the line that called this function.
+    """
+    stack = inspect.stack()
+    return stack[1].lineno


### PR DESCRIPTION
Yeah, ok. @uri-granta is right. Manually maintaining those line numbers in tests is a total pain. Hopefully this will help.