### PR TITLE
Support TensorFlow 2.9.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,13 @@ parameters:
     default: "2.4"
   max_tf_ver:
     type: string
-    default: "2.8"
+    default: "2.9"
   min_tfp_ver:
     type: string
     default: "0.12"
   max_tfp_ver:
     type: string
-    default: "0.16"
+    default: "0.17"
 
 commands:
   setup_venv:

--- a/tests/gpflow/experimental/check_shapes/test_integration.py
+++ b/tests/gpflow/experimental/check_shapes/test_integration.py
@@ -21,6 +21,7 @@ from typing import Any, Callable
 import numpy as np
 import pytest
 import tensorflow as tf
+from packaging.version import Version
 
 from gpflow.base import AnyNDArray
 from gpflow.experimental.check_shapes import check_shape as cs
@@ -138,7 +139,8 @@ _Loss = Callable[[], tf.Tensor]
             tf.function(input_signature=[]),
         ),
         (
-            tf.function(experimental_relax_shapes=True),
+            # See: https://github.com/tensorflow/tensorflow/issues/56414
+            tf.function(experimental_relax_shapes=Version(tf.__version__) < Version("2.9.0")),
             tf.function(experimental_relax_shapes=True),
         ),
     ],


### PR DESCRIPTION
Start testing with the new TensorFlow 2.9.
Fixes: #1891 