### PR TITLE
Add test of documentation warnings.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
           py_ver: <<parameters.py_ver>>
           tf_ver: <<parameters.tf_ver>>
           tfp_ver: <<parameters.tfp_ver>>
-          pytest_filter: not notebooks
+          pytest_filter: not notebooks and not docs
 
   notebook-test:
     parameters:
@@ -182,6 +182,17 @@ jobs:
           tf_ver: <<parameters.tf_ver>>
           tfp_ver: <<parameters.tfp_ver>>
           pytest_filter: notebooks
+
+  docs-test:
+    docker:
+      # build-docs below use `max` version, so let's test with the same version we're going to use.
+      - image: cimg/python:<<pipeline.parameters.max_py_ver>>
+    steps:
+      - run_tests:
+          py_ver: <<pipeline.parameters.max_py_ver>>
+          tf_ver: <<pipeline.parameters.max_tf_ver>>
+          tfp_ver: <<pipeline.parameters.max_tfp_ver>>
+          pytest_filter: docs
 
   build-docs:
     docker:
@@ -329,6 +340,10 @@ workflows:
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
+      - docs-test:
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
       - noop:
           name: fast-tests
           requires:
@@ -338,6 +353,7 @@ workflows:
             - type-check-max
             - format-check-min
             - format-check-max
+            - docs-test
       - unit-test:
           name: unit-test-min
           py_ver: <<pipeline.parameters.min_py_ver>>

--- a/gpflow/experimental/check_shapes/argument_ref.py
+++ b/gpflow/experimental/check_shapes/argument_ref.py
@@ -96,7 +96,7 @@ class RootArgumentRef(ArgumentRef):
 
 @dataclass(frozen=True)  # type: ignore
 class DelegatingArgumentRef(ArgumentRef):
-    """ Abstract base class for `ArgumentRef`s the delegates to a source. """
+    """ Abstract base class for :class:`ArgumentRef`\ s that delegates to a source. """
 
     source: ArgumentRef
 

--- a/gpflow/experimental/check_shapes/error_contexts.py
+++ b/gpflow/experimental/check_shapes/error_contexts.py
@@ -50,7 +50,7 @@ from .base_types import Shape
 
 if TYPE_CHECKING:  # pragma: no cover
     from .argument_ref import ArgumentRef
-    from .bools import ParsedBoolSpec
+    from .bool_specs import ParsedBoolSpec
     from .specs import ParsedNoteSpec, ParsedShapeSpec, ParsedTensorSpec
 
 _UNKNOWN_FILE = "<Unknown file>"

--- a/tests/integration/test_docs.py
+++ b/tests/integration/test_docs.py
@@ -1,0 +1,45 @@
+# Copyright 2022 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import subprocess
+from pathlib import Path
+
+import pytest
+
+BUILD_DOCS_PATH = Path(__file__).parent.parent.parent / "doc" / "build_docs.py"
+
+
+@pytest.mark.docs
+def test_docs(tmp_path: Path) -> None:
+    assert BUILD_DOCS_PATH.is_file()
+    build_path = tmp_path / "build"
+
+    try:
+        subprocess.run(
+            [
+                "python",
+                str(BUILD_DOCS_PATH),
+                "develop",
+                str(build_path),
+                "--max-notebooks",
+                "0",
+                "--fail-on-warning",
+            ]
+        ).check_returncode()
+    except subprocess.CalledProcessError as e:
+        raise AssertionError(
+            "Documentation build had errors / warnings."
+            " Please fix."
+            " Check both any .rst files you may have modified directly,"
+            " and docstrings of your Python code."
+        ) from e


### PR DESCRIPTION
Add a unit test that our documentation build doesn't produce any warnings.

(This doesn't build the notebooks, we have other tests for that.)

Basically this PR consists of:

1. Modify `doc/build_docs.py` with a flag that makes it fail if there are any warnings.
2. Modify `doc/build_docs.py` so that if `--max_notebooks` it generates an empty file, instead of no file, because the missing files would cause errors/warnings.
3. Add an integration test that runs `doc/build_docs.py` with `--max_notebooks=0` and `--fail_on_warning`.
4. Set up CircleCI to run the new test.

Currently this test fails, because our documentation is broken, but it should be fixed by #1856

I've set this up as a separate "fast" test on CircelCI - it seems like it takes about 3 minutes to run: 2 minutes to install GPflow and 1 minute to actually run the test. Alternatively we could run this as a "slow" test, or fold it into the existing "unit" or "notebook" tests. Folding it into an existing test would save the cost of installing GPflow.