### PR TITLE
Add check_shapes to inducing_variables.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,14 +33,13 @@ This release contains contributions from:
 <INSERT>, <NAME>, <HERE>, <USING>, <GITHUB>, <HANDLE>
 
 
-# Release 2.5.3 (next upcoming release in progress)
+# Release 2.6.0 (next upcoming release in progress)
 
 <INSERT SMALL BLURB ABOUT RELEASE FOCUS AREA AND POTENTIAL TOOLCHAIN CHANGES>
 
 ## Breaking Changes
 
-* <DOCUMENT BREAKING CHANGES HERE>
-* <THIS SECTION SHOULD CONTAIN API AND BEHAVIORAL BREAKING CHANGES>
+* Change to `InducingVariables` API. `InducingVariables` must now have a `shape` property.
 
 ## Known Caveats
 
@@ -63,7 +62,7 @@ This release contains contributions from:
 
 This release contains contributions from:
 
-<INSERT>, <NAME>, <HERE>, <USING>, <GITHUB>, <HANDLE>
+jesnie
 
 
 # Release 2.5.2

--- a/doc/sphinx/notebooks/advanced/variational_fourier_features.pct.py
+++ b/doc/sphinx/notebooks/advanced/variational_fourier_features.pct.py
@@ -33,6 +33,7 @@ from gpflow.utilities import to_default_float
 from gpflow import covariances as cov
 from gpflow import kullback_leiblers as kl
 from gpflow.ci_utils import ci_niter
+from gpflow.experimental.check_shapes import Shape
 
 # %%
 # VFF give structured covariance matrices that are computationally efficient.
@@ -59,13 +60,21 @@ class FourierFeatures1D(InducingVariables):
         # [a, b] defining the interval of the Fourier representation:
         self.a = gpflow.Parameter(a, dtype=gpflow.default_float())
         self.b = gpflow.Parameter(b, dtype=gpflow.default_float())
+        self.M = M
         # integer array defining the frequencies, ω_m = 2π (b - a)/m:
         self.ms = np.arange(M)
 
     @property
     def num_inducing(self):
         """ number of inducing variables (defines dimensionality of q(u)) """
-        return 2 * tf.shape(self.ms)[0] - 1  # `M` cosine and `M-1` sine components
+        return 2 * self.M - 1  # `M` cosine and `M-1` sine components
+
+    @property
+    def shape(self) -> Shape:
+        M = 2 * self.M - 1
+        D = 1  # Input size.
+        P = 1  # Output size.
+        return (M, D, P)
 
 
 # %% [markdown]

--- a/gpflow/covariances/kufs.py
+++ b/gpflow/covariances/kufs.py
@@ -35,7 +35,7 @@ def Kuf_sqexp_multiscale(
     Xnew, _ = kernel.slice(Xnew, None)
     Zmu, Zlen = kernel.slice(inducing_variable.Z, inducing_variable.scales)
     idlengthscales = kernel.lengthscales + Zlen
-    d = inducing_variable._cust_square_dist(Xnew, Zmu, idlengthscales)
+    d = inducing_variable._cust_square_dist(Xnew, Zmu, idlengthscales[None, :, :])
     lengthscales = tf.reduce_prod(kernel.lengthscales / idlengthscales, 1)
     lengthscales = tf.reshape(lengthscales, (1, -1))
     return tf.transpose(kernel.variance * tf.exp(-0.5 * d) * lengthscales)

--- a/gpflow/inducing_variables/inducing_variables.py
+++ b/gpflow/inducing_variables/inducing_variables.py
@@ -20,10 +20,11 @@ import tensorflow_probability as tfp
 from deprecated import deprecated
 
 from ..base import Module, Parameter, TensorData, TensorType
+from ..experimental.check_shapes import ErrorContext, Shape, check_shapes, get_shape
 from ..utilities import positive
 
 
-class InducingVariables(Module):
+class InducingVariables(Module, abc.ABC):
     """
     Abstract base class for inducing variables.
     """
@@ -44,20 +45,52 @@ class InducingVariables(Module):
     def __len__(self) -> tf.Tensor:
         return self.num_inducing
 
+    @property
+    @abc.abstractmethod
+    def shape(self) -> Shape:
+        """
+        Return the shape of these inducing variables.
+
+        Shape should be some variation of ``[M, D, P]``, where:
+
+        * ``M`` is the number of inducing variables.
+        * ``D`` is the number of input dimensions.
+        * ``P`` is the number of output dimensions (1 if this is not a multi-output inducing
+          variable).
+        """
+
+
+@get_shape.register(InducingVariables)
+def get_scalar_shape(shaped: InducingVariables, context: ErrorContext) -> Shape:
+    return shaped.shape
+
 
 class InducingPointsBase(InducingVariables):
+    @check_shapes(
+        "Z: [M, D]",
+    )
     def __init__(self, Z: TensorData, name: Optional[str] = None):
         """
-        :param Z: the initial positions of the inducing points, size [M, D]
+        :param Z: The initial positions of the inducing points.
         """
         super().__init__(name=name)
         if not isinstance(Z, (tf.Variable, tfp.util.TransformedVariable)):
             Z = Parameter(Z)
         self.Z = Z
 
-    @property
+    @property  # type: ignore  # mypy doesn't like decorated properties.
+    @check_shapes(
+        "return: []",
+    )
     def num_inducing(self) -> Optional[tf.Tensor]:
         return tf.shape(self.Z)[0]
+
+    @property
+    def shape(self) -> Shape:
+        shape = self.Z.shape
+        if not shape:
+            return None
+        return tuple(shape) + (1,)
 
 
 class InducingPoints(InducingPointsBase):
@@ -73,19 +106,25 @@ class Multiscale(InducingPointsBase):
     Originally proposed in :cite:t:`NIPS2009_3876`.
     """
 
+    @check_shapes(
+        "Z: [M, D]",
+        "scales: [M, D]",
+    )
     def __init__(self, Z: TensorData, scales: TensorData):
         super().__init__(Z)
         # Multi-scale inducing_variable widths (std. dev. of Gaussian)
         self.scales = Parameter(scales, transform=positive())
-        if self.Z.shape != self.scales.shape:
-            raise ValueError(
-                "Input locations `Z` and `scales` must have the same shape."
-            )  # pragma: no cover
 
     @staticmethod
+    @check_shapes(
+        "A: [N, D]",
+        "B: [M, D]",
+        "sc: [broadcast N, broadcast M, D]",
+        "return: [N, M]",
+    )
     def _cust_square_dist(A: TensorType, B: TensorType, sc: TensorType) -> tf.Tensor:
         """
         Custom version of _square_dist that allows sc to provide per-datapoint length
-        scales. sc: [N, M, D].
+        scales.
         """
         return tf.reduce_sum(tf.square((tf.expand_dims(A, 1) - tf.expand_dims(B, 0)) / sc), 2)

--- a/gpflow/inducing_variables/multioutput/inducing_variables.py
+++ b/gpflow/inducing_variables/multioutput/inducing_variables.py
@@ -15,6 +15,7 @@ from typing import Sequence, Tuple
 
 import tensorflow as tf
 
+from ...experimental.check_shapes import Shape, check_shapes
 from ..inducing_variables import InducingVariables
 
 
@@ -67,17 +68,31 @@ class FallbackSharedIndependentInducingVariables(MultioutputInducingVariables):
     processes.
     """
 
+    @check_shapes(
+        "inducing_variable: [M, D, 1]",
+    )
     def __init__(self, inducing_variable: InducingVariables):
         super().__init__()
         self.inducing_variable = inducing_variable
 
-    @property
+    @property  # type: ignore  # mypy doesn't like decorated properties.
+    @check_shapes(
+        "return: []",
+    )
     def num_inducing(self) -> tf.Tensor:
         return self.inducing_variable.num_inducing
 
     @property
     def inducing_variables(self) -> Tuple[InducingVariables]:
         return (self.inducing_variable,)
+
+    @property
+    def shape(self) -> Shape:
+        inner = self.inducing_variable.shape
+        if inner is None:
+            return inner
+        assert inner[2] == 1
+        return inner[:2] + (None,)
 
 
 class FallbackSeparateIndependentInducingVariables(MultioutputInducingVariables):
@@ -113,18 +128,31 @@ class FallbackSeparateIndependentInducingVariables(MultioutputInducingVariables)
     Note: each object should have the same number of inducing variables, M.
     """
 
+    @check_shapes(
+        "inducing_variable_list[all]: [M, D, 1]",
+    )
     def __init__(self, inducing_variable_list: Sequence[InducingVariables]):
         super().__init__()
         self.inducing_variable_list = inducing_variable_list
 
-    @property
+    @property  # type: ignore  # mypy doesn't like decorated properties.
+    @check_shapes(
+        "return: []",
+    )
     def num_inducing(self) -> tf.Tensor:
-        # TODO(st--) we should check that they all have the same length...
         return self.inducing_variable_list[0].num_inducing
 
     @property
     def inducing_variables(self) -> Tuple[InducingVariables, ...]:
         return tuple(self.inducing_variable_list)
+
+    @property
+    def shape(self) -> Shape:
+        inner = self.inducing_variable_list[0].shape
+        if inner is None:
+            return inner
+        assert inner[2] == 1
+        return inner[:2] + (len(self.inducing_variable_list),)
 
 
 class SharedIndependentInducingVariables(FallbackSharedIndependentInducingVariables):
@@ -135,8 +163,6 @@ class SharedIndependentInducingVariables(FallbackSharedIndependentInducingVariab
     the most efficient implementation.
     """
 
-    pass
-
 
 class SeparateIndependentInducingVariables(FallbackSeparateIndependentInducingVariables):
     """
@@ -145,5 +171,3 @@ class SeparateIndependentInducingVariables(FallbackSeparateIndependentInducingVa
     `Kuu()` and `Kuf()` return. This allows a custom `conditional()` to provide
     the most efficient implementation.
     """
-
-    pass

--- a/tests/gpflow/experimental/check_shapes/test_shapes.py
+++ b/tests/gpflow/experimental/check_shapes/test_shapes.py
@@ -35,8 +35,11 @@ from .utils import TestContext
         ((0,), (1,)),
         ([[0.1, 0.2]], (1, 2)),
         ([[[], []]], None),
+        (np.zeros(()), ()),
         (np.zeros((3, 4)), (3, 4)),
+        (tf.zeros(()), ()),
         (tf.zeros((4, 3)), (4, 3)),
+        (tf.Variable(np.zeros(())), ()),
         (tf.Variable(np.zeros((2, 4))), (2, 4)),
         # pylint: disable=unexpected-keyword-arg
         (tf.Variable(np.zeros((2, 4)), shape=[2, None]), (2, None)),

--- a/tests/gpflow/utilities/test_multipledispatch.py
+++ b/tests/gpflow/utilities/test_multipledispatch.py
@@ -117,7 +117,7 @@ def test_dispatcher_autograph_warnings(
     test_fn_compiled = tf.function(test_fn)  # with autograph=True by default
 
     # ...but calling using subclass
-    result = test_fn_compiled(gpflow.inducing_variables.InducingPoints([1.0, 2.0]))
+    result = test_fn_compiled(gpflow.inducing_variables.InducingPoints([[1.0, 2.0]]))
     assert result.numpy() == 3.0  # expect computation to work either way
 
     captured = capsys.readouterr()


### PR DESCRIPTION
Add shape checking to the `inducing_variables` sub-package:

1. I don't know what's going on with that `kufs.py`. See: https://secondmind-ai.slack.com/archives/CUFMWJN4T/p1651748445091629
2. I use `get_shape.register` to define a shape of inducing variables.
3. This triggered some `mypy` warnings in `posteriors.py`, which I fix with a `cast`. `X_data` has type `Union[tf.Tensor, InducingVariables]`, though in practice they should never be `InducingVariables` at that point in the code.
4. Extended tests of `get_shapes`, as I though of some special cases I hadn't covered.
5. Extended tests of `InducingVariables`, particularly around shapes.
