### PR TITLE
Fix doc warnings.

### DIFF
--- a/doc/sphinx/intro.rst
+++ b/doc/sphinx/intro.rst
@@ -39,7 +39,7 @@ GPflow has a slew of kernels that can be combined in a straightforward way. See 
 
 Regression
 """"""""""
-For GP regression with Gaussian noise, it's possible to marginalize the function values exactly: you'll find this in `gpflow.models.GPR`. You can do maximum likelihood or MCMC for the covariance function parameters  (`notebook <notebooks/basics/regression.html>`_).
+For GP regression with Gaussian noise, it's possible to marginalize the function values exactly: you'll find this in `gpflow.models.GPR`. You can do maximum likelihood or MCMC for the covariance function parameters  (`regression notebook <notebooks/basics/regression.html>`_).
 
 It's also possible to do Sparse GP regression using the :class:`gpflow.models.SGPR` class. This is based on work by Michalis Titsias :cite:p:`titsias2009variational`.
 
@@ -77,7 +77,7 @@ mathematical background and the resulting software design is described in :cite:
 GPLVM
 """""
 For visualisation, the GPLVM :cite:p:`lawrence2003gaussian` and Bayesian GPLVM :cite:p:`titsias2010bayesian` models are implemented
-in GPflow (`notebook <notebooks/basics/GPLVM.html>`_).
+in GPflow (`GPLVM notebook <notebooks/basics/GPLVM.html>`_).
 
 Contributing
 ------------

--- a/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
+++ b/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
@@ -52,7 +52,7 @@ iterations = ci_niter(5)
 autotune = tf.data.experimental.AUTOTUNE
 
 # %% [markdown]
-# ### VGP is a GPR
+# ## VGP is a GPR
 
 # %% [markdown]
 # The following section demonstrates how natural gradients can turn VGP into GPR *in a single step, if the likelihood is Gaussian*.
@@ -100,7 +100,7 @@ natgrad_opt.minimize(vgp.training_loss, var_list=variational_params)
 vgp.elbo().numpy()
 
 # %% [markdown]
-# ### Optimize both variational parameters and kernel hyperparameters together
+# ## Optimize both variational parameters and kernel hyperparameters together
 #
 # In the Gaussian likelihood case we can iterate between an Adam update for the hyperparameters and a NatGrad update for the variational parameters. That way, we achieve optimization of hyperparameters as if the model were a GPR.
 
@@ -136,7 +136,7 @@ print(f"GPR lengthscales = {gpr.kernel.lengthscales.numpy():.04f}")
 print(f"VGP lengthscales = {vgp.kernel.lengthscales.numpy():.04f}")
 
 # %% [markdown]
-# ### Natural gradients also work for the sparse model
+# ## Natural gradients also work for the sparse model
 # Similarly, natural gradients turn SVGP into SGPR in the Gaussian likelihood case. <br>
 # We can again combine natural gradients with Adam to update both variational parameters and hyperparameters too.<br>
 # Here we'll just do a single natural step demonstration.
@@ -177,7 +177,7 @@ natgrad_opt.minimize(svgp.training_loss_closure(data), var_list=variational_para
 svgp.elbo(data).numpy()
 
 # %% [markdown]
-# ### Minibatches
+# ## Minibatches
 # A crucial property of the natural gradient method is that it still works with minibatches.
 # In practice though, we need to use a smaller gamma.
 
@@ -205,9 +205,9 @@ for _ in range(ci_niter(100)):
 np.average([svgp.elbo(next(data_minibatch_it)) for _ in ci_range(100)])
 
 # %% [markdown]
-# ### Comparison with ordinary gradients in the conjugate case
+# ## Comparison with ordinary gradients in the conjugate case
 #
-# ##### (Take home message: natural gradients are always better)
+# (Take home message: natural gradients are always better)
 #
 # Compared to SVGP with ordinary gradients with minibatches, the natural gradient optimizer is much faster in the Gaussian case.
 #
@@ -280,10 +280,11 @@ np.average([svgp_ordinary.elbo(next(data_minibatch_it)) for _ in ci_range(100)])
 np.average([svgp_natgrad.elbo(next(data_minibatch_it)) for _ in ci_range(100)])
 
 # %% [markdown]
-# ### Comparison with ordinary gradients in the non-conjugate case
-# #### Binary classification
+# ## Comparison with ordinary gradients in the non-conjugate case
 #
-# ##### (Take home message: natural gradients are usually better)
+# ### Binary classification
+#
+# (Take home message: natural gradients are usually better)
 #
 # We can use natural gradients even when the likelihood isn't Gaussian. It isn't guaranteed to be better, but it usually is better in practical situations.
 

--- a/doc/sphinx/notebooks/intro.md
+++ b/doc/sphinx/notebooks/intro.md
@@ -58,7 +58,7 @@ This section explains the more complex models and features that are available in
   - [Inter-domain Variational Fourier features](advanced/variational_fourier_features.ipynb): how to add new inter-domain inducing variables, at the example of representing sparse GPs in the spectral domain.
   - [Manipulating kernels](advanced/kernels.ipynb): information on the covariances that are included in the library, and how you can combine them to create new ones.
   - [Convolutional GPs](advanced/convolutional.ipynb): how we can use GPs with convolutional kernels for image classification.
-  - [Fast predictions by caching](advanced/fast_predictions.ipynd): how to use caching to speed up repeated predictions.
+  - [Fast predictions by caching](advanced/fast_predictions.ipynb): how to use caching to speed up repeated predictions.
 
 ### Features
 

--- a/doc/sphinx/notebooks/theory/cglb.pct.py
+++ b/doc/sphinx/notebooks/theory/cglb.pct.py
@@ -28,6 +28,8 @@ from gpflow.optimizers import Scipy
 # %matplotlib inline
 
 # %% [markdown]
+# # Conjugate Gradient Lower Bound
+#
 # First, we load the `snelson1d` training dataset.
 
 # %%

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -239,15 +239,15 @@ class Parameter(tfp.util.TransformedVariable):
         Assigns constrained `value` to the unconstrained parameter's variable.
         It passes constrained value through parameter's transform first.
 
-        Example:
-            ```
+        Example::
+
             a = Parameter(2.0, transform=tfp.bijectors.Softplus())
             b = Parameter(3.0)
 
             a.assign(4.0)               # `a` parameter to `2.0` value.
             a.assign(tf.constant(5.0))  # `a` parameter to `5.0` value.
             a.assign(b)                 # `a` parameter to constrained value of `b`.
-            ```
+
 
         :param value: Constrained tensor-like value.
         :param use_locking: If `True`, use locking during the assignment.

--- a/gpflow/conditionals/conditionals.py
+++ b/gpflow/conditionals/conditionals.py
@@ -39,6 +39,7 @@ def _sparse_conditional(
     Single-output GP conditional.
 
     The covariance matrices used to calculate the conditional have the following shape:
+
     - Kuu: [M, M]
     - Kuf: [M, N]
     - Kff: [N, N]
@@ -49,18 +50,19 @@ def _sparse_conditional(
       conditional in the single-output case.
     - See the multiouput notebook for more information about the multiouput framework.
 
-    :param Xnew: data matrix, size [N, D].
-    :param f: data matrix, [M, R]
+    :param Xnew: data matrix: [N, D]
+    :param f: data matrix: [M, R]
     :param full_cov: return the covariance between the datapoints
     :param full_output_cov: return the covariance between the outputs.
-           NOTE: as we are using a single-output kernel with repetitions
-                 these covariances will be zero.
+        NOTE: as we are using a single-output kernel with repetitions
+        these covariances will be zero.
     :param q_sqrt: matrix of standard-deviations or Cholesky matrices,
         size [M, R] or [R, M, M].
     :param white: boolean of whether to use the whitened representation
     :return:
         - mean:     [N, R]
         - variance: [N, R], [R, N, N], [N, R, R] or [N, R, N, R]
+
         Please see `gpflow.conditional._expand_independent_outputs` for more information
         about the shape of the variance, depending on `full_cov` and `full_output_cov`.
     """
@@ -98,11 +100,15 @@ def _dense_conditional(
     q_sqrt. In this case `f` represents the mean of the distribution and
     q_sqrt the square-root of the covariance.
 
-    Additionally, the GP may have been centered (whitened) so that
+    Additionally, the GP may have been centered (whitened) so that::
+
         p(v) = 𝒩(𝟎, 𝐈)
         f = 𝐋v
-    thus
+
+    thus::
+
         p(f) = 𝒩(𝟎, 𝐋𝐋ᵀ) = 𝒩(𝟎, 𝐊).
+
     In this case `f` represents the values taken by v.
 
     The method can either return the diagonals of the covariance matrix for

--- a/gpflow/conditionals/multioutput/conditionals.py
+++ b/gpflow/conditionals/multioutput/conditionals.py
@@ -55,9 +55,11 @@ def shared_independent_conditional(
     q_sqrt: Optional[tf.Tensor] = None,
     white: bool = False,
 ) -> MeanAndVariance:
-    """Multioutput conditional for an independent kernel and shared inducing inducing.
+    """
+    Multioutput conditional for an independent kernel and shared inducing inducing.
     Same behaviour as conditional with non-multioutput kernels.
     The covariance matrices used to calculate the conditional have the following shape:
+
     - Kuu: [M, M]
     - Kuf: [M, N]
     - Kff: N or [N, N]
@@ -79,6 +81,7 @@ def shared_independent_conditional(
     :return:
         - mean:     [N, P]
         - variance: [N, P], [P, N, N], [N, P, P] or [N, P, N, P]
+
         Please see `gpflow.conditional._expand_independent_outputs` for more information
         about the shape of the variance, depending on `full_cov` and `full_output_cov`.
     """

--- a/gpflow/conditionals/sample_conditionals.py
+++ b/gpflow/conditionals/sample_conditionals.py
@@ -43,6 +43,7 @@ def _sample_conditional(
     returning m + sqrt(v) * eps, with eps ~ N(0, 1).
     However, for some combinations of Mok and Mof more efficient sampling routines exists.
     The dispatcher will make sure that we use the most efficient one.
+
     :return: samples, mean, cov
         samples has shape [num_samples, N, P] or [N, P] if num_samples is None
         mean and cov as for conditional()

--- a/gpflow/conditionals/uncertain_conditionals.py
+++ b/gpflow/conditionals/uncertain_conditionals.py
@@ -41,6 +41,7 @@ def uncertain_conditional(
     """
     Calculates the conditional for uncertain inputs Xnew, p(Xnew) = N(Xnew_mu, Xnew_var).
     See ``conditional`` documentation for further reference.
+
     :param Xnew_mu: mean of the inputs, size [N, D]in
     :param Xnew_var: covariance matrix of the inputs, size [N, n, n]
     :param inducing_variable: gpflow.InducingVariable object, only InducingPoints is supported
@@ -48,11 +49,11 @@ def uncertain_conditional(
     :param q_mu: mean inducing points, size [M, Dout]
     :param q_sqrt: cholesky of the covariance matrix of the inducing points, size [t, M, M]
     :param full_output_cov: boolean wheter to compute covariance between output dimension.
-                            Influences the shape of return value ``fvar``. Default is False
+        Influences the shape of return value ``fvar``. Default is False
     :param white: boolean whether to use whitened representation. Default is False.
     :return fmean, fvar: mean and covariance of the conditional, size ``fmean`` is [N, Dout],
-            size ``fvar`` depends on ``full_output_cov``: if True ``f_var`` is [N, t, t],
-            if False then ``f_var`` is [N, Dout]
+        size ``fvar`` depends on ``full_output_cov``: if True ``f_var`` is [N, t, t],
+        if False then ``f_var`` is [N, Dout]
     """
 
     if not isinstance(inducing_variable, InducingPoints):

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -32,16 +32,19 @@ def base_conditional(
     white: bool = False,
 ) -> MeanAndVariance:
     r"""
-    Given a g1 and g2, and distribution p and q such that
+    Given a g1 and g2, and distribution p and q such that::
+
       p(g2) = N(g2; 0, Kmm)
 
       p(g1) = N(g1; 0, Knn)
       p(g1 | g2) = N(g1; Knm (Kmm⁻¹) g2, Knn - Knm (Kmm⁻¹) Kmn)
 
-    And
+    And::
+
       q(g2) = N(g2; f, q_sqrt q_sqrtᵀ)
 
-    This method computes the mean and (co)variance of
+    This method computes the mean and (co)variance of::
+
       q(g1) = ∫ q(g2) p(g1 | g2)
 
     :param Kmn: [M, ..., N]
@@ -175,12 +178,13 @@ def sample_mvn(
     mean: tf.Tensor, cov: tf.Tensor, full_cov: bool, num_samples: Optional[int] = None
 ) -> tf.Tensor:
     """
-    Returns a sample from a D-dimensional Multivariate Normal distribution
+    Returns a sample from a D-dimensional Multivariate Normal distribution.
+
     :param mean: [..., N, D]
     :param cov: [..., N, D] or [..., N, D, D]
     :param full_cov: if `True` return a "full" covariance matrix, otherwise a "diag":
-    - "full": cov holds the full covariance matrix (without jitter)
-    - "diag": cov holds the diagonal elements of the covariance matrix
+        - "full": cov holds the full covariance matrix (without jitter)
+        - "diag": cov holds the diagonal elements of the covariance matrix
     :return: sample from the MVN of shape [..., (S), N, D], S = num_samples
     """
     shape_constraints = [
@@ -228,14 +232,14 @@ def expand_independent_outputs(fvar: tf.Tensor, full_cov: bool, full_output_cov:
 
     :param fvar: has shape [N, P] (full_cov = False) or [P, N, N] (full_cov = True).
     :return:
-    1. full_cov: True and full_output_cov: True
-       fvar [N, P, N, P]
-    2. full_cov: True and full_output_cov: False
-       fvar [P, N, N]
-    3. full_cov: False and full_output_cov: True
-       fvar [N, P, P]
-    4. full_cov: False and full_output_cov: False
-       fvar [N, P]
+        1. full_cov: True and full_output_cov: True
+           fvar [N, P, N, P]
+        2. full_cov: True and full_output_cov: False
+           fvar [P, N, N]
+        3. full_cov: False and full_output_cov: True
+           fvar [N, P, P]
+        4. full_cov: False and full_output_cov: False
+           fvar [N, P]
     """
     if full_cov and full_output_cov:
         fvar = tf.linalg.diag(tf.transpose(fvar))  # [N, N, P, P]
@@ -263,7 +267,9 @@ def independent_interdomain_conditional(
 ) -> MeanAndVariance:
     """
     The inducing outputs live in the g-space (R^L).
+
     Interdomain conditional calculation.
+
     :param Kmn: [M, L, N, P]
     :param Kmm: [L, M, M]
     :param Knn: [N, P]  or  [N, P, P]  or  [P, N, N]  or  [N, P, N, P]
@@ -367,6 +373,7 @@ def fully_correlated_conditional(
     """
     This function handles conditioning of multi-output GPs in the case where the conditioning
     points are all fully correlated, in both the prior and posterior.
+
     :param Kmn: [M, N, P]
     :param Kmm: [M, M]
     :param Knn: [N, P] or [N, P, N, P]
@@ -407,6 +414,7 @@ def fully_correlated_conditional_repeat(
     This function handles conditioning of multi-output GPs in the case where the conditioning
     points are all fully correlated, in both the prior and posterior.
     Note: This conditional can handle 'repetitions' R, given in `f` and `q_sqrt`.
+
     :param Kmn: [M, N, P]
     :param Kmm: [M, M]
     :param Knn: [N, P] or [N, P, P] or [P, N, N] or [N, P, N, P]
@@ -599,9 +607,12 @@ def separate_independent_conditional_implementation(
     q_sqrt: Optional[tf.Tensor] = None,
     white: bool = False,
 ) -> MeanAndVariance:
-    """Multi-output GP with independent GP priors.
+    """
+    Multi-output GP with independent GP priors.
+
     Number of latent processes equals the number of outputs (L = P).
     The covariance matrices used to calculate the conditional have the following shape:
+
     - Kuu: [P, M, M]
     - Kuf: [P, M, N]
     - Kff: [P, N] or [P, N, N]

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -166,24 +166,33 @@ Float = Union[float]
 class Config:
     """
     Immutable object for storing global GPflow settings
-
-    Args:
-        int: Integer data type, int32 or int64.
-        float: Float data type, float32 or float64
-        jitter: Jitter value. Mainly used for for making badly conditioned matrices more stable.
-            Default value is `1e-6`.
-        positive_bijector: Method for positive bijector, either "softplus" or "exp".
-            Default is "softplus".
-        positive_minimum: Lower bound for the positive transformation.
-        summary_fmt: Summary format for module printing.
     """
 
     int: type = field(default_factory=_default_int_factory)
+    """Integer data type, int32 or int64."""
+
     float: type = field(default_factory=_default_float_factory)
+    """Float data type, float32 or float64"""
+
     jitter: Float = field(default_factory=_default_jitter_factory)
+    """
+    Jitter value. Mainly used for for making badly conditioned matrices more stable.
+
+    Default value is `1e-6`.
+    """
+
     positive_bijector: str = field(default_factory=_default_positive_bijector_factory)
+    """
+    Method for positive bijector, either "softplus" or "exp".
+
+    Default is "softplus".
+    """
+
     positive_minimum: Float = field(default_factory=_default_positive_minimum_factory)
+    """Lower bound for the positive transformation."""
+
     summary_fmt: Optional[str] = field(default_factory=_default_summary_fmt_factory)
+    """Summary format for module printing."""
 
 
 def config() -> Config:

--- a/gpflow/covariances/kufs.py
+++ b/gpflow/covariances/kufs.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import numpy as np  # Used by Sphinx to generate documentation.
 import tensorflow as tf
 
 from ..base import TensorLike, TensorType

--- a/gpflow/inducing_variables/multioutput/inducing_variables.py
+++ b/gpflow/inducing_variables/multioutput/inducing_variables.py
@@ -38,21 +38,25 @@ class FallbackSharedIndependentInducingVariables(MultioutputInducingVariables):
     """
     Shared definition of inducing variables for each independent latent process.
 
-    This class is designated to be used to
-     - provide a general interface for multioutput kernels
-       constructed from independent latent processes,
-     - only require the specification of Kuu and Kuf.
+    This class is designated to be used to:
+
+    - provide a general interface for multioutput kernels
+      constructed from independent latent processes,
+    - only require the specification of Kuu and Kuf.
+
     All multioutput kernels constructed from independent latent processes allow
     the inducing variables to be specified in the latent processes, and a
     reasonably efficient method (i.e. one that takes advantage of the
     independence in the latent processes) can be specified quite generally by
     only requiring the following covariances:
-     - Kuu: [L, M, M],
-     - Kuf: [L, M, N, P].
-    In `gpflow/conditionals/multioutput/conditionals.py` we define a conditional() implementation for this
-    combination. We specify this code path for all kernels which inherit from
-    `IndependentLatentBase`. This set-up allows inference with any such kernel
-    to be implemented by specifying only `Kuu()` and `Kuf()`.
+
+    - Kuu: [L, M, M],
+    - Kuf: [L, M, N, P].
+
+    In `gpflow/conditionals/multioutput/conditionals.py` we define a conditional() implementation
+    for this combination. We specify this code path for all kernels which inherit from
+    `IndependentLatentBase`. This set-up allows inference with any such kernel to be implemented by
+    specifying only `Kuu()` and `Kuf()`.
 
     We call this the base class, since many multioutput GPs that are constructed
     from independent latent processes acutally allow even more efficient
@@ -80,21 +84,25 @@ class FallbackSeparateIndependentInducingVariables(MultioutputInducingVariables)
     """
     Separate set of inducing variables for each independent latent process.
 
-    This class is designated to be used to
-     - provide a general interface for multioutput kernels
-       constructed from independent latent processes,
-     - only require the specification of Kuu and Kuf.
+    This class is designated to be used to:
+
+    - provide a general interface for multioutput kernels
+      constructed from independent latent processes,
+    - only require the specification of Kuu and Kuf.
+
     All multioutput kernels constructed from independent latent processes allow
     the inducing variables to be specified in the latent processes, and a
     reasonably efficient method (i.e. one that takes advantage of the
     independence in the latent processes) can be specified quite generally by
     only requiring the following covariances:
-     - Kuu: [L, M, M],
-     - Kuf: [L, M, N, P].
+
+    - Kuu: [L, M, M],
+    - Kuf: [L, M, N, P].
+
     In `gpflow/multioutput/conditionals.py` we define a conditional() implementation for this
     combination. We specify this code path for all kernels which inherit from
-    `IndependentLatentBase`. This set-up allows inference with any such kernel
-    to be implemented by specifying only `Kuu()` and `Kuf()`.
+    `IndependentLatentBase`. This set-up allows inference with any such kernel to be implemented by
+    specifying only `Kuu()` and `Kuf()`.
 
     We call this the base class, since many multioutput GPs that are constructed
     from independent latent processes acutally allow even more efficient

--- a/gpflow/kernels/changepoints.py
+++ b/gpflow/kernels/changepoints.py
@@ -27,13 +27,13 @@ class ChangePoints(Combination):
     input space where different kernels govern different parts of the space.
 
     The kernel is by multiplication and addition of the base kernels with
-    sigmoid functions (σ). A single change-point kernel is defined as:
+    sigmoid functions (σ). A single change-point kernel is defined as::
 
         K₁(x, x') * (1 - σ(x)) * (1 - σ(x')) + K₂(x, x') * σ(x) * σ(x')
 
     where K₁ is deactivated around the change-point and K₂ is activated. The
-    single change-point version can be found in \citet{lloyd2014}. Each sigmoid
-    is a logistic function defined as:
+    single change-point version can be found in :cite:t:`lloyd2014`. Each sigmoid
+    is a logistic function defined as::
 
         σ(x) = 1 / (1 + exp{-s(x - x₀)})
 

--- a/gpflow/kernels/convolutional.py
+++ b/gpflow/kernels/convolutional.py
@@ -25,11 +25,14 @@ from .base import Kernel
 
 class Convolutional(Kernel):
     r"""
-    Plain convolutional kernel as described in \citet{vdw2017convgp}. Defines
-    a GP f( ) that is constructed from a sum of responses of individual patches
+    Plain convolutional kernel as described in :cite:t:`vdw2017convgp`. Defines
+    a GP :math:`f()` that is constructed from a sum of responses of individual patches
     in an image:
-      f(x) = \sum_p x^{[p]}
-    where x^{[p]} is the pth patch in the image.
+
+    .. math::
+       f(x) = \sum_p x^{[p]}
+
+    where :math:`x^{[p]}` is the :math:`p`'th patch in the image.
 
     The key reference is :cite:t:`vdw2017convgp`.
     """

--- a/gpflow/kernels/multioutput/kernels.py
+++ b/gpflow/kernels/multioutput/kernels.py
@@ -26,11 +26,15 @@ class MultioutputKernel(Kernel):
     Multi Output Kernel class.
     This kernel can represent correlation between outputs of different datapoints.
     Therefore, subclasses of Mok should implement `K` which returns:
+
     - [N, P, N, P] if full_output_cov = True
     - [P, N, N] if full_output_cov = False
+
     and `K_diag` returns:
+
     - [N, P, P] if full_output_cov = True
     - [N, P] if full_output_cov = False
+
     The `full_output_cov` argument holds whether the kernel should calculate
     the covariance between the outputs. In case there is no correlation but
     `full_output_cov` is set to True the covariance matrix will be filled with zeros
@@ -55,12 +59,14 @@ class MultioutputKernel(Kernel):
     ) -> tf.Tensor:
         """
         Returns the correlation of f(X) and f(X2), where f(.) can be multi-dimensional.
+
         :param X: data matrix, [N1, D]
         :param X2: data matrix, [N2, D]
         :param full_output_cov: calculate correlation between outputs.
-        :return: cov[f(X), f(X2)] with shape
-        - [N1, P, N2, P] if `full_output_cov` = True
-        - [P, N1, N2] if `full_output_cov` = False
+        :return: cov[f(X), f(X2)] with shape:
+
+            - [N1, P, N2, P] if `full_output_cov` = True
+            - [P, N1, N2] if `full_output_cov` = False
         """
         raise NotImplementedError
 
@@ -68,11 +74,13 @@ class MultioutputKernel(Kernel):
     def K_diag(self, X: TensorType, full_output_cov: bool = True) -> tf.Tensor:
         """
         Returns the correlation of f(X) and f(X), where f(.) can be multi-dimensional.
+
         :param X: data matrix, [N, D]
         :param full_output_cov: calculate correlation between outputs.
-        :return: var[f(X)] with shape
-        - [N, P, N, P] if `full_output_cov` = True
-        - [N, P] if `full_output_cov` = False
+        :return: var[f(X)] with shape:
+
+            - [N, P, N, P] if `full_output_cov` = True
+            - [N, P] if `full_output_cov` = False
         """
         raise NotImplementedError
 
@@ -100,8 +108,10 @@ class SharedIndependent(MultioutputKernel):
     """
     - Shared: we use the same kernel for each latent GP
     - Independent: Latents are uncorrelated a priori.
-    Note: this class is created only for testing and comparison purposes.
-    Use `gpflow.kernels` instead for more efficient code.
+
+    .. warning::
+       This class is created only for testing and comparison purposes.
+       Use `gpflow.kernels` instead for more efficient code.
     """
 
     def __init__(self, kernel: Kernel, output_dim: int) -> None:

--- a/gpflow/kullback_leiblers.py
+++ b/gpflow/kullback_leiblers.py
@@ -46,10 +46,12 @@ def gauss_kl(
     q_mu: TensorType, q_sqrt: TensorType, K: TensorType = None, *, K_cholesky: TensorType = None
 ) -> tf.Tensor:
     """
-    Compute the KL divergence KL[q || p] between
+    Compute the KL divergence KL[q || p] between::
 
           q(x) = N(q_mu, q_sqrt^2)
-    and
+
+    and::
+
           p(x) = N(0, K)    if K is not None
           p(x) = N(0, I)    if K is None
 
@@ -59,10 +61,10 @@ def gauss_kl(
 
     q_mu is a matrix ([M, L]), each column contains a mean.
 
-    q_sqrt can be a 3D tensor ([L, M, M]), each matrix within is a lower
-        triangular square-root matrix of the covariance of q.
-    q_sqrt can be a matrix ([M, L]), each column represents the diagonal of a
-        square-root matrix of the covariance of q.
+    - q_sqrt can be a 3D tensor ([L, M, M]), each matrix within is a lower
+      triangular square-root matrix of the covariance of q.
+    - q_sqrt can be a matrix ([M, L]), each column represents the diagonal of a
+      square-root matrix of the covariance of q.
 
     K is the covariance of p (positive-definite matrix).  The K matrix can be
     passed either directly as `K`, or as its Cholesky factor, `K_cholesky`.  In

--- a/gpflow/likelihoods/__init__.py
+++ b/gpflow/likelihoods/__init__.py
@@ -11,6 +11,46 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+Likelihoods are another core component of GPflow. This describes how likely the
+data is under the assumptions made about the underlying latent functions
+p(Y|F). Different likelihoods make different
+assumptions about the distribution of the data, as such different data-types
+(continuous, binary, ordinal, count) are better modelled with different
+likelihood assumptions.
+
+Use of any likelihood other than Gaussian typically introduces the need to use
+an approximation to perform inference, if one isn't already needed.
+Variational inference and MCMC models are included in GPflow and allow
+approximate inference with non-Gaussian likelihoods. An introduction to these
+models can be found :ref:`here <implemented_models>`. Specific notebooks
+illustrating non-Gaussian likelihood regressions are available for
+`classification <notebooks/classification.html>`_ (binary data), `ordinal
+<notebooks/ordinal.html>`_ and `multiclass <notebooks/multiclass.html>`_.
+
+Creating new likelihoods
+------------------------
+
+Likelihoods are defined by their
+log-likelihood. When creating new likelihoods, the
+:func:`logp <gpflow.likelihoods.Likelihood.logp>` method (log p(Y|F)), the
+:func:`conditional_mean <gpflow.likelihoods.Likelihood.conditional_mean>`,
+:func:`conditional_variance
+<gpflow.likelihoods.Likelihood.conditional_variance>`.
+
+In order to perform variational inference with non-Gaussian likelihoods a term
+called ``variational expectations``, ∫ q(F) log p(Y|F) dF, needs to
+be computed under a Gaussian distribution q(F) ~ N(μ, Σ).
+
+The :func:`variational_expectations <gpflow.likelihoods.Likelihood.variational_expectations>`
+method can be overriden if this can be computed in closed form, otherwise; if
+the new likelihood inherits
+:class:`Likelihood <gpflow.likelihoods.Likelihood>` the default will use
+Gauss-Hermite numerical integration (works well when F is 1D
+or 2D), if the new likelihood inherits from
+:class:`MonteCarloLikelihood <gpflow.likelihoods.MonteCarloLikelihood>` the
+integration is done by sampling (can be more suitable when F is higher dimensional).
+"""
 
 from .base import (
     Likelihood,

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -11,47 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""
-Likelihoods are another core component of GPflow. This describes how likely the
-data is under the assumptions made about the underlying latent functions
-p(Y|F). Different likelihoods make different
-assumptions about the distribution of the data, as such different data-types
-(continuous, binary, ordinal, count) are better modelled with different
-likelihood assumptions.
-
-Use of any likelihood other than Gaussian typically introduces the need to use
-an approximation to perform inference, if one isn't already needed. A
-variational inference and MCMC models are included in GPflow and allow
-approximate inference with non-Gaussian likelihoods. An introduction to these
-models can be found :ref:`here <implemented_models>`. Specific notebooks
-illustrating non-Gaussian likelihood regressions are available for
-`classification <notebooks/classification.html>`_ (binary data), `ordinal
-<notebooks/ordinal.html>`_ and `multiclass <notebooks/multiclass.html>`_.
-
-Creating new likelihoods
-----------
-Likelihoods are defined by their
-log-likelihood. When creating new likelihoods, the
-:func:`logp <gpflow.likelihoods.Likelihood.logp>` method (log p(Y|F)), the
-:func:`conditional_mean <gpflow.likelihoods.Likelihood.conditional_mean>`,
-:func:`conditional_variance
-<gpflow.likelihoods.Likelihood.conditional_variance>`.
-
-In order to perform variational inference with non-Gaussian likelihoods a term
-called ``variational expectations``, ∫ q(F) log p(Y|F) dF, needs to
-be computed under a Gaussian distribution q(F) ~ N(μ, Σ).
-
-The :func:`variational_expectations <gpflow.likelihoods.Likelihood.variational_expectations>`
-method can be overriden if this can be computed in closed form, otherwise; if
-the new likelihood inherits
-:class:`Likelihood <gpflow.likelihoods.Likelihood>` the default will use
-Gauss-Hermite numerical integration (works well when F is 1D
-or 2D), if the new likelihood inherits from
-:class:`MonteCarloLikelihood <gpflow.likelihoods.MonteCarloLikelihood>` the
-integration is done by sampling (can be more suitable when F is higher dimensional).
-"""
-
 import abc
 import warnings
 from typing import Any, Callable, Iterable, Optional, Sequence, Union
@@ -396,8 +355,10 @@ class ScalarLikelihood(QuadratureLikelihood):
 
     The `Likelihood` class contains methods to compute marginal statistics of functions
     of the latents and the data ϕ(y,f):
-     * variational_expectations:  ϕ(y,f) = log p(y|f)
-     * predict_log_density: ϕ(y,f) = p(y|f)
+
+    * variational_expectations:  ϕ(y,f) = log p(y|f)
+    * predict_log_density: ϕ(y,f) = p(y|f)
+
     Those statistics are computed after having first marginalized the latent processes f
     under a multivariate normal distribution q(f) that is fully factorized.
 

--- a/gpflow/likelihoods/multiclass.py
+++ b/gpflow/likelihoods/multiclass.py
@@ -49,18 +49,26 @@ class Softmax(MonteCarloLikelihood):
 
 
 class RobustMax(Module):
-    """
+    r"""
     This class represent a multi-class inverse-link function. Given a vector
-    f=[f_1, f_2, ... f_k], the result of the mapping is
+    :math:`f=[f_1, f_2, ... f_k]`, the result of the mapping is
 
-    y = [y_1 ... y_k]
+    .. math::
+
+       y = [y_1 ... y_k]
 
     with
 
-    y_i = (1-epsilon)  i == argmax(f)
-          epsilon/(k-1)  otherwise
+    .. math::
 
-    where k is the number of classes.
+       y_i = \left\{
+       \begin{array}{ll}
+           (1-\varepsilon)   & \textrm{if} \ i = \textrm{argmax}(f) \\
+           \varepsilon/(k-1) & \textrm{otherwise}
+       \end{array}
+       \right.
+
+    where :math:`k` is the number of classes.
     """
 
     def __init__(self, num_classes: int, epsilon: float = 1e-3, **kwargs: Any) -> None:

--- a/gpflow/models/cglb.py
+++ b/gpflow/models/cglb.py
@@ -71,15 +71,19 @@ class CGLB(SGPR):
         return self._v
 
     def logdet_term(self, common: SGPR.CommonTensors) -> tf.Tensor:
-        """
-        Compute a lower bound on -0.5 * log |K + σ²I| based on a
+        r"""
+        Compute a lower bound on :math:`-0.5 * \log |K + σ²I|` based on a
         low-rank approximation to K.
-        ..  math::
-            log |K + σ²I| <= log |Q + σ²I| + n * log(1 + tr(K - Q)/(σ²n)).
+
+        .. math::
+
+           \log |K + σ²I| <= \log |Q + σ²I| + n * \log(1 + \textrm{tr}(K - Q)/(σ²n)).
 
         This bound is at least as tight as
-        ..  math::
-            log |K + σ²I| <=  log |Q + σ²I| + tr(K - Q)/σ²,
+
+        .. math::
+
+           \log |K + σ²I| <=  \log |Q + σ²I| + \textrm{tr}(K - Q)/σ²,
 
         which appears in SGPR.
         """

--- a/gpflow/models/sgpr.py
+++ b/gpflow/models/sgpr.py
@@ -48,14 +48,15 @@ class SGPRBase_deprecated(GPModel, InternalDataTrainingLossMixin):
         noise_variance: float = 1.0,
     ):
         """
-        `data`:  a tuple of (X, Y), where the inputs X has shape [N, D]
-            and the outputs Y has shape [N, R].
-        `inducing_variable`:  an InducingPoints instance or a matrix of
-            the pseudo inputs Z, of shape [M, D].
-        `kernel`, `mean_function` are appropriate GPflow objects
-
         This method only works with a Gaussian likelihood, its variance is
         initialized to `noise_variance`.
+
+        :param data: a tuple of (X, Y), where the inputs X has shape [N, D]
+            and the outputs Y has shape [N, R].
+        :param inducing_variable:  an InducingPoints instance or a matrix of
+            the pseudo inputs Z, of shape [M, D].
+        :param kernel: An appropriate GPflow kernel object.
+        :param mean_function: An appropriate GPflow mean function object.
         """
         likelihood = likelihoods.Gaussian(noise_variance)
         X_data, Y_data = data_input_to_tensor(data)
@@ -159,13 +160,14 @@ class SGPR_deprecated(SGPRBase_deprecated):
         return self.CommonTensors(A, B, LB, AAT, L)
 
     def logdet_term(self, common: "SGPR.CommonTensors") -> tf.Tensor:
-        """
+        r"""
         Bound from Jensen's Inequality:
+
         .. math::
-            log |K + σ²I| <= log |Q + σ²I| + N * log (1 + tr(K - Q)/(σ²N))
+            \log |K + σ²I| <= \log |Q + σ²I| + N * \log (1 + \textrm{tr}(K - Q)/(σ²N))
 
         :param common: A named tuple containing matrices that will be used
-        :return: log_det, lower bound on -.5 * output_dim * log |K + σ²I|
+        :return: log_det, lower bound on :math:`-.5 * \textrm{output_dim} * \log |K + σ²I|`
         """
         LB = common.LB
         AAT = common.AAT

--- a/gpflow/models/vgp.py
+++ b/gpflow/models/vgp.py
@@ -213,8 +213,8 @@ def update_vgp_data(vgp: VGP_deprecated, new_data: RegressionData) -> None:
     the shape of the data. This functions updates the internal data of the given vgp, and updates
     the variational parameters to fit.
 
-    This function requires that the input :param:`vgp` were create with :class:`tf.Variable`s for
-    :param:`data`.
+    This function requires that the input `vgp` were create with :class:`tf.Variable`s for
+    `data`.
     """
     old_X_data, old_Y_data = vgp.data
     assert is_variable(old_X_data) and is_variable(
@@ -255,7 +255,9 @@ class VGPOpperArchambeau(GPModel, InternalDataTrainingLossMixin):
     posterior precision shares off-diagonal elements with the prior, so
     only the diagonal elements of the precision need be adjusted.
     The posterior approximation is
+
     .. math::
+
        q(\mathbf f) = N(\mathbf f \,|\, \mathbf K \boldsymbol \alpha,
                          [\mathbf K^{-1} + \textrm{diag}(\boldsymbol \lambda))^2]^{-1})
 
@@ -297,9 +299,18 @@ class VGPOpperArchambeau(GPModel, InternalDataTrainingLossMixin):
         q_alpha, q_lambda are variational parameters, size [N, R]
         This method computes the variational lower bound on the likelihood,
         which is:
-            E_{q(F)} [ \log p(Y|F) ] - KL[ q(F) || p(F)]
+
+        .. math::
+
+           E_{q(F)} [ \log p(Y|F) ] - KL[ q(F) || p(F)]
+
         with
-            q(f) = N(f | K alpha + mean, [K^-1 + diag(square(lambda))]^-1) .
+
+        .. math::
+
+           q(f) = N(f |
+               K \alpha + \textrm{mean},
+               [K^-1 + \textrm{diag}(\textrm{square}(\lambda))]^-1) .
         """
         X_data, Y_data = self.data
 
@@ -341,11 +352,19 @@ class VGPOpperArchambeau(GPModel, InternalDataTrainingLossMixin):
     ) -> MeanAndVariance:
         r"""
         The posterior variance of F is given by
-            q(f) = N(f | K alpha + mean, [K^-1 + diag(lambda**2)]^-1)
+
+        .. math::
+
+           q(f) = N(f |
+               K \alpha + \textrm{mean}, [K^-1 + \textrm{diag}(\lambda**2)]^-1)
+
         Here we project this to F*, the values of the GP at Xnew which is given
         by
-           q(F*) = N ( F* | K_{*F} alpha + mean, K_{**} - K_{*f}[K_{ff} +
-                                           diag(lambda**-2)]^-1 K_{f*} )
+
+        .. math::
+
+           q(F*) = N ( F* | K_{*F} \alpha + \textrm{mean}, K_{**} - K_{*f}[K_{ff} +
+                                           \textrm{diag}(\lambda**-2)]^-1 K_{f*} )
 
         Note: This model currently does not allow full output covariances
         """

--- a/gpflow/monitor/base.py
+++ b/gpflow/monitor/base.py
@@ -121,8 +121,8 @@ class Monitor:
     Accepts any number of of `MonitorTaskGroup` instances, and runs them
     according to their specified periodicity.
 
-    Example use-case:
-        ```
+    Example use-case::
+
         # Create some monitor tasks
         log_dir = "logs"
         model_task = ModelToTensorBoard(log_dir, model)
@@ -138,7 +138,6 @@ class Monitor:
 
         # We pass both groups to the `Monitor`
         monitor = Monitor(fast_tasks, slow_tasks)
-        ```
     """
 
     def __init__(self, *task_groups: MonitorTaskGroup) -> None:

--- a/gpflow/monitor/tensorboard.py
+++ b/gpflow/monitor/tensorboard.py
@@ -62,7 +62,9 @@ class ModelToTensorBoard(ToTensorBoard):
 
     Monitors all the model's parameters for which their name matches with `keywords_to_monitor`.
     By default, "kernel" and "likelihood" are elements of `keywords_to_monitor`.
-    Example:
+
+    Example::
+
         keyword = "kernel", parameter = "kernel.lengthscale" => match
         keyword = "variational", parameter = "kernel.lengthscale" => no match
     """

--- a/gpflow/optimizers/mcmc.py
+++ b/gpflow/optimizers/mcmc.py
@@ -26,7 +26,8 @@ class SamplingHelper:
     This helper makes it easy to read from variables being set with a prior and
     writes values back to the same variables.
 
-    Example:
+    Example::
+
         model = ...  # Create a GPflow model
         hmc_helper = SamplingHelper(model.log_posterior_density, model.trainable_parameters)
 

--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -326,12 +326,16 @@ def swap_dimensions(
 ) -> Callable[..., Tuple[tf.Tensor, tf.Tensor]]:
     """
     Converts between GPflow indexing and tensorflow indexing
-    `method` is a function that broadcasts over the first dimension (i.e. like all tensorflow matrix ops):
-        `method` inputs [D, N, 1], [D, N, N]
-        `method` outputs [D, N, 1], [D, N, N]
+    `method` is a function that broadcasts over the first dimension (i.e. like all tensorflow matrix
+    ops):
+
+    * `method` inputs [D, N, 1], [D, N, N]
+    * `method` outputs [D, N, 1], [D, N, N]
+
     :return: Function that broadcasts over the final dimension (i.e. compatible with GPflow):
-        inputs: [N, D], [D, N, N]
-        outputs: [N, D], [D, N, N]
+
+        * inputs: [N, D], [D, N, N]
+        * outputs: [N, D], [D, N, N]
     """
 
     @functools.wraps(method)

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -42,35 +42,32 @@ class Scipy:
         **scipy_kwargs: Any,
     ) -> OptimizeResult:
         """
-        Minimize is a wrapper around the `scipy.optimize.minimize` function
-        handling the packing and unpacking of a list of shaped variables on the
-        TensorFlow side vs. the flat numpy array required on the Scipy side.
+        Minimize `closure`.
 
-        Args:
-            closure: A closure that re-evaluates the model, returning the loss
-                to be minimized.
-            variables: The list (tuple) of variables to be optimized
-                (typically `model.trainable_variables`)
-            method: The type of solver to use in SciPy. Defaults to "L-BFGS-B".
-            step_callback: If not None, a callable that gets called once after
-                each optimisation step. The callable is passed the arguments
-                `step`, `variables`, and `values`. `step` is the optimisation
-                step counter, `variables` is the list of trainable variables as
-                above, and `values` is the corresponding list of tensors of
-                matching shape that contains their value at this optimisation
-                step.
-            compile: If True, wraps the evaluation function (the passed `closure`
-                as well as its gradient computation) inside a `tf.function()`,
-                which will improve optimization speed in most cases.
-            allow_unused_variables: Whether to allow variables that are not
-                actually used in the closure.
-            scipy_kwargs: Arguments passed through to `scipy.optimize.minimize`
-                Note that Scipy's minimize() takes a `callback` argument, but
-                you probably want to use our wrapper and pass in `step_callback`.
+        Minimize is a wrapper around the `scipy.optimize.minimize` function handling the packing and
+        unpacking of a list of shaped variables on the TensorFlow side vs. the flat numpy array
+        required on the Scipy side.
 
-        Returns:
-            The optimization result represented as a Scipy ``OptimizeResult``
-            object. See the Scipy documentation for description of attributes.
+        :param closure: A closure that re-evaluates the model, returning the loss to be minimized.
+        :param variables: The list (tuple) of variables to be optimized
+            (typically `model.trainable_variables`)
+        :param method: The type of solver to use in SciPy. Defaults to "L-BFGS-B".
+        :param step_callback: If not None, a callable that gets called once after each optimisation
+            step. The callable is passed the arguments `step`, `variables`, and `values`. `step` is
+            the optimisation step counter, `variables` is the list of trainable variables as above,
+            and `values` is the corresponding list of tensors of matching shape that contains their
+            value at this optimisation step.
+        :param compile: If True, wraps the evaluation function (the passed `closure` as well as its
+            gradient computation) inside a `tf.function()`, which will improve optimization speed in
+            most cases.
+        :param allow_unused_variables: Whether to allow variables that are not actually used in the
+            closure.
+        :param scipy_kwargs: Arguments passed through to `scipy.optimize.minimize`.
+            Note that Scipy's minimize() takes a `callback` argument, but you probably want to use
+            our wrapper and pass in `step_callback`.
+        :returns:
+            The optimization result represented as a Scipy ``OptimizeResult`` object.
+            See the Scipy documentation for description of attributes.
         """
         if not callable(closure):
             raise TypeError(
@@ -79,7 +76,8 @@ class Scipy:
         variables = tuple(variables)
         if not all(isinstance(v, tf.Variable) for v in variables):
             raise TypeError(
-                "The 'variables' argument is expected to only contain tf.Variable instances (use model.trainable_variables, not model.trainable_parameters)"
+                "The 'variables' argument is expected to only contain tf.Variable instances"
+                " (use model.trainable_variables, not model.trainable_parameters)"
             )  # pragma: no cover
         initial_params = self.initial_parameters(variables)
 

--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -117,7 +117,7 @@ class PrecomputedValue:
     @staticmethod
     def wrap_alpha_Qinv(alpha: TensorType, Qinv: TensorType) -> Tuple["PrecomputedValue", ...]:
         """
-        Wraps `alpha` and `Qinv` in `PrecomputedValue`s.
+        Wraps `alpha` and `Qinv` in `PrecomputedValue`\ s.
         """
         one_dynamic = False
         L_dynamic = False

--- a/gpflow/quadrature/base.py
+++ b/gpflow/quadrature/base.py
@@ -40,23 +40,26 @@ class GaussianQuadrature:
         **kwargs: Any,
     ) -> tf.Tensor:
         r"""
-        Compute the Gaussian Expectation of a function f:
+        Compute the Gaussian Expectation of a function f::
 
             X ~ N(mean, var)
             E[f(X)] = ∫f(x, *args, **kwargs)p(x)dx
 
-        Using the formula:
+        Using the formula::
+
             E[f(X)] = sum_{i=1}^{N_quad_points} f(x_i) * w_i
 
         where x_i, w_i must be provided by the inheriting class through self._build_X_W.
         The computations broadcast along batch-dimensions, represented by [b1, b2, ..., bX].
 
         :param fun: Callable or Iterable of Callables that operates elementwise, with
-            signature f(X, *args, **kwargs). Moreover, it must satisfy the shape-mapping:
+            signature f(X, *args, **kwargs). Moreover, it must satisfy the shape-mapping::
+
                 X shape: [N_quad_points, b1, b2, ..., bX, d],
                     usually [N_quad_points, N, d]
                 f(X) shape: [N_quad_points, b1, b2, ...., bX, d'],
                     usually [N_quad_points, N, 1] or [N_quad_points, N, d]
+
             In most cases, f should only operate over the last dimension of X
         :param mean: Array/Tensor with shape [b1, b2, ..., bX, d], usually [N, d],
             representing the mean of a d-Variate Gaussian distribution
@@ -64,7 +67,7 @@ class GaussianQuadrature:
             representing the variance of a d-Variate Gaussian distribution
         :param *args: Passed to fun
         :param **kargs: Passed to fun
-        :return: Array/Tensor with shape [b1, b2, ...., bX, d'],
+        :return: Array/Tensor with shape [b1, b2, ...., bX, d\'],
             usually [N, d] or [N, 1]
         """
 
@@ -82,31 +85,34 @@ class GaussianQuadrature:
         **kwargs: Any,
     ) -> tf.Tensor:
         r"""
-        Compute the Gaussian log-Expectation of a the exponential of a function f:
+        Compute the Gaussian log-Expectation of a the exponential of a function f::
 
             X ~ N(mean, var)
             log E[exp[f(X)]] = log ∫exp[f(x, *args, **kwargs)]p(x)dx
 
-        Using the formula:
+        Using the formula::
+
             log E[exp[f(X)]] = log sum_{i=1}^{N_quad_points} exp[f(x_i) + log w_i]
 
         where x_i, w_i must be provided by the inheriting class through self._build_X_W.
         The computations broadcast along batch-dimensions, represented by [b1, b2, ..., bX].
 
         :param fun: Callable or Iterable of Callables that operates elementwise, with
-            signature f(X, *args, **kwargs). Moreover, it must satisfy the shape-mapping:
+            signature f(X, \*args, \*\*kwargs). Moreover, it must satisfy the shape-mapping::
+
                 X shape: [N_quad_points, b1, b2, ..., bX, d],
                     usually [N_quad_points, N, d]
                 f(X) shape: [N_quad_points, b1, b2, ...., bX, d'],
                     usually [N_quad_points, N, 1] or [N_quad_points, N, d]
+
             In most cases, f should only operate over the last dimension of X
         :param mean: Array/Tensor with shape [b1, b2, ..., bX, d], usually [N, d],
             representing the mean of a d-Variate Gaussian distribution
         :param var: Array/Tensor with shape b1, b2, ..., bX, d], usually [N, d],
             representing the variance of a d-Variate Gaussian distribution
-        :param *args: Passed to fun
-        :param **kargs: Passed to fun
-        :return: Array/Tensor with shape [b1, b2, ...., bX, d'],
+        :param args: Passed to fun
+        :param kwargs: Passed to fun
+        :return: Array/Tensor with shape [b1, b2, ...., bX, d\'],
             usually [N, d] or [N, 1]
         """
 

--- a/gpflow/quadrature/deprecated.py
+++ b/gpflow/quadrature/deprecated.py
@@ -130,6 +130,8 @@ def ndiagquad(
     The means and variances of the Gaussians are specified by Fmu and Fvar.
     The N-integrals are assumed to be taken wrt the last dimensions of Fmu, Fvar.
 
+    `Fmu`, `Fvar`, `Ys` should all have same shape, with overall size `N`.
+
     :param funcs: the integrand(s):
         Callable or Iterable of Callables that operates elementwise
     :param H: number of Gauss-Hermite quadrature points
@@ -137,9 +139,7 @@ def ndiagquad(
     :param Fvar: array/tensor or `Din`-tuple/list thereof
     :param logspace: if True, funcs are the log-integrands and this calculates
         the log-expectation of exp(funcs)
-    :param **Ys: arrays/tensors; deterministic arguments to be passed by name
-
-    Fmu, Fvar, Ys should all have same shape, with overall size `N`
+    :param Ys: arrays/tensors; deterministic arguments to be passed by name
     :return: shape is the same as that of the first Fmu
     """
     warnings.warn(
@@ -208,6 +208,8 @@ def ndiag_mc(
     Computes N Gaussian expectation integrals of one or more functions
     using Monte Carlo samples. The Gaussians must be independent.
 
+    `Fmu`, `Fvar`, `Ys` should all have same shape, with overall size `N`.
+
     :param funcs: the integrand(s):
         Callable or Iterable of Callables that operates elementwise
     :param S: number of Monte Carlo sampling points
@@ -215,9 +217,7 @@ def ndiag_mc(
     :param Fvar: array/tensor
     :param logspace: if True, funcs are the log-integrands and this calculates
         the log-expectation of exp(funcs)
-    :param **Ys: arrays/tensors; deterministic arguments to be passed by name
-
-    Fmu, Fvar, Ys should all have same shape, with overall size `N`
+    :param Ys: arrays/tensors; deterministic arguments to be passed by name
     :return: shape is the same as that of the first Fmu
     """
     N, D = tf.shape(Fmu)[0], tf.shape(Fvar)[1]

--- a/gpflow/utilities/misc.py
+++ b/gpflow/utilities/misc.py
@@ -40,8 +40,8 @@ def to_default_float(x: TensorData) -> tf.Tensor:
 
 def set_trainable(model: Union[tf.Module, Iterable[tf.Module]], flag: bool) -> None:
     """
-    Set trainable flag for all `tf.Variable`s and `gpflow.Parameter`s in a `tf.Module` or collection
-    of `tf.Module`s.
+    Set trainable flag for all :class:`tf.Variable`\ s and :class:`gpflow.Parameter`\ s in a
+    :class:`tf.Module` or collection of :class:`tf.Module`\ s.
     """
     modules = [model] if isinstance(model, tf.Module) else model
 

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -39,33 +39,36 @@ def eye(num: int, value: tf.Tensor, dtype: Optional[tf.DType] = None) -> tf.Tens
 
 def leading_transpose(tensor: tf.Tensor, perm: List[Any], leading_dim: int = 0) -> tf.Tensor:
     """
-    Transposes tensors with leading dimensions. Leading dimensions in
-    permutation list represented via ellipsis `...` and is of type List[Union[int, type(...)]
-    (please note, due to mypy issues, List[Any] is used instead).
-    When leading dimensions are found, `transpose` method
-    considers them as a single grouped element indexed by 0 in `perm` list. So, passing
-    `perm=[-2, ..., -1]`, you assume that your input tensor has [..., A, B] shape,
-    and you want to move leading dims between A and B dimensions.
-    Dimension indices in permutation list can be negative or positive. Valid positive
-    indices start from 1 up to the tensor rank, viewing leading dimensions `...` as zero
-    index.
-    Example:
+    Transposes tensors with leading dimensions.
+
+    Leading dimensions in permutation list represented via ellipsis `...` and is of type
+    List[Union[int, type(...)]  (please note, due to mypy issues, List[Any] is used instead).  When
+    leading dimensions are found, `transpose` method considers them as a single grouped element
+    indexed by 0 in `perm` list. So, passing `perm=[-2, ..., -1]`, you assume that your input tensor
+    has [..., A, B] shape, and you want to move leading dims between A and B dimensions.  Dimension
+    indices in permutation list can be negative or positive. Valid positive indices start from 1 up
+    to the tensor rank, viewing leading dimensions `...` as zero index.
+
+    Example::
+
         a = tf.random.normal((1, 2, 3, 4, 5, 6))
-            # [..., A, B, C],
-            # where A is 1st element,
-            # B is 2nd element and
-            # C is 3rd element in
-            # permutation list,
-            # leading dimensions are [1, 2, 3]
-            # which are 0th element in permutation
-            # list
+        # [..., A, B, C],
+        # where A is 1st element,
+        # B is 2nd element and
+        # C is 3rd element in
+        # permutation list,
+        # leading dimensions are [1, 2, 3]
+        # which are 0th element in permutation list
         b = leading_transpose(a, [3, -3, ..., -2])  # [C, A, ..., B]
         sess.run(b).shape
+
         output> (6, 4, 1, 2, 3, 5)
+
     :param tensor: TensorFlow tensor.
     :param perm: List of permutation indices.
     :returns: TensorFlow tensor.
-    :raises: ValueError when `...` cannot be found.
+    :raises ValueError: when `...` cannot be found.
+
     """
     perm = copy.copy(perm)
     idx = perm.index(...)


### PR DESCRIPTION
Fix doc warnings. Fixes #1254

Fix all warnings generated by Sphinx. This doesn't mean our documentation is far perfect - far from it.
But at least some classes of problems have been fixed.

For maths it has been a bit of a mix whether I've formatted it as a code example:

```
Example::

    math goes here
```

or as LaTeX:

```
Example:

... math::

    math goes here
```

obviously LaTeX is perttier, but it's also much more work. I figure we'll need to go back and look over all of it again anyway.