### PR TITLE
Make sure all ErrorContext-s are hashable.

### DIFF
--- a/gpflow/experimental/check_shapes/error_contexts.py
+++ b/gpflow/experimental/check_shapes/error_contexts.py
@@ -371,6 +371,16 @@ class ArgumentContext(ErrorContext):
             with builder.indent() as b:
                 b.add_columned_line("Value:", self.value)
 
+    def __eq__(self, other: Any) -> bool:
+        return (
+            type(self) == type(other)
+            and self.name_or_index == other.name_or_index
+            and self.value is other.value
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.name_or_index, id(self.value)))
+
 
 @dataclass(frozen=True)
 class AttributeContext(ErrorContext):
@@ -386,6 +396,12 @@ class AttributeContext(ErrorContext):
         if self.value is not _NO_VALUE:
             with builder.indent() as b:
                 b.add_columned_line("Value:", self.value)
+
+    def __eq__(self, other: Any) -> bool:
+        return type(self) == type(other) and self.name == other.name and self.value is other.value
+
+    def __hash__(self) -> int:
+        return hash((self.name, id(self.value)))
 
 
 @dataclass(frozen=True)
@@ -403,6 +419,12 @@ class IndexContext(ErrorContext):
             with builder.indent() as b:
                 b.add_columned_line("Value:", self.value)
 
+    def __eq__(self, other: Any) -> bool:
+        return type(self) == type(other) and self.index == other.index and self.value is other.value
+
+    def __hash__(self) -> int:
+        return hash((self.index, id(self.value)))
+
 
 @dataclass(frozen=True)
 class MappingKeyContext(ErrorContext):
@@ -414,6 +436,12 @@ class MappingKeyContext(ErrorContext):
 
     def print(self, builder: MessageBuilder) -> None:
         builder.add_columned_line("Map key:", f"[{self.key!r}]")
+
+    def __eq__(self, other: Any) -> bool:
+        return type(self) == type(other) and self.key is other.key
+
+    def __hash__(self) -> int:
+        return id(self.key)
 
 
 @dataclass(frozen=True)
@@ -430,6 +458,12 @@ class MappingValueContext(ErrorContext):
         if self.value is not _NO_VALUE:
             with builder.indent() as b:
                 b.add_columned_line("Value:", self.value)
+
+    def __eq__(self, other: Any) -> bool:
+        return type(self) == type(other) and self.key is other.key and self.value is other.value
+
+    def __hash__(self) -> int:
+        return hash((id(self.key), id(self.value)))
 
 
 @dataclass(frozen=True)
@@ -485,6 +519,12 @@ class ObjectValueContext(ErrorContext):
     def print(self, builder: MessageBuilder) -> None:
         builder.add_columned_line("Value:", repr(self.obj))
 
+    def __eq__(self, other: Any) -> bool:
+        return type(self) == type(other) and self.obj is other.obj
+
+    def __hash__(self) -> int:
+        return id(self.obj)
+
 
 @dataclass(frozen=True)
 class ObjectTypeContext(ErrorContext):
@@ -497,6 +537,12 @@ class ObjectTypeContext(ErrorContext):
     def print(self, builder: MessageBuilder) -> None:
         t = type(self.obj)
         builder.add_columned_line("Object type:", f"{t.__module__}.{t.__qualname__}")
+
+    def __eq__(self, other: Any) -> bool:
+        return type(self) == type(other) and self.obj is other.obj
+
+    def __hash__(self) -> int:
+        return id(self.obj)
 
 
 @dataclass(frozen=True)  # type: ignore  # mypy doesn't like abstract `dataclasses`.
@@ -545,6 +591,9 @@ class LarkUnexpectedInputContext(ParserInputContext):
             builder.add_line("Found unexpected character.")
         if isinstance(self.error, UnexpectedEOF):
             builder.add_line("Found unexpected end of input.")
+
+    def __hash__(self) -> int:
+        return hash((self.error, *sorted(self.terminal_descriptions.items())))
 
 
 @dataclass(frozen=True)

--- a/tests/gpflow/experimental/check_shapes/test_bool_specs.py
+++ b/tests/gpflow/experimental/check_shapes/test_bool_specs.py
@@ -15,7 +15,7 @@
 Unit test for code for specifying and evaluating boolean expressions.
 """
 from dataclasses import dataclass
-from typing import Any, Mapping, Tuple
+from typing import Any, List, Mapping, Tuple
 
 import pytest
 
@@ -41,6 +41,10 @@ class BoolSpecTest:
 
     def __str__(self) -> str:
         return repr(self.spec).replace(" ", "_")
+
+
+_NON_EMPTY_LIST = [3]
+_EMPTY_LIST: List[int] = []
 
 
 TESTS = [
@@ -88,22 +92,22 @@ TESTS = [
                 ),
             ),
             (
-                {"foo": [3]},
+                {"foo": _NON_EMPTY_LIST},
                 (
                     True,
                     StackContext(
                         ArgumentContext("foo"),
-                        ObjectValueContext([3]),
+                        ObjectValueContext(_NON_EMPTY_LIST),
                     ),
                 ),
             ),
             (
-                {"foo": []},
+                {"foo": _EMPTY_LIST},
                 (
                     False,
                     StackContext(
                         ArgumentContext("foo"),
-                        ObjectValueContext([]),
+                        ObjectValueContext(_EMPTY_LIST),
                     ),
                 ),
             ),


### PR DESCRIPTION
Make sure all `ErrorContext`s are hashable.

A couple of places we hash the error context, but actually they were not always hashable, leading to crashes. This PR ensure that all the `ErrorContext`s are hashable.