### PR TITLE
Make sure all code compiles correctly.

### DIFF
--- a/gpflow/conditionals/util.py
+++ b/gpflow/conditionals/util.py
@@ -631,7 +631,13 @@ def separate_independent_conditional_implementation(
         q_sqrts = (
             tf.transpose(q_sqrt)[:, :, None] if q_sqrt.shape.ndims == 2 else q_sqrt[:, None, :, :]
         )
-        base_conditional_args_to_map: Tuple[tf.Tensor, ...] = (Kmms, Kmns, Knns, fs, q_sqrts)
+        base_conditional_args_to_map = (
+            Kmms,
+            Kmns,
+            Knns,
+            fs,
+            q_sqrts,
+        )  # type: Tuple[tf.Tensor, ...]
 
         def single_gp_conditional(
             t: Tuple[tf.Tensor, ...]

--- a/gpflow/experimental/check_shapes/checker.py
+++ b/gpflow/experimental/check_shapes/checker.py
@@ -315,7 +315,7 @@ class ShapeChecker:
 
             # Determine shape:
             if shaped is None:
-                shape: Shape = None
+                shape = None
             else:
                 shape = get_shape(shaped, context)
             self._observed_shapes.append((shape, parsed_tensor_check, context))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+# Copyright 2022 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Iterable
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+
+@pytest.fixture(autouse=True)
+def test_auto_graph_compile(caplog: LogCaptureFixture) -> Iterable[None]:
+    yield
+
+    for when in ["setup", "call", "teardown"]:
+        for record in caplog.get_records(when):
+            assert not record.msg.startswith("AutoGraph could not transform"), record.getMessage()

--- a/tests/gpflow/test_monitor.py
+++ b/tests/gpflow/test_monitor.py
@@ -189,12 +189,16 @@ def test_ExecuteCallback_arguments(capsys: CaptureFixture[str]) -> None:
 # ########################################
 
 
+def none() -> None:
+    return None
+
+
 @pytest.mark.parametrize(
     "task_or_tasks",
     [
-        ExecuteCallback(lambda: None),
-        [ExecuteCallback(lambda: None)],
-        [ExecuteCallback(lambda: None), ExecuteCallback(lambda: None)],
+        ExecuteCallback(none),
+        [ExecuteCallback(none)],
+        [ExecuteCallback(none), ExecuteCallback(none)],
     ],
 )
 def test_MonitorTaskGroup_and_Monitor(task_or_tasks: Union[MonitorTask, List[MonitorTask]]) -> None:


### PR DESCRIPTION
Sometimes TensorFlow will (almost) silently not compile your code.
This PR adds a test that none of our other tests prints: "AutoGraph could not transform", and fixes the couple of cases there were discovered.

(Surprisingly TensorFlow *really* don't like type annotations...)