### PR TITLE
Fix problems with forward references in our documentation.

### DIFF
--- a/doc/generate_module_rst.py
+++ b/doc/generate_module_rst.py
@@ -16,10 +16,9 @@ To be run by the CI system to update docs.
 """
 import inspect
 from dataclasses import dataclass
-from io import TextIOWrapper
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, Deque, Dict, List, Mapping, Optional, Set, Type, Union
+from typing import Any, Callable, Deque, Dict, List, Mapping, Optional, Set, TextIO, Type, Union
 
 from gpflow.utilities import Dispatcher
 
@@ -50,7 +49,7 @@ class DocumentableDispatcher:
             implementations.setdefault(impl, []).append(args)
         return implementations
 
-    def write(self, out: TextIOWrapper) -> None:
+    def write(self, out: TextIO) -> None:
         out.write(
             f"""
 {_header(self.name, 2)}
@@ -84,7 +83,7 @@ class DocumentableClass:
     name: str
     obj: Type[Any]
 
-    def write(self, out: TextIOWrapper) -> None:
+    def write(self, out: TextIO) -> None:
         out.write(
             f"""
 {_header(self.name, 2)}
@@ -102,7 +101,7 @@ class DocumentableFunction:
     name: str
     obj: Callable[..., Any]
 
-    def write(self, out: TextIOWrapper) -> None:
+    def write(self, out: TextIO) -> None:
         out.write(
             f"""
 {_header(self.name, 2)}
@@ -215,7 +214,7 @@ class DocumentableModule:
         self.prune_duplicates()
         self.prune_empty_modules()
 
-    def write_modules(self, out: TextIOWrapper) -> None:
+    def write_modules(self, out: TextIO) -> None:
         if not self.modules:
             return
 
@@ -231,7 +230,7 @@ class DocumentableModule:
         for module in self.modules:
             out.write(f"   {module.name} <{module.name.split('.')[-1]}/index>\n")
 
-    def write_classes(self, out: TextIOWrapper) -> None:
+    def write_classes(self, out: TextIO) -> None:
         if not self.classes:
             return
 
@@ -243,7 +242,7 @@ class DocumentableModule:
         for cls in self.classes:
             cls.write(out)
 
-    def write_functions(self, out: TextIOWrapper) -> None:
+    def write_functions(self, out: TextIO) -> None:
         if not self.functions:
             return
 

--- a/gpflow/experimental/check_shapes/error_contexts.py
+++ b/gpflow/experimental/check_shapes/error_contexts.py
@@ -48,7 +48,7 @@ from lark.exceptions import UnexpectedCharacters, UnexpectedEOF, UnexpectedInput
 
 from .base_types import Shape
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .argument_ref import ArgumentRef
     from .specs import ParsedNoteSpec, ParsedShapeSpec
 

--- a/gpflow/monitor/tensorboard.py
+++ b/gpflow/monitor/tensorboard.py
@@ -25,7 +25,7 @@ from ..models import BayesianModel
 from ..utilities import parameter_dict
 from .base import MonitorTask
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     import matplotlib
 
 


### PR DESCRIPTION
What appears to be happening is:

In file "a.py" we have an alias with a forward reference:
```
MyType = Union["SomeForwardReference", "SomeOtherReference"]
```

In file "b.py" we use the alias:
```
from a import MyType

def f() -> MyType:
    return ...
```

Now Sphinx tries to resolve `MyType` in the file `b.py` where `SomeForwardReference` isn't defined, and Sphinx blows up.

So, I shuffle about some stuff to avoid aliases with forward references.


A couple of drive-by fixes:
* Mark `if TYPE_CHECKING` statements with `# pragma: no cover`, because obviously they aren't tested.
* Some types in `doc/generate_module_rst.py`.