### PR TITLE
Add support for 'is None' and 'is not None' checks to check_shapes.

### DIFF
--- a/gpflow/experimental/check_shapes/__init__.py
+++ b/gpflow/experimental/check_shapes/__init__.py
@@ -196,6 +196,15 @@ This is useful if shapes depend on other input parameters. Valid conditions are:
      :end-before: [bool_spec_argument_ref]
      :dedent:
 
+* ``<argument specifier> is None``, and ``<argument specifier> is not None``, with the usual rules
+  for an ``<argument specifier>``, to test whether an argument is, or is not, ``None``. We currently
+  only allow tests against ``None``, not general Python equality tests:
+
+  .. literalinclude:: /examples/test_check_shapes_examples.py
+     :start-after: [bool_spec_argument_ref_is_none]
+     :end-before: [bool_spec_argument_ref_is_none]
+     :dedent:
+
 * ``<left> or <right>``, evaluates to ``True`` if any of ``<left>`` or ``<right>`` evaluates to
   ``True`` and to ``False`` otherwise:
 

--- a/gpflow/experimental/check_shapes/bool_specs.py
+++ b/gpflow/experimental/check_shapes/bool_specs.py
@@ -16,7 +16,8 @@ Code for specifying and evaluating boolean expressions.
 """
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Mapping, Tuple
+from enum import Enum
+from typing import Any, Callable, Mapping, Tuple, cast
 
 from .argument_ref import ArgumentRef
 from .error_contexts import ErrorContext, ObjectValueContext, ParallelContext, StackContext
@@ -35,7 +36,7 @@ def _paren_repr(spec: ParsedBoolSpec) -> str:
     Return the `repr` of `spec`, wrapping it in parenthesis if it is a non-trivial expression.
     """
     result = repr(spec)
-    if isinstance(spec, ParsedArgumentRefBoolSpec):
+    if isinstance(spec, ParsedArgumentRefBoolSpec) and spec.bool_test == BoolTest.BOOL:
         return result
     return f"({result})"
 
@@ -86,15 +87,35 @@ class ParsedNotBoolSpec(ParsedBoolSpec):
         return f"not {_paren_repr(self.right)}"
 
 
+class BoolTest(Enum):
+    """
+    Strategies for converting a value to ``bool``.
+    """
+
+    BOOL = (bool, lambda arg: arg)
+    IS_NONE = ((lambda x: x is None), lambda arg: f"{arg} is None")
+    IS_NOT_NONE = ((lambda x: x is not None), lambda arg: f"{arg} is not None")
+
+    @property
+    def to_bool(self) -> Callable[[Any], bool]:
+        return cast(Callable[[Any], bool], self.value[0])
+
+    @property
+    def repr(self) -> Callable[[str], str]:
+        return cast(Callable[[str], str], self.value[1])
+
+
 @dataclass(frozen=True)
 class ParsedArgumentRefBoolSpec(ParsedBoolSpec):
     """ A reference to an input argument. """
 
     argument_ref: ArgumentRef
+    bool_test: BoolTest
 
     def get(self, arg_map: Mapping[str, Any], context: ErrorContext) -> Tuple[bool, ErrorContext]:
         ((arg_value, relative_context),) = self.argument_ref.get(arg_map, context)
-        return bool(arg_value), StackContext(relative_context, ObjectValueContext(arg_value))
+        bool_value = self.bool_test.to_bool(arg_value)
+        return bool_value, StackContext(relative_context, ObjectValueContext(arg_value))
 
     def __repr__(self) -> str:
-        return repr(self.argument_ref)
+        return self.bool_test.repr(repr(self.argument_ref))

--- a/gpflow/experimental/check_shapes/check_shapes.lark
+++ b/gpflow/experimental/check_shapes/check_shapes.lark
@@ -27,11 +27,15 @@ argument_spec: argument_ref ":" shape_spec ("if" bool_spec)? note_spec?
 
 ?bool_spec_2: "(" bool_spec ")"
             | bool_spec_not
+            | bool_spec_argument_ref_is_none
+            | bool_spec_argument_ref_is_not_none
             | bool_spec_argument_ref
 
 bool_spec_or: bool_spec "or" bool_spec_1
 bool_spec_and: bool_spec_1 "and" bool_spec_2
 bool_spec_not: "not" bool_spec_2
+bool_spec_argument_ref_is_none: argument_ref "is" "None"
+bool_spec_argument_ref_is_not_none: argument_ref "is" "not" "None"
 bool_spec_argument_ref: argument_ref
 
 ?argument_ref: argument_ref_root

--- a/tests/examples/test_check_shapes_examples.py
+++ b/tests/examples/test_check_shapes_examples.py
@@ -370,6 +370,29 @@ def test_example__bool_spec_argument_ref() -> None:
     # [bool_spec_argument_ref]
 
 
+def test_example__bool_spec_argument_ref_is_none() -> None:
+    # pylint: disable=unused-argument
+
+    # [bool_spec_argument_ref_is_none]
+
+    @check_shapes(
+        "a: [n_a]",
+        "b: [n_b]",
+        "return: [n_a, n_a] if b is None",
+        "return: [n_a, n_b] if b is not None",
+    )
+    def square(a: AnyNDArray, b: Optional[AnyNDArray] = None) -> AnyNDArray:
+        if b is None:
+            b = a
+        result: AnyNDArray = a[:, None] * b[None, :]
+        return result
+
+    square(np.ones((3,)))
+    square(np.ones((3,)), np.ones((4,)))
+
+    # [bool_spec_argument_ref_is_none]
+
+
 def test_example__bool_spec_or() -> None:
     # pylint: disable=unused-argument
 

--- a/tests/gpflow/experimental/check_shapes/test_bool_specs.py
+++ b/tests/gpflow/experimental/check_shapes/test_bool_specs.py
@@ -125,6 +125,158 @@ TESTS = [
         expected_repr="foo",
     ),
     BoolSpecTest(
+        spec=barg("foo", "IS_NONE"),
+        expected_get=(
+            (
+                {"foo": True},
+                (
+                    False,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(True),
+                    ),
+                ),
+            ),
+            (
+                {"foo": False},
+                (
+                    False,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(False),
+                    ),
+                ),
+            ),
+            (
+                {"foo": 7},
+                (
+                    False,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(7),
+                    ),
+                ),
+            ),
+            (
+                {"foo": 0},
+                (
+                    False,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(0),
+                    ),
+                ),
+            ),
+            (
+                {"foo": _NON_EMPTY_LIST},
+                (
+                    False,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(_NON_EMPTY_LIST),
+                    ),
+                ),
+            ),
+            (
+                {"foo": _EMPTY_LIST},
+                (
+                    False,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(_EMPTY_LIST),
+                    ),
+                ),
+            ),
+            (
+                {"foo": None},
+                (
+                    True,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(None),
+                    ),
+                ),
+            ),
+        ),
+        expected_repr="foo is None",
+    ),
+    BoolSpecTest(
+        spec=barg("foo", "IS_NOT_NONE"),
+        expected_get=(
+            (
+                {"foo": True},
+                (
+                    True,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(True),
+                    ),
+                ),
+            ),
+            (
+                {"foo": False},
+                (
+                    True,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(False),
+                    ),
+                ),
+            ),
+            (
+                {"foo": 7},
+                (
+                    True,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(7),
+                    ),
+                ),
+            ),
+            (
+                {"foo": 0},
+                (
+                    True,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(0),
+                    ),
+                ),
+            ),
+            (
+                {"foo": _NON_EMPTY_LIST},
+                (
+                    True,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(_NON_EMPTY_LIST),
+                    ),
+                ),
+            ),
+            (
+                {"foo": _EMPTY_LIST},
+                (
+                    True,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(_EMPTY_LIST),
+                    ),
+                ),
+            ),
+            (
+                {"foo": None},
+                (
+                    False,
+                    StackContext(
+                        ArgumentContext("foo"),
+                        ObjectValueContext(None),
+                    ),
+                ),
+            ),
+        ),
+        expected_repr="foo is not None",
+    ),
+    BoolSpecTest(
         spec=bor(barg("left"), barg("right")),
         expected_get=(
             (
@@ -177,6 +329,60 @@ TESTS = [
             ),
         ),
         expected_repr="left or right",
+    ),
+    BoolSpecTest(
+        spec=bor(barg("left", "IS_NONE"), barg("right", "IS_NOT_NONE")),
+        expected_get=(
+            (
+                {"left": 1, "right": 1},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(1)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(1)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": 1, "right": None},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(1)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(None)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": None, "right": 1},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(None)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(1)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": None, "right": None},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(None)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(None)),
+                        )
+                    ),
+                ),
+            ),
+        ),
+        expected_repr="(left is None) or (right is not None)",
     ),
     BoolSpecTest(
         spec=band(barg("left"), barg("right")),
@@ -233,6 +439,60 @@ TESTS = [
         expected_repr="left and right",
     ),
     BoolSpecTest(
+        spec=band(barg("left", "IS_NOT_NONE"), barg("right", "IS_NONE")),
+        expected_get=(
+            (
+                {"left": 1, "right": 1},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(1)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(1)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": 1, "right": None},
+                (
+                    True,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(1)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(None)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": None, "right": 1},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(None)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(1)),
+                        )
+                    ),
+                ),
+            ),
+            (
+                {"left": None, "right": None},
+                (
+                    False,
+                    ParallelContext(
+                        (
+                            StackContext(ArgumentContext("left"), ObjectValueContext(None)),
+                            StackContext(ArgumentContext("right"), ObjectValueContext(None)),
+                        )
+                    ),
+                ),
+            ),
+        ),
+        expected_repr="(left is not None) and (right is None)",
+    ),
+    BoolSpecTest(
         spec=bnot(barg("right")),
         expected_get=(
             (
@@ -245,6 +505,34 @@ TESTS = [
             ),
         ),
         expected_repr="not right",
+    ),
+    BoolSpecTest(
+        spec=bnot(barg("right", "IS_NONE")),
+        expected_get=(
+            (
+                {"right": 1},
+                (True, StackContext(ArgumentContext("right"), ObjectValueContext(1))),
+            ),
+            (
+                {"right": None},
+                (False, StackContext(ArgumentContext("right"), ObjectValueContext(None))),
+            ),
+        ),
+        expected_repr="not (right is None)",
+    ),
+    BoolSpecTest(
+        spec=bnot(barg("right", "IS_NOT_NONE")),
+        expected_get=(
+            (
+                {"right": 1},
+                (False, StackContext(ArgumentContext("right"), ObjectValueContext(1))),
+            ),
+            (
+                {"right": None},
+                (True, StackContext(ArgumentContext("right"), ObjectValueContext(None))),
+            ),
+        ),
+        expected_repr="not (right is not None)",
     ),
     BoolSpecTest(
         spec=bor(bnot(barg("left")), bnot(barg("right"))),

--- a/tests/gpflow/experimental/check_shapes/test_decorator.py
+++ b/tests/gpflow/experimental/check_shapes/test_decorator.py
@@ -564,15 +564,18 @@ def test_check_shapes__condition() -> None:
     @check_shapes(
         "a: [1] if b1",
         "a: [2] if not b1 and b2",
-        "a: [3] if not b1 and not b2",
+        "a: [3] if not b1 and b2 is not None and not b2",
+        "a: [4] if not b1 and b2 is None",
     )
-    def f(a: TestShaped, b1: bool, b2: bool) -> None:
+    def f(a: TestShaped, b1: bool, b2: Optional[bool]) -> None:
         pass
 
     f(t(1), True, True)
     f(t(1), True, False)
+    f(t(1), True, None)
     f(t(2), False, True)
     f(t(3), False, False)
+    f(t(4), False, None)
 
     with pytest.raises(ShapeMismatchError):
         f(t(2), True, True)
@@ -581,10 +584,16 @@ def test_check_shapes__condition() -> None:
         f(t(2), True, False)
 
     with pytest.raises(ShapeMismatchError):
+        f(t(2), True, None)
+
+    with pytest.raises(ShapeMismatchError):
         f(t(1), False, True)
 
     with pytest.raises(ShapeMismatchError):
         f(t(2), False, False)
+
+    with pytest.raises(ShapeMismatchError):
+        f(t(2), False, None)
 
 
 def test_check_shapes__reuse() -> None:

--- a/tests/gpflow/experimental/check_shapes/test_integration.py
+++ b/tests/gpflow/experimental/check_shapes/test_integration.py
@@ -35,7 +35,7 @@ from gpflow.experimental.check_shapes.exceptions import ShapeMismatchError
 def test_check_shapes__numpy() -> None:
     @check_shapes(
         "a: [d1, d2]",
-        "b: [d1, d3]",
+        "b: [d1, d3] if b is not None",
         "return: [d2, d3]",
     )
     def f(a: AnyNDArray, b: AnyNDArray) -> AnyNDArray:
@@ -47,7 +47,7 @@ def test_check_shapes__numpy() -> None:
 def test_check_shapes__tensorflow() -> None:
     @check_shapes(
         "a: [d1, d2]",
-        "b: [d1, d3]",
+        "b: [d1, d3] if b is not None",
         "return: [d2, d3]",
     )
     def f(a: tf.Tensor, b: tf.Tensor) -> tf.Tensor:

--- a/tests/gpflow/experimental/check_shapes/test_parser.py
+++ b/tests/gpflow/experimental/check_shapes/test_parser.py
@@ -472,6 +472,18 @@ _TEST_DATA = [
             "x: [10] if not (b1 or b2)",
             "x: [11] if not b1 and b2",
             "x: [12] if not (b1 and b2)",
+            "x: [13] if b1 is None",
+            "x: [14] if b1 is None or b2",
+            "x: [15] if b1 is None and b2",
+            "x: [16] if b1 or b2 is None",
+            "x: [17] if b1 and b2 is None",
+            "x: [18] if not b1 is None",
+            "x: [19] if b1 is not None",
+            "x: [20] if b1 is not None or b2",
+            "x: [21] if b1 is not None and b2",
+            "x: [22] if b1 or b2 is not None",
+            "x: [23] if b1 and b2 is not None",
+            "x: [24] if not b1 is not None",
         ),
         ParsedFunctionSpec(
             (
@@ -535,6 +547,66 @@ _TEST_DATA = [
                     make_shape_spec(12),
                     condition=bnot(band(barg("b1"), barg("b2"))),
                 ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(13),
+                    condition=barg("b1", "IS_NONE"),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(14),
+                    condition=bor(barg("b1", "IS_NONE"), barg("b2")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(15),
+                    condition=band(barg("b1", "IS_NONE"), barg("b2")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(16),
+                    condition=bor(barg("b1"), barg("b2", "IS_NONE")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(17),
+                    condition=band(barg("b1"), barg("b2", "IS_NONE")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(18),
+                    condition=bnot(barg("b1", "IS_NONE")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(19),
+                    condition=barg("b1", "IS_NOT_NONE"),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(20),
+                    condition=bor(barg("b1", "IS_NOT_NONE"), barg("b2")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(21),
+                    condition=band(barg("b1", "IS_NOT_NONE"), barg("b2")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(22),
+                    condition=bor(barg("b1"), barg("b2", "IS_NOT_NONE")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(23),
+                    condition=band(barg("b1"), barg("b2", "IS_NOT_NONE")),
+                ),
+                make_arg_spec(
+                    make_argument_ref("x"),
+                    make_shape_spec(24),
+                    condition=bnot(barg("b1", "IS_NOT_NONE")),
+                ),
             ),
             (),
         ),
@@ -546,7 +618,19 @@ _TEST_DATA = [
             * **x** has shape [10] if not (*b1* or *b2*).
             * **x** has shape [11] if (not *b1*) and *b2*.
             * **x** has shape [12] if not (*b1* and *b2*).
+            * **x** has shape [13] if *b1* is *None*.
+            * **x** has shape [14] if (*b1* is *None*) or *b2*.
+            * **x** has shape [15] if (*b1* is *None*) and *b2*.
+            * **x** has shape [16] if *b1* or (*b2* is *None*).
+            * **x** has shape [17] if *b1* and (*b2* is *None*).
+            * **x** has shape [18] if not (*b1* is *None*).
+            * **x** has shape [19] if *b1* is not *None*.
             * **x** has shape [1] if *b1*.
+            * **x** has shape [20] if (*b1* is not *None*) or *b2*.
+            * **x** has shape [21] if (*b1* is not *None*) and *b2*.
+            * **x** has shape [22] if *b1* or (*b2* is not *None*).
+            * **x** has shape [23] if *b1* and (*b2* is not *None*).
+            * **x** has shape [24] if not (*b1* is not *None*).
             * **x** has shape [2] if *b1* or *b2*.
             * **x** has shape [3] if *b1* and *b2*.
             * **x** has shape [4] if not *b1*.

--- a/tests/gpflow/experimental/check_shapes/utils.py
+++ b/tests/gpflow/experimental/check_shapes/utils.py
@@ -30,6 +30,7 @@ from gpflow.experimental.check_shapes.argument_ref import (
     ValuesRef,
 )
 from gpflow.experimental.check_shapes.bool_specs import (
+    BoolTest,
     ParsedAndBoolSpec,
     ParsedArgumentRefBoolSpec,
     ParsedBoolSpec,
@@ -110,8 +111,10 @@ def make_argument_ref(
     return result
 
 
-def barg(name: str) -> ParsedBoolSpec:
-    return ParsedArgumentRefBoolSpec(RootArgumentRef(name))
+def barg(name: str, bool_test: Union[BoolTest, str] = BoolTest.BOOL) -> ParsedBoolSpec:
+    if isinstance(bool_test, str):
+        bool_test = BoolTest[bool_test]
+    return ParsedArgumentRefBoolSpec(RootArgumentRef(name), bool_test)
 
 
 def bor(left: ParsedBoolSpec, right: ParsedBoolSpec) -> ParsedBoolSpec:


### PR DESCRIPTION
Add support for 'is None' and 'is not None' checks to check_shapes.

Again, not a feature I'm excited about supporting, but it's very much necessary to shape-check GPflow kernels.