### PR TITLE
Support checking all elements of collections.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -137,6 +137,7 @@ disable=missing-docstring,
         len-as-condition,
         too-many-statements,
         duplicate-code,
+        too-many-public-methods,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/gpflow/experimental/check_shapes/__init__.py
+++ b/gpflow/experimental/check_shapes/__init__.py
@@ -53,6 +53,9 @@ The ``<argument specifier>`` can then be modified to refer to elements of the ob
 * Use ``.<name>`` to refer to attributes of the object.
 * Use ``[<index>]`` to refer to elements of a sequence. This is particularly useful if your
   function returns a tuple of values.
+* Use ``[all]`` to select all elements in a collection.
+* Use ``.keys()`` to select all keys in a mapping.
+* Use ``.values()`` to select all values in a mapping.
 
 We do not support looking up values in a  ``dict``.
 
@@ -65,7 +68,10 @@ For example::
         "data.training_data: ...",
         "return: ...",
         "return[0]: ...",
-        "something[0].foo.bar[23]: ...",
+        "data_list[all]: ...",
+        "data_dict.keys(): ...",
+        "data_dict.values(): ...",
+        "something[all].foo[0].bar.values(): ...",
     )
     def f(...):
         ...
@@ -123,8 +129,9 @@ You can use the optional `if <condition>` syntax to conditionally evaluate shape
 <condition>` is used, the specification is only appplied if `<condition>` evaluates to `True`. This
 is useful if shapes depend on other input parameters. Valid conditions are:
 
-* ``<argument specifier>``, with the same syntax and rules as above, uses the `bool` built-in to
-  convert the value of the argument to a `bool`.
+* ``<argument specifier>``, with the same syntax and rules as above, except that constructions that
+  evaluates to multiple elements are disallowed. Uses the `bool` built-in to convert the value of
+  the argument to a `bool`.
 * ``<left> or <right>``, evaluates to `True` if any of `<left>` or `<right>` evaluates to `True`
   and to `False` otherwise.
 * ``<left> and <right>``, evaluates to `False` if any of `<left>` or `<right>` evaluates to
@@ -431,7 +438,10 @@ from .error_contexts import (
     FunctionDefinitionContext,
     IndexContext,
     LarkUnexpectedInputContext,
+    MappingKeyContext,
+    MappingValueContext,
     MessageBuilder,
+    MultipleElementBoolContext,
     ObjectTypeContext,
     ObjectValueContext,
     ParallelContext,
@@ -466,7 +476,10 @@ __all__ = [
     "FunctionDefinitionContext",
     "IndexContext",
     "LarkUnexpectedInputContext",
+    "MappingKeyContext",
+    "MappingValueContext",
     "MessageBuilder",
+    "MultipleElementBoolContext",
     "NoShapeError",
     "ObjectTypeContext",
     "ObjectValueContext",

--- a/gpflow/experimental/check_shapes/argument_ref.py
+++ b/gpflow/experimental/check_shapes/argument_ref.py
@@ -16,13 +16,15 @@ Code for (de)referencing arguments.
 """
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import Any, Iterable, List, Mapping, Sequence, Tuple
 
 from .error_contexts import (
     ArgumentContext,
     AttributeContext,
     ErrorContext,
     IndexContext,
+    MappingKeyContext,
+    MappingValueContext,
     StackContext,
 )
 from .exceptions import ArgumentReferenceError
@@ -49,16 +51,13 @@ class ArgumentRef(ABC):
         Returns `RESULT_TOKEN` if this in an argument to the function result.
         """
 
-    @property
     @abstractmethod
-    def error_context(self) -> ErrorContext:
+    def get(
+        self, arg_map: Mapping[str, Any], context: ErrorContext
+    ) -> Sequence[Tuple[Any, ErrorContext]]:
         """
-        Return an error context for the value of this argument.
+        Get the value(s) of this argument from the given argument map.
         """
-
-    @abstractmethod
-    def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Optional[Any]:
-        """ Get the value of this argument from the given argument map. """
 
     @abstractmethod
     def __repr__(self) -> str:
@@ -79,81 +78,134 @@ class RootArgumentRef(ArgumentRef):
     def root_argument_name(self) -> str:
         return self.argument_name
 
-    @property
-    def error_context(self) -> ErrorContext:
-        return ArgumentContext(self.argument_name)
+    def get(
+        self, arg_map: Mapping[str, Any], context: ErrorContext
+    ) -> Sequence[Tuple[Any, ErrorContext]]:
+        relative_context = ArgumentContext(self.argument_name)
 
-    def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Optional[Any]:
         try:
-            return arg_map[self.argument_name]
+            arg_value = arg_map[self.argument_name]
         except Exception as e:
-            raise ArgumentReferenceError(StackContext(context, self.error_context)) from e
+            raise ArgumentReferenceError(StackContext(context, relative_context)) from e
+
+        return [(arg_value, relative_context)]
 
     def __repr__(self) -> str:
         return self.argument_name
 
 
+@dataclass(frozen=True)  # type: ignore
+class DelegatingArgumentRef(ArgumentRef):
+    """ Abstract base class for `ArgumentRef`s the delegates to a source. """
+
+    source: ArgumentRef
+
+    @property
+    def is_result(self) -> bool:
+        return self.source.is_result
+
+    @property
+    def root_argument_name(self) -> str:
+        return self.source.root_argument_name
+
+    @abstractmethod
+    def map_value(self, value: Any, context: ErrorContext) -> Iterable[Tuple[Any, ErrorContext]]:
+        """
+        Map this value, from `self.source` to new value(s).
+        """
+
+    def map_context(self, context: ErrorContext) -> ErrorContext:
+        """
+        Pre-map this error context from `self.source`.
+
+        The mapped value will both be used for error messages and passed to `map_value` above.
+        """
+        return context
+
+    def get(
+        self, arg_map: Mapping[str, Any], context: ErrorContext
+    ) -> Sequence[Tuple[Any, ErrorContext]]:
+        results: List[Tuple[Any, ErrorContext]] = []
+        sources = self.source.get(arg_map, context)
+        for source, source_relative_context in sources:
+
+            if source is None:
+                results.append((source, source_relative_context))
+                continue
+
+            try:
+                relative_context = self.map_context(source_relative_context)
+            except Exception as e:
+                raise ArgumentReferenceError(context) from e
+
+            try:
+                results.extend(self.map_value(source, relative_context))
+            except Exception as e:
+                raise ArgumentReferenceError(StackContext(context, relative_context)) from e
+
+        return results
+
+
 @dataclass(frozen=True)
-class AttributeArgumentRef(ArgumentRef):
+class AttributeArgumentRef(DelegatingArgumentRef):
     """ A reference to an attribute on an argument. """
 
-    source: ArgumentRef
     attribute_name: str
 
-    @property
-    def is_result(self) -> bool:
-        return self.source.is_result
+    def map_value(self, value: Any, context: ErrorContext) -> Iterable[Tuple[Any, ErrorContext]]:
+        return [(getattr(value, self.attribute_name), context)]
 
-    @property
-    def root_argument_name(self) -> str:
-        return self.source.root_argument_name
-
-    @property
-    def error_context(self) -> ErrorContext:
-        return StackContext(self.source.error_context, AttributeContext(self.attribute_name))
-
-    def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Optional[Any]:
-        source = self.source.get(arg_map, context)
-        if source is None:
-            return None
-
-        try:
-            return getattr(source, self.attribute_name)
-        except Exception as e:
-            raise ArgumentReferenceError(StackContext(context, self.error_context)) from e
+    def map_context(self, context: ErrorContext) -> ErrorContext:
+        return StackContext(context, AttributeContext(self.attribute_name))
 
     def __repr__(self) -> str:
-        return f"{repr(self.source)}.{self.attribute_name}"
+        return f"{self.source!r}.{self.attribute_name}"
 
 
 @dataclass(frozen=True)
-class IndexArgumentRef(ArgumentRef):
+class IndexArgumentRef(DelegatingArgumentRef):
     """ A reference to an element in a list. """
 
-    source: ArgumentRef
     index: int
 
-    @property
-    def is_result(self) -> bool:
-        return self.source.is_result
+    def map_value(self, value: Any, context: ErrorContext) -> Iterable[Tuple[Any, ErrorContext]]:
+        return [(value[self.index], context)]
 
-    @property
-    def root_argument_name(self) -> str:
-        return self.source.root_argument_name
-
-    @property
-    def error_context(self) -> ErrorContext:
-        return StackContext(self.source.error_context, IndexContext(self.index))
-
-    def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Optional[Any]:
-        source = self.source.get(arg_map, context)
-        if source is None:
-            return None
-
-        try:
-            return source[self.index]  # type: ignore
-        except Exception as e:
-            raise ArgumentReferenceError(StackContext(context, self.error_context)) from e
+    def map_context(self, context: ErrorContext) -> ErrorContext:
+        return StackContext(context, IndexContext(self.index))
 
     def __repr__(self) -> str:
-        return f"{repr(self.source)}[{self.index}]"
+        return f"{self.source!r}[{self.index}]"
+
+
+@dataclass(frozen=True)
+class AllElementsRef(DelegatingArgumentRef):
+    """ A reference to all elements in a collection. """
+
+    def map_value(self, value: Any, context: ErrorContext) -> Iterable[Tuple[Any, ErrorContext]]:
+        return [(v, StackContext(context, IndexContext(i))) for i, v in enumerate(value)]
+
+    def __repr__(self) -> str:
+        return f"{self.source!r}[all]"
+
+
+@dataclass(frozen=True)
+class KeysRef(DelegatingArgumentRef):
+    """ A reference to all keys of a mapping. """
+
+    def map_value(self, value: Any, context: ErrorContext) -> Iterable[Tuple[Any, ErrorContext]]:
+        return [(k, StackContext(context, MappingKeyContext(k))) for k in value]
+
+    def __repr__(self) -> str:
+        return f"{self.source!r}.keys()"
+
+
+@dataclass(frozen=True)
+class ValuesRef(DelegatingArgumentRef):
+    """ A reference to all values of a mapping. """
+
+    def map_value(self, value: Any, context: ErrorContext) -> Iterable[Tuple[Any, ErrorContext]]:
+        return [(v, StackContext(context, MappingValueContext(k))) for k, v in value.items()]
+
+    def __repr__(self) -> str:
+        return f"{self.source!r}.values()"

--- a/gpflow/experimental/check_shapes/bool_specs.py
+++ b/gpflow/experimental/check_shapes/bool_specs.py
@@ -93,10 +93,8 @@ class ParsedArgumentRefBoolSpec(ParsedBoolSpec):
     argument_ref: ArgumentRef
 
     def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Tuple[bool, ErrorContext]:
-        arg_value = self.argument_ref.get(arg_map, context)
-        return bool(arg_value), StackContext(
-            self.argument_ref.error_context, ObjectValueContext(arg_value)
-        )
+        ((arg_value, relative_context),) = self.argument_ref.get(arg_map, context)
+        return bool(arg_value), StackContext(relative_context, ObjectValueContext(arg_value))
 
     def __repr__(self) -> str:
         return repr(self.argument_ref)

--- a/gpflow/experimental/check_shapes/check_shapes.lark
+++ b/gpflow/experimental/check_shapes/check_shapes.lark
@@ -37,10 +37,16 @@ bool_spec_argument_ref: argument_ref
 ?argument_ref: argument_ref_root
              | argument_ref_attribute
              | argument_ref_index
+             | argument_ref_all
+             | argument_ref_keys
+             | argument_ref_values
 
 argument_ref_root: CNAME
 argument_ref_attribute: argument_ref "." CNAME
 argument_ref_index: argument_ref "[" INT "]"
+argument_ref_all: argument_ref "[" "all" "]"
+argument_ref_keys: argument_ref "." "keys" "(" ")"
+argument_ref_values: argument_ref "." "values" "(" ")"
 
 tensor_spec: shape_spec note_spec?
 

--- a/gpflow/experimental/check_shapes/error_contexts.py
+++ b/gpflow/experimental/check_shapes/error_contexts.py
@@ -404,6 +404,34 @@ class IndexContext(ErrorContext):
 
 
 @dataclass(frozen=True)
+class MappingKeyContext(ErrorContext):
+    """
+    An error occurent in the context of a key in a map.
+    """
+
+    key: Any
+
+    def print(self, builder: MessageBuilder) -> None:
+        builder.add_columned_line("Map key:", f"[{self.key!r}]")
+
+
+@dataclass(frozen=True)
+class MappingValueContext(ErrorContext):
+    """
+    An error occurent in the context of a value in a map.
+    """
+
+    key: Any
+    value: Any = _NO_VALUE
+
+    def print(self, builder: MessageBuilder) -> None:
+        builder.add_columned_line("Map value, of key:", f"[{self.key!r}]")
+        if self.value is not _NO_VALUE:
+            with builder.indent() as b:
+                b.add_columned_line("Value:", self.value)
+
+
+@dataclass(frozen=True)
 class ConditionContext(ErrorContext):
     """
     An error occurred in a conditional context.
@@ -533,3 +561,20 @@ class TrailingBroadcastVarrankContext(ParserInputContext):
         if self.variable is not None:
             builder.add_columned_line("Variable", self.variable)
         builder.add_line("Broadcasting not supported for non-leading variable-rank variables.")
+
+
+@dataclass(frozen=True)
+class MultipleElementBoolContext(ParserInputContext):
+    """
+    An error was caused by trying to use a multi-element argument specification as a bool.
+    """
+
+    line: int
+    column: int
+
+    def print(self, builder: MessageBuilder) -> None:
+        self.print_line(builder, self.line, self.column)
+        builder.add_line(
+            "Argument references that evaluate to multiple values are not supported for boolean"
+            " expressions."
+        )

--- a/tests/gpflow/experimental/check_shapes/test_argument_ref.py
+++ b/tests/gpflow/experimental/check_shapes/test_argument_ref.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Sequence, Tuple
 
 import pytest
 
@@ -23,16 +23,23 @@ from gpflow.experimental.check_shapes.error_contexts import (
     AttributeContext,
     ErrorContext,
     IndexContext,
+    MappingKeyContext,
+    MappingValueContext,
     StackContext,
 )
 
-from .utils import TestContext, make_argument_ref
+from .utils import TestContext, all_ref, keys_ref, make_argument_ref, values_ref
 
 
 @dataclass(frozen=True)
 class SomeClass:
     a: Optional[str]
     b: str
+
+
+@dataclass(frozen=True)
+class ManyClass:
+    many: Sequence[Optional[int]]
 
 
 ARG_MAP: Mapping[str, Any] = {
@@ -43,6 +50,23 @@ ARG_MAP: Mapping[str, Any] = {
     "some_class_none": SomeClass(None, "bbb"),
     "some_tuple": (42, 69),
     "some_tuple_none": (None, None),
+    "many": [
+        (
+            3,
+            {
+                "a": ManyClass(many=[111, 112]),
+                "b": ManyClass(many=[121, 122]),
+            },
+        ),
+        None,
+        (
+            7,
+            {
+                None: ManyClass(many=[None, 221]),
+                "d": None,
+            },
+        ),
+    ],
     RESULT_TOKEN: "return_value",
 }
 
@@ -53,14 +77,16 @@ class ArgumentRefTest:
     argument_ref: ArgumentRef
     expected_is_result: Optional[bool]
     expected_root_argument_name: str
-    expected_error_context: ErrorContext
     expected_repr: str
-    expected_get: Any = None
+    expected_get: Sequence[Tuple[Any, ErrorContext]] = ()
     expected_error: Optional[str] = None
 
 
 def name(test: ArgumentRefTest) -> str:
     return test.name
+
+
+sc = StackContext
 
 
 TESTS = [
@@ -69,34 +95,30 @@ TESTS = [
         argument_ref=make_argument_ref("foo"),
         expected_is_result=False,
         expected_root_argument_name="foo",
-        expected_error_context=ArgumentContext("foo"),
         expected_repr="foo",
-        expected_get="foo_value",
+        expected_get=[("foo_value", ArgumentContext("foo"))],
     ),
     ArgumentRefTest(
         name="return",
         argument_ref=make_argument_ref(RESULT_TOKEN),
         expected_is_result=True,
         expected_root_argument_name=RESULT_TOKEN,
-        expected_error_context=ArgumentContext(RESULT_TOKEN),
         expected_repr=RESULT_TOKEN,
-        expected_get="return_value",
+        expected_get=[("return_value", ArgumentContext(RESULT_TOKEN))],
     ),
     ArgumentRefTest(
         name="None_argument",
         argument_ref=make_argument_ref("none"),
         expected_is_result=False,
         expected_root_argument_name="none",
-        expected_error_context=ArgumentContext("none"),
         expected_repr="none",
-        expected_get=None,
+        expected_get=[(None, ArgumentContext("none"))],
     ),
     ArgumentRefTest(
         name="missing_argument",
         argument_ref=make_argument_ref("baz"),
         expected_is_result=False,
         expected_root_argument_name="baz",
-        expected_error_context=ArgumentContext("baz"),
         expected_repr="baz",
         expected_error="""
 Unable to resolve argument / missing argument.
@@ -109,36 +131,30 @@ Unable to resolve argument / missing argument.
         argument_ref=make_argument_ref("some_class", "b"),
         expected_is_result=False,
         expected_root_argument_name="some_class",
-        expected_error_context=StackContext(ArgumentContext("some_class"), AttributeContext("b")),
         expected_repr="some_class.b",
-        expected_get="bbb",
+        expected_get=[("bbb", sc(ArgumentContext("some_class"), AttributeContext("b")))],
     ),
     ArgumentRefTest(
         name="None_class_member",
         argument_ref=make_argument_ref("none", "c"),
         expected_is_result=False,
         expected_root_argument_name="none",
-        expected_error_context=StackContext(ArgumentContext("none"), AttributeContext("c")),
         expected_repr="none.c",
-        expected_get=None,
+        expected_get=[(None, ArgumentContext("none"))],
     ),
     ArgumentRefTest(
         name="class_None_member",
         argument_ref=make_argument_ref("some_class_none", "a"),
         expected_is_result=False,
         expected_root_argument_name="some_class_none",
-        expected_error_context=StackContext(
-            ArgumentContext("some_class_none"), AttributeContext("a")
-        ),
         expected_repr="some_class_none.a",
-        expected_get=None,
+        expected_get=[(None, sc(ArgumentContext("some_class_none"), AttributeContext("a")))],
     ),
     ArgumentRefTest(
         name="class_missing_member",
         argument_ref=make_argument_ref("some_class", "c"),
         expected_is_result=False,
         expected_root_argument_name="some_class",
-        expected_error_context=StackContext(ArgumentContext("some_class"), AttributeContext("c")),
         expected_repr="some_class.c",
         expected_error="""
 Unable to resolve argument / missing argument.
@@ -152,34 +168,30 @@ Unable to resolve argument / missing argument.
         argument_ref=make_argument_ref("some_tuple", 1),
         expected_is_result=False,
         expected_root_argument_name="some_tuple",
-        expected_error_context=StackContext(ArgumentContext("some_tuple"), IndexContext(1)),
         expected_repr="some_tuple[1]",
-        expected_get=69,
+        expected_get=[(69, sc(ArgumentContext("some_tuple"), IndexContext(1)))],
     ),
     ArgumentRefTest(
         name="None_tuple_element",
         argument_ref=make_argument_ref("none", 1),
         expected_is_result=False,
         expected_root_argument_name="none",
-        expected_error_context=StackContext(ArgumentContext("none"), IndexContext(1)),
         expected_repr="none[1]",
-        expected_get=None,
+        expected_get=[(None, ArgumentContext("none"))],
     ),
     ArgumentRefTest(
         name="tuple_None_element",
         argument_ref=make_argument_ref("some_tuple_none", 1),
         expected_is_result=False,
         expected_root_argument_name="some_tuple_none",
-        expected_error_context=StackContext(ArgumentContext("some_tuple_none"), IndexContext(1)),
         expected_repr="some_tuple_none[1]",
-        expected_get=None,
+        expected_get=[(None, sc(ArgumentContext("some_tuple_none"), IndexContext(1)))],
     ),
     ArgumentRefTest(
         name="tuple_missing_element",
         argument_ref=make_argument_ref("some_tuple", 2),
         expected_is_result=False,
         expected_root_argument_name="some_tuple",
-        expected_error_context=StackContext(ArgumentContext("some_tuple"), IndexContext(2)),
         expected_repr="some_tuple[2]",
         expected_error="""
 Unable to resolve argument / missing argument.
@@ -193,9 +205,6 @@ Unable to resolve argument / missing argument.
         argument_ref=make_argument_ref(RESULT_TOKEN, 1, "a"),
         expected_is_result=True,
         expected_root_argument_name="return",
-        expected_error_context=StackContext(
-            StackContext(ArgumentContext(RESULT_TOKEN), IndexContext(1)), AttributeContext("a")
-        ),
         expected_repr="return[1].a",
         expected_error="""
 Unable to resolve argument / missing argument.
@@ -204,6 +213,166 @@ Unable to resolve argument / missing argument.
       Index: [1]
         Attribute: .a
 """,
+    ),
+    ArgumentRefTest(
+        name="all_elements__keys",
+        argument_ref=make_argument_ref("many", all_ref, 1, keys_ref),
+        expected_is_result=False,
+        expected_root_argument_name="many",
+        expected_repr="many[all][1].keys()",
+        expected_get=[
+            (
+                "a",
+                sc(
+                    sc(
+                        sc(ArgumentContext("many"), IndexContext(0)),
+                        IndexContext(1),
+                    ),
+                    MappingKeyContext("a"),
+                ),
+            ),
+            (
+                "b",
+                sc(
+                    sc(
+                        sc(ArgumentContext("many"), IndexContext(0)),
+                        IndexContext(1),
+                    ),
+                    MappingKeyContext("b"),
+                ),
+            ),
+            (None, sc(ArgumentContext("many"), IndexContext(1))),
+            (
+                None,
+                sc(
+                    sc(
+                        sc(ArgumentContext("many"), IndexContext(2)),
+                        IndexContext(1),
+                    ),
+                    MappingKeyContext(None),
+                ),
+            ),
+            (
+                "d",
+                sc(
+                    sc(
+                        sc(ArgumentContext("many"), IndexContext(2)),
+                        IndexContext(1),
+                    ),
+                    MappingKeyContext("d"),
+                ),
+            ),
+        ],
+    ),
+    ArgumentRefTest(
+        name="all_elements__values",
+        argument_ref=make_argument_ref("many", all_ref, 1, values_ref, "many", all_ref),
+        expected_is_result=False,
+        expected_root_argument_name="many",
+        expected_repr="many[all][1].values().many[all]",
+        expected_get=[
+            (
+                111,
+                sc(
+                    sc(
+                        sc(
+                            sc(
+                                sc(ArgumentContext("many"), IndexContext(0)),
+                                IndexContext(1),
+                            ),
+                            MappingValueContext("a"),
+                        ),
+                        AttributeContext("many"),
+                    ),
+                    IndexContext(0),
+                ),
+            ),
+            (
+                112,
+                sc(
+                    sc(
+                        sc(
+                            sc(
+                                sc(ArgumentContext("many"), IndexContext(0)),
+                                IndexContext(1),
+                            ),
+                            MappingValueContext("a"),
+                        ),
+                        AttributeContext("many"),
+                    ),
+                    IndexContext(1),
+                ),
+            ),
+            (
+                121,
+                sc(
+                    sc(
+                        sc(
+                            sc(
+                                sc(ArgumentContext("many"), IndexContext(0)),
+                                IndexContext(1),
+                            ),
+                            MappingValueContext("b"),
+                        ),
+                        AttributeContext("many"),
+                    ),
+                    IndexContext(0),
+                ),
+            ),
+            (
+                122,
+                sc(
+                    sc(
+                        sc(
+                            sc(
+                                sc(ArgumentContext("many"), IndexContext(0)),
+                                IndexContext(1),
+                            ),
+                            MappingValueContext("b"),
+                        ),
+                        AttributeContext("many"),
+                    ),
+                    IndexContext(1),
+                ),
+            ),
+            (None, sc(ArgumentContext("many"), IndexContext(1))),
+            (
+                None,
+                sc(
+                    sc(
+                        sc(
+                            sc(sc(ArgumentContext("many"), IndexContext(2)), IndexContext(1)),
+                            MappingValueContext(None),
+                        ),
+                        AttributeContext("many"),
+                    ),
+                    IndexContext(0),
+                ),
+            ),
+            (
+                221,
+                sc(
+                    sc(
+                        sc(
+                            sc(
+                                sc(ArgumentContext("many"), IndexContext(2)),
+                                IndexContext(1),
+                            ),
+                            MappingValueContext(None),
+                        ),
+                        AttributeContext("many"),
+                    ),
+                    IndexContext(1),
+                ),
+            ),
+            (
+                None,
+                sc(
+                    sc(sc(ArgumentContext("many"), IndexContext(2)), IndexContext(1)),
+                    MappingValueContext("d"),
+                ),
+            ),
+        ],
     ),
 ]
 
@@ -219,28 +388,21 @@ def test_parse_argument_ref__root_argument_name(test: ArgumentRefTest) -> None:
 
 
 @pytest.mark.parametrize("test", TESTS, ids=name)
-def test_parse_argument_ref__error_context(test: ArgumentRefTest) -> None:
-    assert test.expected_error_context == test.argument_ref.error_context
-
-
-@pytest.mark.parametrize("test", TESTS, ids=name)
 def test_parse_argument_ref__repr(test: ArgumentRefTest) -> None:
     assert test.expected_repr == repr(test.argument_ref)
 
 
 @pytest.mark.parametrize("test", [test for test in TESTS if test.expected_error is None], ids=name)
 def test_parse_argument_ref__get(test: ArgumentRefTest) -> None:
-    context = TestContext()
-    value = test.argument_ref.get(ARG_MAP, context)
-    assert test.expected_get == value
+    values = test.argument_ref.get(ARG_MAP, TestContext())
+    assert test.expected_get == values
 
 
 @pytest.mark.parametrize(
     "test", [test for test in TESTS if test.expected_error is not None], ids=name
 )
 def test_parse_argument_ref__error(test: ArgumentRefTest) -> None:
-    context = TestContext()
     with pytest.raises(ArgumentReferenceError) as e:
-        test.argument_ref.get(ARG_MAP, context)
+        test.argument_ref.get(ARG_MAP, TestContext())
     (message,) = e.value.args
     assert test.expected_error == message

--- a/tests/gpflow/experimental/check_shapes/utils.py
+++ b/tests/gpflow/experimental/check_shapes/utils.py
@@ -16,14 +16,18 @@ Utilities for testing the `check_shapes` library.
 """
 import inspect
 from dataclasses import dataclass
+from enum import Enum
 from typing import Optional, Union
 
 from gpflow.experimental.check_shapes import Dimension, Shape, get_shape
 from gpflow.experimental.check_shapes.argument_ref import (
+    AllElementsRef,
     ArgumentRef,
     AttributeArgumentRef,
     IndexArgumentRef,
+    KeysRef,
     RootArgumentRef,
+    ValuesRef,
 )
 from gpflow.experimental.check_shapes.bool_specs import (
     ParsedAndBoolSpec,
@@ -76,13 +80,33 @@ def t(*shape: Dimension) -> TestShaped:
     return TestShaped(shape)
 
 
-def make_argument_ref(argument_name: str, *refs: Union[int, str]) -> ArgumentRef:
+class ArgumentRefConstant(Enum):
+    ALL = "all"
+    KEYS = "keys"
+    VALUES = "values"
+
+
+all_ref = ArgumentRefConstant.ALL
+keys_ref = ArgumentRefConstant.KEYS
+values_ref = ArgumentRefConstant.VALUES
+
+
+def make_argument_ref(
+    argument_name: str, *refs: Union[int, str, ArgumentRefConstant]
+) -> ArgumentRef:
     result: ArgumentRef = RootArgumentRef(argument_name)
     for ref in refs:
         if isinstance(ref, int):
             result = IndexArgumentRef(result, ref)
-        else:
+        elif isinstance(ref, str):
             result = AttributeArgumentRef(result, ref)
+        elif ref == all_ref:
+            result = AllElementsRef(result)
+        elif ref == keys_ref:
+            result = KeysRef(result)
+        else:
+            assert ref == values_ref
+            result = ValuesRef(result)
     return result
 
 


### PR DESCRIPTION
What we're trying to achieve is to enable the checking of all members of collections. For example we might have a function (`concat_rows`) that takes a collection of array, and require:

1. All inputs have rank 2.
2. The inputs may have any number of rows.
3. The inputs must have the same number of columns.
4. The output has rank 2.
5. The output may have any number of rows.
6. The output has the same number of columns as the input.

```python
check_shapes(
    "xs[all]: [., n_cols]",
    "return: [., n_cols]",
)
def concat_rows(xs: Sequence[np.ndarray]) -> np.ndarray:
    return np.concatenate(xs, axis=0)
```

To do that we:

1. Update `ArgumentRef` and friends to handle collections. Previously `get` would return a single value and `error_context` would return a single `ErrorContext`. In this PR I remove `error_context` and update `get` to return a list of `(value, error_context)` tuples. Then I update all the `ArgumentRef` implementations to handle sequences. Note that previously missing values were handled by returning `None` - now I handle them by returning an empty list.
7. Update `check_shapes` to handle that the `ArgumentRef` now returns a list, and check all elements of that list.
8. Create a common abstract base class (`DelegatingArgumentRef`) for `ArgumentRef`s that are a wrapper around another `ArgumentRef` - which is most of the implementations. This is just for code reuse.
9. Add new syntax for selecting all elements of collections to `check_shapes.lark`. I use `foo[all]` to select all elements of a sequence, `foo.keys()` to select the keys of a mapping, and `foo.values()` to select the values from a mapping. I'm not super happy about the inconsistent syntax - any ideas?
10. Add new `ArgumentRef` implementations (`AllElementsRef`, `KeysRef`, and `ValuesRef`) corresponding to the three new syntaxes.
11. Add new `ErrorContext`s (`MappingKeyContext` and `MappingValueContext`) to be used by errors generated by (`KeysRef` and `ValuesRef`) respectively. (`AllElementsRef` uses the pre-existing `IndexContext`.)
12. Update `parser.py` to translate the new syntax into the new arguments refs.
13. Update our documentation to mention the new syntax.
14. Update our unit tests.