### PR TITLE
Make check_shapes play well with tf's custom code inspection.

### DIFF
--- a/gpflow/experimental/check_shapes/exceptions.py
+++ b/gpflow/experimental/check_shapes/exceptions.py
@@ -39,6 +39,9 @@ class CheckShapesError(Exception):
 
         self.context = context
 
+        # Prevent Keras from rewriting our exception:
+        self._keras_call_info_injected = True
+
 
 class VariableTypeError(CheckShapesError):
     """


### PR DESCRIPTION
Tensorflow has its own code for decorating functions and for code inspection, because of course they cannot do anything the easy way. This updates `check_shapes` to be compatible with that.

Fixes #1858