### PR TITLE
Add shape checks to covariances.

### DIFF
--- a/gpflow/covariances/kufs.py
+++ b/gpflow/covariances/kufs.py
@@ -16,12 +16,18 @@ import numpy as np  # pylint: disable=unused-import  # Used by Sphinx to generat
 import tensorflow as tf
 
 from ..base import TensorLike, TensorType
+from ..experimental.check_shapes import check_shapes
 from ..inducing_variables import InducingPatches, InducingPoints, Multiscale
 from ..kernels import Convolutional, Kernel, SquaredExponential
 from .dispatch import Kuf
 
 
 @Kuf.register(InducingPoints, Kernel, TensorLike)
+@check_shapes(
+    "inducing_variable: [M, D, 1]",
+    "Xnew: [batch..., N, D]",
+    "return: [M, batch..., N]",
+)
 def Kuf_kernel_inducingpoints(
     inducing_variable: InducingPoints, kernel: Kernel, Xnew: TensorType
 ) -> tf.Tensor:
@@ -29,6 +35,11 @@ def Kuf_kernel_inducingpoints(
 
 
 @Kuf.register(Multiscale, SquaredExponential, TensorLike)
+@check_shapes(
+    "inducing_variable: [M, D, 1]",
+    "Xnew: [batch..., N, D]",
+    "return: [M, batch..., N]",
+)
 def Kuf_sqexp_multiscale(
     inducing_variable: Multiscale, kernel: SquaredExponential, Xnew: TensorType
 ) -> tf.Tensor:
@@ -42,6 +53,11 @@ def Kuf_sqexp_multiscale(
 
 
 @Kuf.register(InducingPatches, Convolutional, object)
+@check_shapes(
+    "inducing_variable: [M, D, 1]",
+    "Xnew: [batch..., N, D2]",
+    "return: [M, batch..., N]",
+)
 def Kuf_conv_patch(
     inducing_variable: InducingPatches, kernel: Convolutional, Xnew: TensorType
 ) -> tf.Tensor:

--- a/gpflow/covariances/kuus.py
+++ b/gpflow/covariances/kuus.py
@@ -15,12 +15,17 @@
 import tensorflow as tf
 
 from ..config import default_float
+from ..experimental.check_shapes import check_shapes
 from ..inducing_variables import InducingPatches, InducingPoints, Multiscale
 from ..kernels import Convolutional, Kernel, SquaredExponential
 from .dispatch import Kuu
 
 
 @Kuu.register(InducingPoints, Kernel)
+@check_shapes(
+    "inducing_variable: [M, D, 1]",
+    "return: [M, M]",
+)
 def Kuu_kernel_inducingpoints(
     inducing_variable: InducingPoints, kernel: Kernel, *, jitter: float = 0.0
 ) -> tf.Tensor:
@@ -30,6 +35,10 @@ def Kuu_kernel_inducingpoints(
 
 
 @Kuu.register(Multiscale, SquaredExponential)
+@check_shapes(
+    "inducing_variable: [M, D, 1]",
+    "return: [M, M]",
+)
 def Kuu_sqexp_multiscale(
     inducing_variable: Multiscale, kernel: SquaredExponential, *, jitter: float = 0.0
 ) -> tf.Tensor:
@@ -45,6 +54,10 @@ def Kuu_sqexp_multiscale(
 
 
 @Kuu.register(InducingPatches, Convolutional)
+@check_shapes(
+    "inducing_variable: [M, D, 1]",
+    "return: [M, M]",
+)
 def Kuu_conv_patch(
     inducing_variable: InducingPatches, kernel: Convolutional, jitter: float = 0.0
 ) -> tf.Tensor:

--- a/tests/gpflow/covariances/test_multioutput.py
+++ b/tests/gpflow/covariances/test_multioutput.py
@@ -1,4 +1,4 @@
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence
 
 import numpy as np
 import pytest
@@ -35,6 +35,10 @@ def make_ips(num: int) -> Sequence[InducingVariables]:
     return [make_ip() for _ in range(num)]
 
 
+def type_name(x: Any) -> str:
+    return x.__class__.__name__  # type: ignore
+
+
 # ------------------------------------------
 # Data classes: storing constants
 # ------------------------------------------
@@ -52,66 +56,96 @@ class Datum:
 
 
 multioutput_inducing_variable_list = [
-    mf.SharedIndependentInducingVariables(make_ip()),
-    mf.SeparateIndependentInducingVariables(make_ips(Datum.P)),
+    (
+        mf.SharedIndependentInducingVariables(make_ip()),
+        mf.SharedIndependentInducingVariables(make_ip()),
+    ),
+    (
+        mf.SeparateIndependentInducingVariables(make_ips(Datum.P)),
+        mf.SeparateIndependentInducingVariables(make_ips(Datum.L)),
+    ),
 ]
 
 multioutput_fallback_inducing_variable_list = [
     mf.FallbackSharedIndependentInducingVariables(make_ip()),
-    mf.FallbackSeparateIndependentInducingVariables(make_ips(Datum.P)),
+    mf.FallbackSeparateIndependentInducingVariables(make_ips(Datum.L)),
 ]
 
 multioutput_kernel_list = [
     mk.SharedIndependent(make_kernel(), Datum.P),
-    mk.SeparateIndependent(make_kernels(Datum.L)),
+    mk.SeparateIndependent(make_kernels(Datum.P)),
     mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W),
 ]
 
 
-@pytest.mark.parametrize("inducing_variable", multioutput_inducing_variable_list)
-@pytest.mark.parametrize("kernel", multioutput_kernel_list)
-def test_kuu_shape(inducing_variable: InducingVariables, kernel: Kernel) -> None:
+@pytest.mark.parametrize(
+    "inducing_variable_P,inducing_variable_L", multioutput_inducing_variable_list, ids=type_name
+)
+@pytest.mark.parametrize("kernel", multioutput_kernel_list, ids=type_name)
+def test_kuu_shape(
+    inducing_variable_P: InducingVariables, inducing_variable_L: InducingVariables, kernel: Kernel
+) -> None:
+    if isinstance(kernel, mk.LinearCoregionalization):
+        inducing_variable = inducing_variable_L
+    else:
+        inducing_variable = inducing_variable_P
+
     Kuu = covariances.Kuu(inducing_variable, kernel, jitter=1e-9)
     t = tf.linalg.cholesky(Kuu)
 
     if isinstance(kernel, mk.SharedIndependent):
         if isinstance(inducing_variable, mf.SeparateIndependentInducingVariables):
-            assert t.shape == (3, 10, 10)
+            assert t.shape == (Datum.P, Datum.M, Datum.M)
         else:
-            assert t.shape == (10, 10)
+            assert t.shape == (Datum.M, Datum.M)
+    elif isinstance(kernel, mk.LinearCoregionalization):
+        assert t.shape == (Datum.L, Datum.M, Datum.M)
     else:
-        assert t.shape == (2, 10, 10)
+        assert t.shape == (Datum.P, Datum.M, Datum.M)
 
 
-@pytest.mark.parametrize("inducing_variable", multioutput_inducing_variable_list)
-@pytest.mark.parametrize("kernel", multioutput_kernel_list)
-def test_kuf_shape(inducing_variable: InducingVariables, kernel: Kernel) -> None:
+@pytest.mark.parametrize(
+    "inducing_variable_P,inducing_variable_L", multioutput_inducing_variable_list, ids=type_name
+)
+@pytest.mark.parametrize("kernel", multioutput_kernel_list, ids=type_name)
+def test_kuf_shape(
+    inducing_variable_P: InducingVariables, inducing_variable_L: InducingVariables, kernel: Kernel
+) -> None:
+    if isinstance(kernel, mk.LinearCoregionalization):
+        inducing_variable = inducing_variable_L
+    else:
+        inducing_variable = inducing_variable_P
+
     Kuf = covariances.Kuf(inducing_variable, kernel, Datum.Xnew)
 
     if isinstance(kernel, mk.SharedIndependent):
         if isinstance(inducing_variable, mf.SeparateIndependentInducingVariables):
-            assert Kuf.shape == (3, 10, 100)
+            assert Kuf.shape == (Datum.P, Datum.M, Datum.N)
         else:
-            assert Kuf.shape == (10, 100)
+            assert Kuf.shape == (Datum.M, Datum.N)
+    elif isinstance(kernel, mk.LinearCoregionalization):
+        assert Kuf.shape == (Datum.L, Datum.M, Datum.N)
     else:
-        assert Kuf.shape == (2, 10, 100)
+        assert Kuf.shape == (Datum.P, Datum.M, Datum.N)
 
 
-@pytest.mark.parametrize("inducing_variable", multioutput_fallback_inducing_variable_list)
+@pytest.mark.parametrize(
+    "inducing_variable", multioutput_fallback_inducing_variable_list, ids=type_name
+)
 def test_kuf_fallback_shared_inducing_variables_shape(inducing_variable: InducingVariables) -> None:
     kernel = mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W)
     Kuf = covariances.Kuf(inducing_variable, kernel, Datum.Xnew)
 
-    assert Kuf.shape == (10, 2, 100, 3)
+    assert Kuf.shape == (Datum.M, Datum.L, Datum.N, Datum.P)
 
 
-@pytest.mark.parametrize("fun", [covariances.Kuu, covariances.Kuf])
+@pytest.mark.parametrize("fun", [covariances.Kuu, covariances.Kuf], ids=type_name)
 def test_mixed_shared_shape(fun: Callable[..., tf.Tensor]) -> None:
     inducing_variable = mf.SharedIndependentInducingVariables(make_ip())
     kernel = mk.LinearCoregionalization(make_kernels(Datum.L), Datum.W)
     if fun is covariances.Kuu:
         t = tf.linalg.cholesky(fun(inducing_variable, kernel, jitter=1e-9))
-        assert t.shape == (2, 10, 10)
+        assert t.shape == (Datum.L, Datum.M, Datum.M)
     else:
         t = fun(inducing_variable, kernel, Datum.Xnew)
-        assert t.shape == (2, 10, 100)
+        assert t.shape == (Datum.L, Datum.M, Datum.N)


### PR DESCRIPTION
Add shape checks to covariances.

This involves significant changes to `tests/gpflow/covariances/test_multioutput.py`, because it was actually using inconsistent shapes.

Partial: #1241 