### PR TITLE
Stop using uninitialised variables.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,15 +55,13 @@ This release contains contributions from:
 
 ## Bug Fixes and Other Changes
 
-* <SIMILAR TO ABOVE SECTION, BUT FOR OTHER IMPORTANT CHANGES / BUG FIXES>
-* <IF A CHANGE CLOSES A GITHUB ISSUE, IT SHOULD BE DOCUMENTED HERE>
-* <NOTES SHOULD BE GROUPED PER AREA>
+* Fixed some bugs that prevented TensorFlow compilation and had negative performance impact. (#1882)
 
 ## Thanks to our Contributors
 
 This release contains contributions from:
 
-<INSERT>, <NAME>, <HERE>, <USING>, <GITHUB>, <HANDLE>
+jesnie
 
 
 # Release 2.5.1

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -135,7 +135,6 @@ class Parameter(tfp.util.TransformedVariable):
         if transform:
             name = name or transform.name
 
-        tensor_value: TensorType
         if isinstance(value, Parameter):
             transform = transform or value.transform
             prior = prior or value.prior
@@ -144,7 +143,7 @@ class Parameter(tfp.util.TransformedVariable):
             trainable = value.trainable if trainable is None else trainable
 
             if dtype:
-                tensor_value = _cast_to_dtype(value, dtype)
+                tensor_value: TensorType = _cast_to_dtype(value, dtype)
             else:
                 tensor_value = value
         else:

--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Optional, Tuple
+from typing import Optional, Tuple
 
 import tensorflow as tf
 
@@ -627,14 +627,11 @@ def separate_independent_conditional_implementation(
     fs = tf.transpose(f)[:, :, None]  # [P, M, 1]
     # [P, 1, M, M]  or  [P, M, 1]
 
-    base_conditional_args_to_map: Tuple[tf.Tensor, ...]
-    single_gp_conditional: Callable[[Tuple[tf.Tensor, ...]], MeanAndVariance]
-
     if q_sqrt is not None:
         q_sqrts = (
             tf.transpose(q_sqrt)[:, :, None] if q_sqrt.shape.ndims == 2 else q_sqrt[:, None, :, :]
         )
-        base_conditional_args_to_map = (Kmms, Kmns, Knns, fs, q_sqrts)
+        base_conditional_args_to_map: Tuple[tf.Tensor, ...] = (Kmms, Kmns, Knns, fs, q_sqrts)
 
         def single_gp_conditional(
             t: Tuple[tf.Tensor, ...]

--- a/gpflow/covariances/kufs.py
+++ b/gpflow/covariances/kufs.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np  # Used by Sphinx to generate documentation.
+import numpy as np  # pylint: disable=unused-import  # Used by Sphinx to generate documentation.
 import tensorflow as tf
 
 from ..base import TensorLike, TensorType

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
-import warnings
 from typing import Any, Callable, Iterable, Optional, Sequence, Union
 
 import tensorflow as tf

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -133,10 +133,9 @@ class GPModel(BayesianModel):
         problematic assumptions re the output dimensions of mean_function.
         See https://github.com/GPflow/GPflow/issues/1343
         """
-        num_latent_gps: int
         if isinstance(kernel, MultioutputKernel):
             # MultioutputKernels already have num_latent_gps attributes
-            num_latent_gps = kernel.num_latent_gps
+            num_latent_gps: int = kernel.num_latent_gps
         elif isinstance(likelihood, SwitchedLikelihood):
             # the SwitchedLikelihood partitions/stitches based on the last
             # column in Y, but we should not add a separate latent GP for this!

--- a/gpflow/utilities/multipledispatch.py
+++ b/gpflow/utilities/multipledispatch.py
@@ -46,9 +46,8 @@ class Dispatcher(GeneratorDispatcher):
         """
         Returns matching function for `types`; if not existing returns None.
         """
-        result: AnyCallable
         if types in self.funcs:
-            result = self.funcs[types]
+            result: AnyCallable = self.funcs[types]
             return result
 
         return self.get_first_occurrence(*types)
@@ -75,10 +74,9 @@ class Dispatcher(GeneratorDispatcher):
         `None` is returned.
         """
         n = len(types)
-        result: AnyCallable
         for signature in self.ordering:
             if len(signature) == n and all(map(issubclass, types, signature)):  # type: ignore
-                result = self.funcs[signature]
+                result: AnyCallable = self.funcs[signature]
                 return result
             elif len(signature) and isvariadic(signature[-1]):
                 if variadic_signature_matches(types, signature):

--- a/tests/gpflow/test_initial_value.py
+++ b/tests/gpflow/test_initial_value.py
@@ -1,0 +1,146 @@
+# Copyright 2022 the GPflow authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import ast
+from pathlib import Path
+from typing import List, Sequence, Union
+
+import pytest
+
+import gpflow
+
+
+def find_py_files() -> Sequence[Path]:
+    """
+    Find all ``.py`` files of the GPflow user-facing code.
+    """
+    root_module = gpflow
+    root_path_str = root_module.__file__
+    assert root_path_str is not None
+    root_path = Path(root_path_str).parent
+    return tuple(root_path.glob("**/*.py"))
+
+
+_PY_FILES = find_py_files()
+
+
+@pytest.mark.parametrize("path", _PY_FILES, ids=str)
+def test_assignment_value(path: Path) -> None:
+    """
+    Python allows assignments without a value, generally used for typing. For example::
+
+        @tf.function
+        def foo(a: tf.Tensor, b: tf.Tensor) -> tf.Tensor:
+            result: tf.Tensor  # <-- Assignment without a value. Only for typing.
+            result = a + b
+            return result
+
+    However, ``TensorFlow < 2.9.0`` cannot compile these.
+
+    This test parses all our ``.py`` files and look for assignments without a value, to ensure all
+    our code can be compiled by TensorFlow.
+
+    See also: https://github.com/tensorflow/tensorflow/issues/56024
+    """
+
+    tree = ast.parse(path.read_text(), str(path))
+
+    class RequireAssignmentValue(ast.NodeVisitor):
+        """
+        When ``.visit(tree)`` is called this will recursively visit all nodes of ``tree``.
+
+        Visitor methods are called based on the types of the nodes of the tree. If a node has type
+        ``Foo``, then ``visit_Foo(...)`` below will be called. If no such method exists
+        ``generic_visit`` is called insted, which just visits the children of the node recursively.
+        """
+
+        def __init__(self) -> None:
+            super().__init__()
+
+            self.in_function_stack: List[bool] = []
+            """
+            Keeps track of whether we're inside a function.  We only raise errors for assignments in
+            functions - I think variables on classes are handled differently, and doesn't cause
+            these problems.
+            """
+
+            self.bad_assigns: List[ast.AST] = []
+            """
+            List of bad assignments, so that we can report multiple errors at the same time.
+            """
+
+        def set_in_function(self, node: ast.AST, in_function: bool) -> None:
+            """
+            Set whether we're inside a function, and visit children recursively.
+            """
+            self.in_function_stack.append(in_function)
+            self.generic_visit(node)
+            self.in_function_stack.pop()
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            """
+            Called for class definitions.
+            """
+            self.set_in_function(node, False)
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            """
+            Called for function (and method) definitions.
+            """
+            self.set_in_function(node, True)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            """
+            Called for async function definitions.
+            """
+            self.set_in_function(node, True)
+
+        def check_assign(self, node: Union[ast.Assign, ast.AugAssign, ast.AnnAssign]) -> None:
+            """
+            Checks whether this is a valid assignment, and visit children recursively.
+            """
+            if self.in_function_stack and self.in_function_stack[-1]:
+                if not node.value:
+                    self.bad_assigns.append(node)
+            self.generic_visit(node)
+
+        def visit_Assign(self, node: ast.Assign) -> None:
+            """
+            Called for a regular assignment.
+            """
+            self.check_assign(node)
+
+        def visit_AugAssign(self, node: ast.AugAssign) -> None:
+            """
+            Called for +=, -=, etc.
+            """
+            self.check_assign(node)
+
+        def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+            """
+            Called for an assigment with a type annotation.
+            """
+            self.check_assign(node)
+
+    visitor = RequireAssignmentValue()
+    visitor.visit(tree)
+
+    if visitor.bad_assigns:
+        lines = [""]
+        lines.extend(f"{path}:{n.lineno}" for n in visitor.bad_assigns)
+        lines.append(
+            "TensorFlow cannot compile assignments without a value,"
+            " so for performance reasons we require all assgnments to have a value."
+            " See: https://github.com/tensorflow/tensorflow/issues/56024 "
+        )
+        raise AssertionError("\n".join(lines))


### PR DESCRIPTION
Fixes #1881 

Apparently TensorFlow cannot compile code that has variables without a value. See #1881 .
This PR:

- Adds a unit test that all assignments have a value.
- Removes any cases of assignments without a value that we had.
- (And drive-by fixes a couple of unused imports...)
