### PR TITLE
Add conditional shapes.

### DIFF
--- a/gpflow/experimental/check_shapes/argument_ref.py
+++ b/gpflow/experimental/check_shapes/argument_ref.py
@@ -58,7 +58,7 @@ class ArgumentRef(ABC):
 
     @abstractmethod
     def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Optional[Any]:
-        """ Get the value of this argument from this given map. """
+        """ Get the value of this argument from the given argument map. """
 
     @abstractmethod
     def __repr__(self) -> str:

--- a/gpflow/experimental/check_shapes/bool_specs.py
+++ b/gpflow/experimental/check_shapes/bool_specs.py
@@ -1,0 +1,102 @@
+# Copyright 2022 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Code for specifying and evaluating boolean expressions.
+"""
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Mapping, Tuple
+
+from .argument_ref import ArgumentRef
+from .error_contexts import ErrorContext, ObjectValueContext, ParallelContext, StackContext
+
+
+class ParsedBoolSpec(ABC):
+    """ A boolean expression. """
+
+    @abstractmethod
+    def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Tuple[bool, ErrorContext]:
+        """ Evaluate this boolean value. """
+
+
+def _paren_repr(spec: ParsedBoolSpec) -> str:
+    """
+    Return the `repr` of `spec`, wrapping it in parenthesis if it is a non-trivial expression.
+    """
+    result = repr(spec)
+    if isinstance(spec, ParsedArgumentRefBoolSpec):
+        return result
+    return f"({result})"
+
+
+@dataclass(frozen=True)
+class ParsedOrBoolSpec(ParsedBoolSpec):
+    """ An "or" expression. """
+
+    left: ParsedBoolSpec
+    right: ParsedBoolSpec
+
+    def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Tuple[bool, ErrorContext]:
+        left_value, left_context = self.left.get(arg_map, context)
+        right_value, right_context = self.right.get(arg_map, context)
+        return (left_value or right_value), ParallelContext((left_context, right_context))
+
+    def __repr__(self) -> str:
+        return f"{_paren_repr(self.left)} or {_paren_repr(self.right)}"
+
+
+@dataclass(frozen=True)
+class ParsedAndBoolSpec(ParsedBoolSpec):
+    """ An "and" expression. """
+
+    left: ParsedBoolSpec
+    right: ParsedBoolSpec
+
+    def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Tuple[bool, ErrorContext]:
+        left_value, left_context = self.left.get(arg_map, context)
+        right_value, right_context = self.right.get(arg_map, context)
+        return (left_value and right_value), ParallelContext((left_context, right_context))
+
+    def __repr__(self) -> str:
+        return f"{_paren_repr(self.left)} and {_paren_repr(self.right)}"
+
+
+@dataclass(frozen=True)
+class ParsedNotBoolSpec(ParsedBoolSpec):
+    """ A "not" expression. """
+
+    right: ParsedBoolSpec
+
+    def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Tuple[bool, ErrorContext]:
+        right_value, right_context = self.right.get(arg_map, context)
+        return (not right_value), right_context
+
+    def __repr__(self) -> str:
+        return f"not {_paren_repr(self.right)}"
+
+
+@dataclass(frozen=True)
+class ParsedArgumentRefBoolSpec(ParsedBoolSpec):
+    """ A reference to an input argument. """
+
+    argument_ref: ArgumentRef
+
+    def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Tuple[bool, ErrorContext]:
+        arg_value = self.argument_ref.get(arg_map, context)
+        return bool(arg_value), StackContext(
+            self.argument_ref.error_context, ObjectValueContext(arg_value)
+        )
+
+    def __repr__(self) -> str:
+        return repr(self.argument_ref)

--- a/gpflow/experimental/check_shapes/check_shapes.lark
+++ b/gpflow/experimental/check_shapes/check_shapes.lark
@@ -17,7 +17,22 @@
 ?argument_or_note_spec: argument_spec
                       | note_spec
 
-argument_spec: argument_ref ":" tensor_spec
+argument_spec: argument_ref ":" shape_spec ("if" bool_spec)? note_spec?
+
+?bool_spec: bool_spec_1
+          | bool_spec_or
+
+?bool_spec_1: bool_spec_2
+            | bool_spec_and
+
+?bool_spec_2: "(" bool_spec ")"
+            | bool_spec_not
+            | bool_spec_argument_ref
+
+bool_spec_or: bool_spec "or" bool_spec_1
+bool_spec_and: bool_spec_1 "and" bool_spec_2
+bool_spec_not: "not" bool_spec_2
+bool_spec_argument_ref: argument_ref
 
 ?argument_ref: argument_ref_root
              | argument_ref_attribute

--- a/gpflow/experimental/check_shapes/checker.py
+++ b/gpflow/experimental/check_shapes/checker.py
@@ -256,15 +256,15 @@ class ShapeChecker:
                     StackContext(
                         VariableContext(variable),
                         ParallelContext(
-                            [
+                            tuple(
                                 StackContext(c, TensorSpecContext(s))
                                 for s, c in self._specs_by_variable[variable]
-                            ]
+                            )
                         ),
                     )
                 )
         if new_variable_error_contexts:
-            raise VariableTypeError(ParallelContext(new_variable_error_contexts))
+            raise VariableTypeError(ParallelContext(tuple(new_variable_error_contexts)))
 
         def _assert(condition: bool) -> None:
             if not condition:
@@ -275,10 +275,10 @@ class ShapeChecker:
                     shape_error_context: ErrorContext = ShapeContext(tensor_spec.shape, shape)
                     if tensor_spec.note is not None:
                         shape_error_context = ParallelContext(
-                            [NoteContext(tensor_spec.note), shape_error_context]
+                            (NoteContext(tensor_spec.note), shape_error_context)
                         )
                     contexts.append(StackContext(context, shape_error_context))
-                raise ShapeMismatchError(ParallelContext(contexts))
+                raise ShapeMismatchError(ParallelContext(tuple(contexts)))
 
         for actual, tensor_spec in new_shapes:
             actual_len = len(actual)

--- a/gpflow/experimental/check_shapes/decorator.py
+++ b/gpflow/experimental/check_shapes/decorator.py
@@ -16,7 +16,7 @@ Decorator for checking the shapes of function using tf Tensors.
 """
 import inspect
 from functools import wraps
-from typing import Any, Callable, cast
+from typing import Any, Callable, Sequence, cast
 
 from ..utils import experimental
 from .accessors import set_check_shapes
@@ -26,12 +26,15 @@ from .checker import ShapeChecker
 from .checker_context import set_shape_checker
 from .config import get_enable_check_shapes
 from .error_contexts import (
+    ConditionContext,
     FunctionCallContext,
     FunctionDefinitionContext,
     NoteContext,
+    ParallelContext,
     StackContext,
 )
 from .parser import parse_and_rewrite_docstring, parse_function_spec
+from .specs import ParsedArgumentSpec
 
 
 def null_check_shapes(func: C) -> C:
@@ -89,27 +92,47 @@ def check_shapes(*specs: str) -> Callable[[C], C]:
             for note_spec in note_specs:
                 checker.add_context(StackContext(bound_error_context, NoteContext(note_spec)))
 
-            checker.check_shapes(
-                (
-                    arg_spec.argument_ref.get(arg_map, bound_error_context),
-                    arg_spec.tensor,
-                    StackContext(bound_error_context, arg_spec.argument_ref.error_context),
-                )
-                for arg_spec in pre_specs
-            )
+            def _check_specs(specs: Sequence[ParsedArgumentSpec]) -> None:
+                processed_specs = []
+
+                for arg_spec in specs:
+                    arg_value = arg_spec.argument_ref.get(arg_map, bound_error_context)
+                    arg_context = StackContext(
+                        bound_error_context, arg_spec.argument_ref.error_context
+                    )
+
+                    if arg_spec.condition is not None:
+                        condition, condition_context = arg_spec.condition.get(
+                            arg_map, StackContext(arg_context, ConditionContext(arg_spec.condition))
+                        )
+                        if not condition:
+                            continue
+                        arg_context = StackContext(
+                            bound_error_context,
+                            ParallelContext(
+                                (
+                                    StackContext(
+                                        arg_spec.argument_ref.error_context,
+                                        StackContext(
+                                            ConditionContext(arg_spec.condition),
+                                            condition_context,
+                                        ),
+                                    ),
+                                )
+                            ),
+                        )
+
+                    processed_specs.append((arg_value, arg_spec.tensor, arg_context))
+
+                checker.check_shapes(processed_specs)
+
+            _check_specs(pre_specs)
 
             with set_shape_checker(checker):
                 result = func(*args, **kwargs)
             arg_map[RESULT_TOKEN] = result
 
-            checker.check_shapes(
-                (
-                    arg_spec.argument_ref.get(arg_map, bound_error_context),
-                    arg_spec.tensor,
-                    StackContext(bound_error_context, arg_spec.argument_ref.error_context),
-                )
-                for arg_spec in post_specs
-            )
+            _check_specs(post_specs)
 
             return result
 

--- a/gpflow/experimental/check_shapes/specs.py
+++ b/gpflow/experimental/check_shapes/specs.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from .argument_ref import ArgumentRef
+from .bool_specs import ParsedBoolSpec
 
 
 @dataclass(frozen=True)
@@ -95,9 +96,22 @@ class ParsedTensorSpec:
 class ParsedArgumentSpec:
     argument_ref: ArgumentRef
     tensor: ParsedTensorSpec
+    condition: Optional[ParsedBoolSpec]
 
     def __repr__(self) -> str:
-        return f"{self.argument_ref}: {self.tensor}"
+        tokens = []
+        tokens.append(f"{self.argument_ref}: ")
+        tokens.append(repr(self.tensor.shape))
+
+        if self.condition is not None:
+            tokens.append(" if ")
+            tokens.append(repr(self.condition))
+
+        if self.tensor.note is not None:
+            tokens.append("  ")
+            tokens.append(repr(self.tensor.note))
+
+        return "".join(tokens)
 
 
 @dataclass(frozen=True)

--- a/tests/gpflow/experimental/check_shapes/test_bool_specs.py
+++ b/tests/gpflow/experimental/check_shapes/test_bool_specs.py
@@ -1,0 +1,378 @@
+# Copyright 2022 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit test for code for specifying and evaluating boolean expressions.
+"""
+from dataclasses import dataclass
+from typing import Any, Mapping, Tuple
+
+import pytest
+
+from gpflow.experimental.check_shapes.bool_specs import ParsedBoolSpec
+from gpflow.experimental.check_shapes.error_contexts import (
+    ArgumentContext,
+    ErrorContext,
+    ObjectValueContext,
+    ParallelContext,
+    StackContext,
+)
+
+from .utils import TestContext, band, barg, bnot, bor
+
+CONTEXT = TestContext()
+
+
+@dataclass(frozen=True)
+class BoolSpecTest:
+    spec: ParsedBoolSpec
+    expected_get: Tuple[Tuple[Mapping[str, Any], Tuple[bool, ErrorContext]], ...]
+    expected_repr: str
+
+    def __str__(self) -> str:
+        return repr(self.spec).replace(" ", "_")
+
+
+TESTS = [
+    BoolSpecTest(
+        spec=barg("foo"),
+        expected_get=(
+            (
+                {"foo": True},
+                (
+                    True,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(True),
+                    ),
+                ),
+            ),
+            (
+                {"foo": False},
+                (
+                    False,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(False),
+                    ),
+                ),
+            ),
+            (
+                {"foo": 7},
+                (
+                    True,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(7),
+                    ),
+                ),
+            ),
+            (
+                {"foo": 0},
+                (
+                    False,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(0),
+                    ),
+                ),
+            ),
+            (
+                {"foo": [3]},
+                (
+                    True,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext([3]),
+                    ),
+                ),
+            ),
+            (
+                {"foo": []},
+                (
+                    False,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext([]),
+                    ),
+                ),
+            ),
+            (
+                {"foo": None},
+                (
+                    False,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(None),
+                    ),
+                ),
+            ),
+        ),
+        expected_repr="foo",
+    ),
+    BoolSpecTest(
+        spec=bor(barg("left"), barg("right")),
+        expected_get=(
+            (
+                {"left": True, "right": True},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(True)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(True)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": True, "right": False},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(True)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(False)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": False, "right": True},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(False)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(True)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": False, "right": False},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(False)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(False)),
+                        )
+                    ),
+                ),
+            ),
+        ),
+        expected_repr="left or right",
+    ),
+    BoolSpecTest(
+        spec=band(barg("left"), barg("right")),
+        expected_get=(
+            (
+                {"left": True, "right": True},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(True)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(True)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": True, "right": False},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(True)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(False)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": False, "right": True},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(False)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(True)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": False, "right": False},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(False)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(False)),
+                        )
+                    ),
+                ),
+            ),
+        ),
+        expected_repr="left and right",
+    ),
+    BoolSpecTest(
+        spec=bnot(barg("right")),
+        expected_get=(
+            (
+                {"right": True},
+                (False, StackContext(ArgumentContext("right"), ObjectValueContext(True))),
+            ),
+            (
+                {"right": False},
+                (True, StackContext(ArgumentContext("right"), ObjectValueContext(False))),
+            ),
+        ),
+        expected_repr="not right",
+    ),
+    BoolSpecTest(
+        spec=bor(bnot(barg("left")), bnot(barg("right"))),
+        expected_get=(
+            (
+                {"left": True, "right": True},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(True)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(True)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": True, "right": False},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(True)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(False)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": False, "right": True},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(False)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(True)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": False, "right": False},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(False)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(False)),
+                        )
+                    ),
+                ),
+            ),
+        ),
+        expected_repr="(not left) or (not right)",
+    ),
+    BoolSpecTest(
+        spec=band(bnot(barg("left")), bnot(barg("right"))),
+        expected_get=(
+            (
+                {"left": True, "right": True},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(True)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(True)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": True, "right": False},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(True)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(False)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": False, "right": True},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(False)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(True)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": False, "right": False},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(False)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(False)),
+                        )
+                    ),
+                ),
+            ),
+        ),
+        expected_repr="(not left) and (not right)",
+    ),
+    BoolSpecTest(
+        spec=bnot(bnot(barg("right"))),
+        expected_get=(
+            (
+                {"right": True},
+                (True, StackContext(ArgumentContext("right"), ObjectValueContext(True))),
+            ),
+            (
+                {"right": False},
+                (False, StackContext(ArgumentContext("right"), ObjectValueContext(False))),
+            ),
+        ),
+        expected_repr="not (not right)",
+    ),
+]
+
+
+@pytest.mark.parametrize("test", TESTS, ids=str)
+def test_bool_spec__get(test: BoolSpecTest) -> None:
+    for arg_map, expected in test.expected_get:
+        assert expected == test.spec.get(arg_map, CONTEXT)
+
+
+@pytest.mark.parametrize("test", TESTS, ids=str)
+def test_bool_spec__repr(test: BoolSpecTest) -> None:
+    assert test.expected_repr == repr(test.spec)

--- a/tests/gpflow/experimental/check_shapes/test_parser.py
+++ b/tests/gpflow/experimental/check_shapes/test_parser.py
@@ -27,7 +27,11 @@ from gpflow.experimental.check_shapes.specs import ParsedFunctionSpec, ParsedNot
 
 from .utils import (
     TestContext,
+    band,
+    barg,
     bc,
+    bnot,
+    bor,
     current_line,
     make_arg_spec,
     make_argument_ref,
@@ -61,17 +65,14 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec(2, 3),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("b"),
                     make_shape_spec(2, 4),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec(3, 4),
-                    note=None,
                 ),
             ),
             (),
@@ -108,17 +109,14 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec("d1", "d2"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("b"),
                     make_shape_spec("d1", "d3"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec("d2", "d3"),
-                    note=None,
                 ),
             ),
             (),
@@ -157,27 +155,22 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec(varrank("ds")),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("b"),
                     make_shape_spec(varrank("ds"), "d1"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("c"),
                     make_shape_spec("d1", varrank("ds"), "d2"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("d"),
                     make_shape_spec("d1", varrank("ds")),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec(varrank("ds"), "d1", "d2"),
-                    note=None,
                 ),
             ),
             (),
@@ -226,27 +219,22 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec(None, "d1"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("b"),
                     make_shape_spec(None, "d2"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("c"),
                     make_shape_spec(varrank(None), "d1"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("d"),
                     make_shape_spec(varrank(None), "d2"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec(varrank(None), "d1", "d2"),
-                    note=None,
                 ),
             ),
             (),
@@ -295,27 +283,22 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec("d1", bc(3)),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("b"),
                     make_shape_spec(bc("d1"), "d2"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("c"),
                     make_shape_spec("d1", bc(None), "d2"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("d"),
                     make_shape_spec(bc(varrank("ds"))),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec(bc(varrank(None))),
-                    note=None,
                 ),
             ),
             (),
@@ -362,17 +345,14 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec(),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("b"),
                     make_shape_spec(),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec(),
-                    note=None,
                 ),
             ),
             (),
@@ -410,22 +390,18 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("x", "ins", 0),
                     make_shape_spec(varrank("a_batch"), 1),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("x", "ins", 1),
                     make_shape_spec(varrank("b_batch"), 2),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return", 0, "out"),
                     make_shape_spec(varrank("a_batch"), 3),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return", 1, "out"),
                     make_shape_spec(varrank("b_batch"), 4),
-                    note=None,
                 ),
             ),
             (),
@@ -448,6 +424,108 @@ _TEST_DATA = [
         """,
     ),
     TestData(
+        "conditionals",
+        (
+            "x: [1] if b1",
+            "x: [2] if b1 or b2",
+            "x: [3] if b1 and b2",
+            "x: [4] if not b1",
+            "x: [5] if b1 or b2 and b3",
+            "x: [6] if (b1 or b2) and b3",
+            "x: [7] if b1 and b2 or b3",
+            "x: [8] if b1 and (b2 or b3)",
+            "x: [9] if not b1 or b2",
+            "x: [10] if not (b1 or b2)",
+            "x: [11] if not b1 and b2",
+            "x: [12] if not (b1 and b2)",
+        ),
+        ParsedFunctionSpec(
+            (
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(1),
+                    condition=barg("b1"),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(2),
+                    condition=bor(barg("b1"), barg("b2")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(3),
+                    condition=band(barg("b1"), barg("b2")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(4),
+                    condition=bnot(barg("b1")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(5),
+                    condition=bor(barg("b1"), band(barg("b2"), barg("b3"))),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(6),
+                    condition=band(bor(barg("b1"), barg("b2")), barg("b3")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(7),
+                    condition=bor(band(barg("b1"), barg("b2")), barg("b3")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(8),
+                    condition=band(barg("b1"), bor(barg("b2"), barg("b3"))),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(9),
+                    condition=bor(bnot(barg("b1")), barg("b2")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(10),
+                    condition=bnot(bor(barg("b1"), barg("b2"))),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(11),
+                    condition=band(bnot(barg("b1")), barg("b2")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(12),
+                    condition=bnot(band(barg("b1"), barg("b2"))),
+                ),
+            ),
+            (),
+        ),
+        """
+        :param x: Parameter x.
+        """,
+        """
+        :param x:
+            * **x** has shape [10] if not (*b1* or *b2*).
+            * **x** has shape [11] if (not *b1*) and *b2*.
+            * **x** has shape [12] if not (*b1* and *b2*).
+            * **x** has shape [1] if *b1*.
+            * **x** has shape [2] if *b1* or *b2*.
+            * **x** has shape [3] if *b1* and *b2*.
+            * **x** has shape [4] if not *b1*.
+            * **x** has shape [5] if *b1* or (*b2* and *b3*).
+            * **x** has shape [6] if (*b1* or *b2*) and *b3*.
+            * **x** has shape [7] if (*b1* and *b2*) or *b3*.
+            * **x** has shape [8] if *b1* and (*b2* or *b3*).
+            * **x** has shape [9] if (not *b1*) or *b2*.
+
+            Parameter x.
+        """,
+    ),
+    TestData(
         "notes",
         (
             "a: [d1, d2]",
@@ -461,7 +539,6 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec("d1", "d2"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("b"),
@@ -519,17 +596,14 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec("d1", "d2"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("b"),
                     make_shape_spec("d1", "d3"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec("d2", "d3"),
-                    note=None,
                 ),
             ),
             (),
@@ -549,17 +623,14 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec("d1", "d2"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("b"),
                     make_shape_spec("d1", "d3"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec("d2", "d3"),
-                    note=None,
                 ),
             ),
             (),
@@ -586,17 +657,14 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec("d1", "d2"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("b"),
                     make_shape_spec("d1", "d3"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec("d2", "d3"),
-                    note=None,
                 ),
             ),
             (),
@@ -618,12 +686,10 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec(varrank("batch"), "n_features"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec(varrank("batch"), 1),
-                    note=None,
                 ),
             ),
             (),
@@ -666,12 +732,10 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("a"),
                     make_shape_spec(varrank("batch"), "n_features"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec(varrank("batch"), 1),
-                    note=None,
                 ),
             ),
             (),
@@ -714,7 +778,6 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("train", "features"),
                     make_shape_spec(varrank("train_batch"), "n_features"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("train", "labels"),
@@ -724,17 +787,14 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("test_features"),
                     make_shape_spec(varrank("test_batch"), "n_features"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return", 0),
                     make_shape_spec(varrank("test_batch"), "n_labels"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return", 1),
                     make_shape_spec(varrank("test_batch"), "n_labels"),
-                    note=None,
                 ),
             ),
             (ParsedNoteSpec("Function note."),),
@@ -793,7 +853,6 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("train", "features"),
                     make_shape_spec(varrank("train_batch"), "n_features"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("train", "labels"),
@@ -803,17 +862,14 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("test_features"),
                     make_shape_spec(varrank("test_batch"), "n_features"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return", 0),
                     make_shape_spec(varrank("test_batch"), "n_labels"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return", 1),
                     make_shape_spec(varrank("test_batch"), "n_labels"),
-                    note=None,
                 ),
             ),
             (ParsedNoteSpec("Function note."),),
@@ -861,7 +917,6 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("train", "features"),
                     make_shape_spec(varrank("train_batch"), "n_features"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("train", "labels"),
@@ -871,17 +926,14 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("test_features"),
                     make_shape_spec(varrank("test_batch"), "n_features"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return", 0),
                     make_shape_spec(varrank("test_batch"), "n_labels"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return", 1),
                     make_shape_spec(varrank("test_batch"), "n_labels"),
-                    note=None,
                 ),
             ),
             (ParsedNoteSpec("Function note."),),
@@ -934,7 +986,6 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("train", "features"),
                     make_shape_spec(varrank("train_batch"), "n_features"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("train", "labels"),
@@ -944,17 +995,14 @@ _TEST_DATA = [
                 make_arg_spec(
                     make_argument_ref("test_features"),
                     make_shape_spec(varrank("test_batch"), "n_features"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return", 0),
                     make_shape_spec(varrank("test_batch"), "n_labels"),
-                    note=None,
                 ),
                 make_arg_spec(
                     make_argument_ref("return", 1),
                     make_shape_spec(varrank("test_batch"), "n_labels"),
-                    note=None,
                 ),
             ),
             (ParsedNoteSpec("Function note."),),

--- a/tests/gpflow/experimental/check_shapes/test_specs.py
+++ b/tests/gpflow/experimental/check_shapes/test_specs.py
@@ -19,7 +19,7 @@ from gpflow.experimental.check_shapes.specs import (
     ParsedNoteSpec,
 )
 
-from .utils import bc, make_arg_spec, make_argument_ref, make_shape_spec, varrank
+from .utils import barg, bc, make_arg_spec, make_argument_ref, make_shape_spec, varrank
 
 
 def test_note_spec() -> None:
@@ -34,7 +34,6 @@ def test_note_spec() -> None:
             make_arg_spec(
                 make_argument_ref("foo"),
                 make_shape_spec(),
-                note=None,
             ),
             "foo: []",
         ),
@@ -42,7 +41,6 @@ def test_note_spec() -> None:
             make_arg_spec(
                 make_argument_ref("foo"),
                 make_shape_spec(1, 2),
-                note=None,
             ),
             "foo: [1, 2]",
         ),
@@ -50,7 +48,6 @@ def test_note_spec() -> None:
             make_arg_spec(
                 make_argument_ref("foo"),
                 make_shape_spec("x", "y"),
-                note=None,
             ),
             "foo: [x, y]",
         ),
@@ -58,7 +55,6 @@ def test_note_spec() -> None:
             make_arg_spec(
                 make_argument_ref("foo"),
                 make_shape_spec(varrank("x"), "y"),
-                note=None,
             ),
             "foo: [x..., y]",
         ),
@@ -66,7 +62,6 @@ def test_note_spec() -> None:
             make_arg_spec(
                 make_argument_ref("foo"),
                 make_shape_spec("x", varrank("y"), "z"),
-                note=None,
             ),
             "foo: [x, y..., z]",
         ),
@@ -74,7 +69,6 @@ def test_note_spec() -> None:
             make_arg_spec(
                 make_argument_ref("foo"),
                 make_shape_spec(None, varrank(None), None),
-                note=None,
             ),
             "foo: [., ..., .]",
         ),
@@ -82,7 +76,6 @@ def test_note_spec() -> None:
             make_arg_spec(
                 make_argument_ref("foo"),
                 make_shape_spec(bc(varrank("y")), bc(3), bc("x")),
-                note=None,
             ),
             "foo: [broadcast y..., broadcast 3, broadcast x]",
         ),
@@ -90,7 +83,6 @@ def test_note_spec() -> None:
             make_arg_spec(
                 make_argument_ref("foo"),
                 make_shape_spec(bc(varrank(None)), bc(None)),
-                note=None,
             ),
             "foo: [broadcast ..., broadcast .]",
         ),
@@ -101,6 +93,23 @@ def test_note_spec() -> None:
                 note=ParsedNoteSpec("bar"),
             ),
             "foo: [x, y]  # bar",
+        ),
+        (
+            make_arg_spec(
+                make_argument_ref("foo"),
+                make_shape_spec("x", "y"),
+                condition=barg("bar"),
+            ),
+            "foo: [x, y] if bar",
+        ),
+        (
+            make_arg_spec(
+                make_argument_ref("foo"),
+                make_shape_spec("x", "y"),
+                condition=barg("bar"),
+                note="baz",
+            ),
+            "foo: [x, y] if bar  # baz",
         ),
     ],
 )
@@ -118,7 +127,6 @@ def test_argument_spec(argument_spec: ParsedArgumentSpec, expected_repr: str) ->
                     make_arg_spec(
                         make_argument_ref("foo"),
                         make_shape_spec("x", "y"),
-                        note=None,
                     ),
                 ),
                 (ParsedNoteSpec("note 1"),),
@@ -131,7 +139,6 @@ def test_argument_spec(argument_spec: ParsedArgumentSpec, expected_repr: str) ->
                     make_arg_spec(
                         make_argument_ref("foo"),
                         make_shape_spec("x", "y"),
-                        note=None,
                     ),
                     make_arg_spec(
                         make_argument_ref("bar"),

--- a/tests/gpflow/experimental/check_shapes/utils.py
+++ b/tests/gpflow/experimental/check_shapes/utils.py
@@ -25,6 +25,13 @@ from gpflow.experimental.check_shapes.argument_ref import (
     IndexArgumentRef,
     RootArgumentRef,
 )
+from gpflow.experimental.check_shapes.bool_specs import (
+    ParsedAndBoolSpec,
+    ParsedArgumentRefBoolSpec,
+    ParsedBoolSpec,
+    ParsedNotBoolSpec,
+    ParsedOrBoolSpec,
+)
 from gpflow.experimental.check_shapes.error_contexts import ErrorContext, MessageBuilder
 from gpflow.experimental.check_shapes.specs import (
     ParsedArgumentSpec,
@@ -77,6 +84,22 @@ def make_argument_ref(argument_name: str, *refs: Union[int, str]) -> ArgumentRef
         else:
             result = AttributeArgumentRef(result, ref)
     return result
+
+
+def barg(name: str) -> ParsedBoolSpec:
+    return ParsedArgumentRefBoolSpec(RootArgumentRef(name))
+
+
+def bor(left: ParsedBoolSpec, right: ParsedBoolSpec) -> ParsedBoolSpec:
+    return ParsedOrBoolSpec(left, right)
+
+
+def band(left: ParsedBoolSpec, right: ParsedBoolSpec) -> ParsedBoolSpec:
+    return ParsedAndBoolSpec(left, right)
+
+
+def bnot(right: ParsedBoolSpec) -> ParsedBoolSpec:
+    return ParsedNotBoolSpec(right)
 
 
 def make_note_spec(note: Union[ParsedNoteSpec, str, None]) -> Optional[ParsedNoteSpec]:
@@ -139,15 +162,19 @@ def make_shape_spec(*dims: Union[int, str, varrank, bc, None]) -> ParsedShapeSpe
 
 
 def make_tensor_spec(
-    shape_spec: ParsedShapeSpec, note: Union[ParsedNoteSpec, str, None]
+    shape_spec: ParsedShapeSpec, note: Union[ParsedNoteSpec, str, None] = None
 ) -> ParsedTensorSpec:
     return ParsedTensorSpec(shape_spec, make_note_spec(note))
 
 
 def make_arg_spec(
-    argument_ref: ArgumentRef, shape_spec: ParsedShapeSpec, note: Union[ParsedNoteSpec, str, None]
+    argument_ref: ArgumentRef,
+    shape_spec: ParsedShapeSpec,
+    *,
+    condition: Optional[ParsedBoolSpec] = None,
+    note: Union[ParsedNoteSpec, str, None] = None,
 ) -> ParsedArgumentSpec:
-    return ParsedArgumentSpec(argument_ref, make_tensor_spec(shape_spec, note))
+    return ParsedArgumentSpec(argument_ref, make_tensor_spec(shape_spec, note), condition)
 
 
 def current_line() -> int:


### PR DESCRIPTION
Add support for conditional shapes.

Including:

1. Extend the specification language with an `if` statement and minimal support for boolean expressions.
2. Type of `ParallelContext.children` has changed from `List` to `Tuple`, which allows `ParallelContext` to be hashed, which is necessary to nest a `ParallelContext` within another `ParallelContext`.
3. Updating the `check_shapes` decorator to respect the new `if` statements.
4. Added a couple of new `ErrorContext`s to describe errors within conditionals.
5. Updated test `utils.py` with some functions, `barg`, `bor`, `band`, and `bnot` to make it easy to create boolean expressions to tests. Made the `note` argument optional on a couple of existing functions.