### PR TITLE
Make check_shapes add info-fields for arguments that don't have any.

### DIFF
--- a/gpflow/experimental/check_shapes/__init__.py
+++ b/gpflow/experimental/check_shapes/__init__.py
@@ -403,8 +403,11 @@ Documenting shapes
 
 The :func:`check_shapes` decorator rewrites the docstring (``.__doc__``) of the decorated function
 to add information about shapes, in a format compatible with
-`Sphinx <https://www.sphinx-doc.org/en/master/>`_. Only parameters that already have a
-``:param ...:`` section will be modified.
+`Sphinx <https://www.sphinx-doc.org/en/master/>`_.
+
+Only functions that already have a docstring will be updated. Functions that have no docstring at
+all will not have one added, this is so that we do not override a docstring that would have been
+inherited from a super class.
 
 For example:
 

--- a/tests/gpflow/experimental/check_shapes/test_parser.py
+++ b/tests/gpflow/experimental/check_shapes/test_parser.py
@@ -730,7 +730,75 @@ _TEST_DATA = [
         None,
     ),
     TestData(
-        "partial_docstring",
+        "empty_docstring",
+        (
+            "a: [d1, d2]",
+            "b: [d1, d3]",
+            "return: [d2, d3]",
+        ),
+        ParsedFunctionSpec(
+            (
+                make_arg_spec(
+                    make_argument_ref("a"),
+                    make_shape_spec("d1", "d2"),
+                ),
+                make_arg_spec(
+                    make_argument_ref("b"),
+                    make_shape_spec("d1", "d3"),
+                ),
+                make_arg_spec(
+                    make_argument_ref("return"),
+                    make_shape_spec("d2", "d3"),
+                ),
+            ),
+            (),
+        ),
+        "",
+        """:param a:
+    * **a** has shape [*d1*, *d2*].
+:param b:
+    * **b** has shape [*d1*, *d3*].
+:returns:
+    * **return** has shape [*d2*, *d3*].
+""",
+    ),
+    TestData(
+        "no_params_doc",
+        (
+            "a: [d1, d2]",
+            "b: [d1, d3]",
+            "return: [d2, d3]",
+        ),
+        ParsedFunctionSpec(
+            (
+                make_arg_spec(
+                    make_argument_ref("a"),
+                    make_shape_spec("d1", "d2"),
+                ),
+                make_arg_spec(
+                    make_argument_ref("b"),
+                    make_shape_spec("d1", "d3"),
+                ),
+                make_arg_spec(
+                    make_argument_ref("return"),
+                    make_shape_spec("d2", "d3"),
+                ),
+            ),
+            (),
+        ),
+        """Some docstring.""",
+        """Some docstring.
+
+:param a:
+    * **a** has shape [*d1*, *d2*].
+:param b:
+    * **b** has shape [*d1*, *d3*].
+:returns:
+    * **return** has shape [*d2*, *d3*].
+""",
+    ),
+    TestData(
+        "partial_params_doc",
         (
             "a: [d1, d2]",
             "b: [d1, d3]",
@@ -761,6 +829,10 @@ _TEST_DATA = [
             * **b** has shape [*d1*, *d3*].
 
             Parameter b.
+        :param a:
+            * **a** has shape [*d1*, *d2*].
+        :returns:
+            * **return** has shape [*d2*, *d3*].
         """,
     ),
     TestData(
@@ -791,7 +863,12 @@ _TEST_DATA = [
         """:param b:
     * **b** has shape [*d1*, *d3*].
 
-    Parameter b.""",
+    Parameter b.
+:param a:
+    * **a** has shape [*d1*, *d2*].
+:returns:
+    * **return** has shape [*d2*, *d3*].
+""",
     ),
     TestData(
         "other_info_fields",
@@ -837,6 +914,42 @@ _TEST_DATA = [
 
             Some description of the return type.
         :rtype: TensorType
+        """,
+    ),
+    TestData(
+        "only_other_info_fields",
+        (
+            "a: [batch..., n_features]",
+            "return: [batch..., 1]",
+        ),
+        ParsedFunctionSpec(
+            (
+                make_arg_spec(
+                    make_argument_ref("a"),
+                    make_shape_spec(varrank("batch"), "n_features"),
+                ),
+                make_arg_spec(
+                    make_argument_ref("return"),
+                    make_shape_spec(varrank("batch"), 1),
+                ),
+            ),
+            (),
+        ),
+        """
+        :meta: Blah blah.
+        :type a: TensorType
+        :meta: More chaff.
+        :rtype: TensorType
+        """,
+        """
+        :meta: Blah blah.
+        :type a: TensorType
+        :meta: More chaff.
+        :rtype: TensorType
+        :param a:
+            * **a** has shape [*batch*..., *n_features*].
+        :returns:
+            * **return** has shape [*batch*..., 1].
         """,
     ),
     TestData(
@@ -1087,7 +1200,8 @@ _TEST_DATA = [
         * **return[0]** has shape [*test_batch*..., *n_labels*].
         * **return[1]** has shape [*test_batch*..., *n_labels*].
 
-        Model mean and variance prediction.""",
+        Model mean and variance prediction.
+""",
     ),
     TestData(
         "funny_formatting_4",
@@ -1156,7 +1270,8 @@ And some more comment.
 * **return[0]** has shape [*test_batch*..., *n_labels*].
 * **return[1]** has shape [*test_batch*..., *n_labels*].
 
-Model mean and variance prediction.""",
+Model mean and variance prediction.
+""",
     ),
 ]
 


### PR DESCRIPTION
Fixes: #1902

Make check_shapes add info-fields for arguments that don't have any.