### PR TITLE
Fix update_versions.py.

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -80,7 +80,6 @@ html_theme_options = {
     "github_url": "https://github.com/GPflow/GPflow",
     "switcher": {
         "json_url": "https://gpflow.github.io/GPflow/versions.json",
-        "url_template": "https://gpflow.github.io/GPflow/{version}/index.html",
         "version_match": Path("build_version.txt").read_text().strip(),
     },
     "navbar_end": ["version-switcher"],

--- a/doc/update_versions.py
+++ b/doc/update_versions.py
@@ -50,6 +50,7 @@ class _Versions:
         self._versions.append(
             {
                 "version": version,
+                "url": f"https://gpflow.github.io/GPflow/{version}/index.html",
             }
         )
         self._sorted = False
@@ -65,6 +66,7 @@ class _Versions:
             # Insert `develop` in the second spot, after the latest release, but before older
             # releases:
             versions.insert(1, develop)
+        self._versions = versions
         self._sorted = True
 
     @property


### PR DESCRIPTION
It had two problems:

1. (Embarrassingly) forgot to update `self._versions` in `_Versions.sort`.
2. New version of `pydata-sphinx-theme` has removed the `url_template`, and instead require each version to have an explicit `url` value.