### PR TITLE
Support multiple variable-rank dimension specifications.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,8 +49,8 @@ This release contains contributions from:
 
 ## Major Features and Improvements
 
-* <INSERT MAJOR FEATURE HERE, USING MARKDOWN SYNTAX>
-* <IF RELEASE CONTAINS MULTIPLE FEATURES FROM SAME AREA, GROUP THEM TOGETHER>
+* `gpflow.experimental.check_shapes`
+  - Now support multiple variable-rank dimensions at the same time, e.g. `cov: [n..., n...]`.
 
 ## Bug Fixes and Other Changes
 

--- a/gpflow/experimental/check_shapes/__init__.py
+++ b/gpflow/experimental/check_shapes/__init__.py
@@ -256,6 +256,23 @@ places:
      :dedent:
 
 
+Best-effort checking
+++++++++++++++++++++
+
+This library will perform shape checks on a best-effort basis. Many things can prevent this library
+from being able to check shapes. For example:
+
+* Unknown shapes. Sometimes the library is not able to determine the shape of an object, and thus
+  cannot check that object. For example ``Optional`` arguments with value ``None`` cannot be
+  checked, and compiled TensorFlow code can have variables with an unknown shape.
+
+* Use of variable-rank dimensions. In general we cannot infer the size of variable-rank dimensions
+  if there are multiple variable-rank specifications within the same shape specification (e.g.
+  ``cov: [m..., n...]``). This library will try to learn the size of these variable-rank dimensions
+  from neighbouring shape specifications, but this is not always possible. Use of ``broadcast`` with
+  variable-rank dimensions makes it even harder to infer these values.
+
+
 Shape reuse
 +++++++++++
 

--- a/gpflow/experimental/check_shapes/specs.py
+++ b/gpflow/experimental/check_shapes/specs.py
@@ -68,10 +68,6 @@ class ParsedShapeSpec:
     dims: Tuple[ParsedDimensionSpec, ...]
 
     def __post_init__(self) -> None:
-        n_variable_rank = sum(dim.variable_rank for dim in self.dims)
-        assert (
-            n_variable_rank <= 1
-        ), f"At most one variable-rank dimension allowed. Found {n_variable_rank} in {self}."
         for dim in self.dims[1:]:
             assert (not dim.broadcastable) or (
                 not dim.variable_rank

--- a/gpflow/utilities/ops.py
+++ b/gpflow/utilities/ops.py
@@ -98,7 +98,7 @@ def leading_transpose(tensor: tf.Tensor, perm: List[Any], leading_dim: int = 0) 
 @check_shapes(
     "a: [a_shape...]",
     "b: [b_shape...]",
-    "return: [a_shape_b_shape...]",
+    "return: [a_shape..., b_shape...]",
 )
 def broadcasting_elementwise(
     op: Callable[[tf.Tensor, tf.Tensor], tf.Tensor], a: tf.Tensor, b: tf.Tensor
@@ -115,7 +115,7 @@ def broadcasting_elementwise(
 @check_shapes(
     "X: [batch..., D]",
     "X2: [batch2..., D]",
-    "return: [batch_batch2...]",
+    "return: [batch..., batch2...]",
 )
 def square_distance(X: tf.Tensor, X2: Optional[tf.Tensor]) -> tf.Tensor:
     """
@@ -146,7 +146,7 @@ def square_distance(X: tf.Tensor, X2: Optional[tf.Tensor]) -> tf.Tensor:
 @check_shapes(
     "X: [batch..., D]",
     "X2: [batch2..., D]",
-    "return: [batch_batch2..., D]",
+    "return: [batch..., batch2..., D]",
 )
 def difference_matrix(X: tf.Tensor, X2: Optional[tf.Tensor]) -> tf.Tensor:
     """

--- a/tests/gpflow/experimental/check_shapes/test_checker.py
+++ b/tests/gpflow/experimental/check_shapes/test_checker.py
@@ -150,6 +150,54 @@ TESTS = [
         True,
     ),
     ShapeCheckerTest(
+        "var_rank_multi_1",
+        [
+            (t(1, 2, 3), "[ds1..., ds2...]"),
+            (t(1, 2), "[ds1...]"),
+            (t(3), "[ds2...]"),
+        ],
+        True,
+    ),
+    ShapeCheckerTest(
+        "var_rank_multi_2",
+        [
+            (t(1), "[ds1...]"),
+            (t(1, 2, 3), "[ds1..., ds2...]"),
+            (t(2, 3), "[ds2...]"),
+        ],
+        True,
+    ),
+    ShapeCheckerTest(
+        "var_rank_multi_3",
+        [
+            (t(), "[ds1...]"),
+            (t(1, 2, 3), "[ds2...]"),
+            (t(1, 2, 3), "[ds1..., ds2...]"),
+        ],
+        True,
+    ),
+    ShapeCheckerTest(
+        "var_rank_multi_4",
+        [
+            (t(1, 2, 1, 2), "[ds..., ds...]"),
+        ],
+        True,
+    ),
+    ShapeCheckerTest(
+        "var_rank_multi_5",
+        [
+            (t(1, 2, 3, 4, 5, 6), "[1, ..., 3, ..., 6]"),
+        ],
+        True,
+    ),
+    ShapeCheckerTest(
+        "var_rank_multi_broadcast",
+        [
+            (t(2, 1, 1, 2, 3), "[broadcast ds..., ds...]"),
+        ],
+        True,
+    ),
+    ShapeCheckerTest(
         "var_rank_unknown_dim_1",
         [
             (t(None, 6), "[ds...]"),
@@ -237,6 +285,51 @@ TESTS = [
         [
             (t(2, 3), "[ds...]"),
             (t(1, 2, 3), "[ds...]"),
+        ],
+        False,
+    ),
+    ShapeCheckerTest(
+        "var_rank_bad_6",
+        [
+            (t(1, 4, 3), "[ds1..., ds2...]"),
+            (t(1, 2), "[ds1...]"),
+            (t(3), "[ds2...]"),
+        ],
+        False,
+    ),
+    ShapeCheckerTest(
+        "var_rank_bad_7",
+        [
+            (t(1, 2, 1, 2, 3), "[ds..., ds...]"),
+        ],
+        False,
+    ),
+    ShapeCheckerTest(
+        "var_rank_bad_8",
+        [
+            (t(1, 2, 1, 3), "[ds..., ds...]"),
+        ],
+        False,
+    ),
+    ShapeCheckerTest(
+        "var_rank_bad_9",
+        [
+            (t(7, 2, 3, 4, 5, 6), "[1, ..., 3, ..., 6]"),
+        ],
+        False,
+    ),
+    ShapeCheckerTest(
+        "var_rank_bad_10",
+        [
+            (t(1, 2, 3, 4, 7), "[1, ..., 3, ..., 5]"),
+        ],
+        False,
+    ),
+    ShapeCheckerTest(
+        "var_rank_bad_11",
+        [
+            (t(2, 1, 1, 2, 3), "[broadcast ds..., ds...]"),
+            (t(1, 1, 2, 3), "[ds...]"),
         ],
         False,
     ),

--- a/tests/gpflow/experimental/check_shapes/test_parser.py
+++ b/tests/gpflow/experimental/check_shapes/test_parser.py
@@ -151,6 +151,7 @@ _TEST_DATA = [
             "b: [ds..., d1]",
             "c: [d1, ds..., d2]",
             "d: [d1, ds...]",
+            "e: [*ds1, ds2..., *ds3]",
             "return: [*ds, d1, d2]",
         ),
         ParsedFunctionSpec(
@@ -172,6 +173,10 @@ _TEST_DATA = [
                     make_shape_spec("d1", varrank("ds")),
                 ),
                 make_arg_spec(
+                    make_argument_ref("e"),
+                    make_shape_spec(varrank("ds1"), varrank("ds2"), varrank("ds3")),
+                ),
+                make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec(varrank("ds"), "d1", "d2"),
                 ),
@@ -183,6 +188,7 @@ _TEST_DATA = [
         :param b: Parameter b.
         :param c: Parameter c.
         :param d: Parameter d.
+        :param e: Parameter e.
         :returns: Return value.
         """,
         """
@@ -202,6 +208,10 @@ _TEST_DATA = [
             * **d** has shape [*d1*, *ds*...].
 
             Parameter d.
+        :param e:
+            * **e** has shape [*ds1*..., *ds2*..., *ds3*...].
+
+            Parameter e.
         :returns:
             * **return** has shape [*ds*..., *d1*, *d2*].
 
@@ -215,6 +225,7 @@ _TEST_DATA = [
             "b: [None, d2]",
             "c: [..., d1]",
             "d: [*, d2]",
+            "e: [*, ..., *]",
             "return: [..., d1, d2]",
         ),
         ParsedFunctionSpec(
@@ -236,6 +247,10 @@ _TEST_DATA = [
                     make_shape_spec(varrank(None), "d2"),
                 ),
                 make_arg_spec(
+                    make_argument_ref("e"),
+                    make_shape_spec(varrank(None), varrank(None), varrank(None)),
+                ),
+                make_arg_spec(
                     make_argument_ref("return"),
                     make_shape_spec(varrank(None), "d1", "d2"),
                 ),
@@ -247,6 +262,7 @@ _TEST_DATA = [
         :param b: Parameter b.
         :param c: Parameter c.
         :param d: Parameter d.
+        :param e: Parameter e.
         :returns: Return value.
         """,
         """
@@ -266,6 +282,10 @@ _TEST_DATA = [
             * **d** has shape [..., *d2*].
 
             Parameter d.
+        :param e:
+            * **e** has shape [..., ..., ...].
+
+            Parameter e.
         :returns:
             * **return** has shape [..., *d1*, *d2*].
 

--- a/tests/gpflow/experimental/check_shapes/test_specs.py
+++ b/tests/gpflow/experimental/check_shapes/test_specs.py
@@ -68,6 +68,13 @@ def test_note_spec() -> None:
         (
             make_arg_spec(
                 make_argument_ref("foo"),
+                make_shape_spec(varrank("x"), varrank("y")),
+            ),
+            "foo: [x..., y...]",
+        ),
+        (
+            make_arg_spec(
+                make_argument_ref("foo"),
                 make_shape_spec(None, varrank(None), None),
             ),
             "foo: [., ..., .]",


### PR DESCRIPTION
Fixes: #1889

Support multiple variable-rank dimension specifications. For example:

```python
@check_shapes(
    "a: [a_shape...]",
    "b: [b_shape...]",
    "return: [a_shape..., b_shape...]",  # <-- Previously not allowed.
)
def broadcasting_elementwise(
    op: Callable[[tf.Tensor, tf.Tensor], tf.Tensor], a: tf.Tensor, b: tf.Tensor
) -> tf.Tensor:
    """ Apply binary operation `op` to every pair in tensors `a` and `b`. """
```

This is more complexity than I'm really happy with, but GPflow uses that kind of shapes heavily, so we probably need to support it.