### PR TITLE
Micro optimisations of check_shapes.

### DIFF
--- a/gpflow/experimental/check_shapes/__init__.py
+++ b/gpflow/experimental/check_shapes/__init__.py
@@ -465,8 +465,10 @@ from .config import (
     DocstringFormat,
     disable_check_shapes,
     get_enable_check_shapes,
+    get_enable_function_call_precompute,
     get_rewrite_docstrings,
     set_enable_check_shapes,
+    set_enable_function_call_precompute,
     set_rewrite_docstrings,
 )
 from .decorator import check_shapes
@@ -495,6 +497,7 @@ __all__ = [
     "exceptions",
     "get_check_shapes",
     "get_enable_check_shapes",
+    "get_enable_function_call_precompute",
     "get_rewrite_docstrings",
     "get_shape",
     "get_shape_checker",
@@ -502,6 +505,7 @@ __all__ = [
     "inheritance",
     "parser",
     "set_enable_check_shapes",
+    "set_enable_function_call_precompute",
     "set_rewrite_docstrings",
     "shapes",
     "specs",

--- a/gpflow/experimental/check_shapes/config.py
+++ b/gpflow/experimental/check_shapes/config.py
@@ -19,6 +19,7 @@ from enum import Enum
 from typing import Iterator, Union
 
 _enabled = True
+_function_call_precompute_enabled = False
 
 
 class DocstringFormat(Enum):
@@ -108,3 +109,28 @@ def get_rewrite_docstrings() -> DocstringFormat:
     Get how :mod:`check_shapes` should rewrite docstrings.
     """
     return _docstring_format
+
+
+def set_enable_function_call_precompute(enabled: bool) -> None:
+    """
+    Set whether to precompute function call path and line numbers for debugging.
+
+    This is disabled by default, because it is (relatively) slow. Enabling this can give better
+    error messages.
+
+    Example:
+
+    .. literalinclude:: /examples/test_check_shapes_examples.py
+       :start-after: [disable_function_call_precompute]
+       :end-before: [disable_function_call_precompute]
+       :dedent:
+    """
+    global _function_call_precompute_enabled
+    _function_call_precompute_enabled = enabled
+
+
+def get_enable_function_call_precompute() -> bool:
+    """
+    Get whether to precompute function call path and line numbers for debugging.
+    """
+    return _function_call_precompute_enabled

--- a/gpflow/experimental/check_shapes/error_contexts.py
+++ b/gpflow/experimental/check_shapes/error_contexts.py
@@ -48,6 +48,7 @@ from typing import (
 from lark.exceptions import UnexpectedCharacters, UnexpectedEOF, UnexpectedInput
 
 from .base_types import Shape
+from .config import get_enable_function_call_precompute
 
 if TYPE_CHECKING:  # pragma: no cover
     from .argument_ref import ArgumentRef
@@ -56,7 +57,12 @@ if TYPE_CHECKING:  # pragma: no cover
 
 _UNKNOWN_FILE = "<Unknown file>"
 _UNKNOWN_LINE = "<Unknown line>"
-_NONE_SHAPE = "<Tensor has unknown shape>"
+_DISABLED_FILE_AND_LINE = (
+    f"{_UNKNOWN_FILE}:{_UNKNOWN_LINE}"
+    " (Disabled. Call gpflow.experimental.check_shapes.set_enable_function_call_precompute(True) to"
+    " see this. (Slow.))"
+)
+_NONE_SHAPE = "<Tensor is None or has unknown shape>"
 
 _NO_VALUE = object()
 """
@@ -300,7 +306,10 @@ class FunctionCallContext(ErrorContext):
 
         :returns: A new instance with precomptued values.
         """
-        return FunctionCallContext(self.func, self._compute())
+        if get_enable_function_call_precompute():
+            return FunctionCallContext(self.func, self._compute())
+        else:
+            return FunctionCallContext(self.func, _DISABLED_FILE_AND_LINE)
 
 
 @dataclass(frozen=True)

--- a/tests/examples/test_check_shapes_examples.py
+++ b/tests/examples/test_check_shapes_examples.py
@@ -62,10 +62,13 @@ from gpflow.experimental.check_shapes import (
     check_shapes,
     disable_check_shapes,
     get_check_shapes,
+    get_enable_check_shapes,
+    get_enable_function_call_precompute,
     get_rewrite_docstrings,
     get_shape,
     inherit_check_shapes,
     set_enable_check_shapes,
+    set_enable_function_call_precompute,
     set_rewrite_docstrings,
 )
 
@@ -680,6 +683,8 @@ def test_example__disable__manual() -> None:
     def performance_sensitive_function() -> None:
         pass
 
+    old_value = get_enable_check_shapes()
+
     try:
 
         # [disable__manual]
@@ -691,7 +696,27 @@ def test_example__disable__manual() -> None:
         # [disable__manual]
 
     finally:
-        set_enable_check_shapes(True)
+        set_enable_check_shapes(old_value)
+
+
+def test_example__disable_function_call_precompute() -> None:
+    def buggy_function() -> None:
+        pass
+
+    old_value = get_enable_function_call_precompute()
+
+    try:
+
+        # [disable_function_call_precompute]
+
+        set_enable_function_call_precompute(True)
+
+        buggy_function()
+
+        # [disable_function_call_precompute]
+
+    finally:
+        set_enable_function_call_precompute(old_value)
 
 
 def test_example__doc_rewrite() -> None:

--- a/tests/gpflow/experimental/check_shapes/conftest.py
+++ b/tests/gpflow/experimental/check_shapes/conftest.py
@@ -18,8 +18,10 @@ import pytest
 from gpflow.experimental.check_shapes.config import (
     DocstringFormat,
     get_enable_check_shapes,
+    get_enable_function_call_precompute,
     get_rewrite_docstrings,
     set_enable_check_shapes,
+    set_enable_function_call_precompute,
     set_rewrite_docstrings,
 )
 
@@ -31,8 +33,11 @@ def reset_settings() -> Iterable[None]:
     # 2: If a test manipulates `check_shapes` settings, they are reset after the test.
     old_enable = get_enable_check_shapes()
     old_rewrite_docstrings = get_rewrite_docstrings()
+    old_function_call_precompute = get_enable_function_call_precompute()
     set_enable_check_shapes(True)
     set_rewrite_docstrings(DocstringFormat.SPHINX)
+    set_enable_function_call_precompute(True)
     yield
+    set_enable_function_call_precompute(old_function_call_precompute)
     set_rewrite_docstrings(old_rewrite_docstrings)
     set_enable_check_shapes(old_enable)

--- a/tests/gpflow/experimental/check_shapes/test_config.py
+++ b/tests/gpflow/experimental/check_shapes/test_config.py
@@ -17,8 +17,10 @@ from gpflow.experimental.check_shapes.config import (
     DocstringFormat,
     disable_check_shapes,
     get_enable_check_shapes,
+    get_enable_function_call_precompute,
     get_rewrite_docstrings,
     set_enable_check_shapes,
+    set_enable_function_call_precompute,
     set_rewrite_docstrings,
 )
 
@@ -62,3 +64,11 @@ def test_get_set_rewrite_docstrings() -> None:
     assert DocstringFormat.SPHINX == get_rewrite_docstrings()
     set_rewrite_docstrings(DocstringFormat.NONE)
     assert DocstringFormat.NONE == get_rewrite_docstrings()
+
+
+def test_get_set_enable_function_call_precompute() -> None:
+    assert get_enable_function_call_precompute()
+    set_enable_function_call_precompute(False)
+    assert not get_enable_function_call_precompute()
+    set_enable_function_call_precompute(True)
+    assert get_enable_function_call_precompute()


### PR DESCRIPTION
A couple of optimisations to `check_shapes` after looking at it through a profiler:

1. It turns out we were spending a lot of time computing hashes. Instead of having many dicts, each containing some information for each variable, we create a `_VariableState` structure, and have a single dict. This allows us to reduce many dict look-ups to a single call. (And is arguably more readable anyway...) In the process of this `_check_variable_use` got merged into `_parse_checks`.
2. Have a config option for whether to pre-compute file and line numbers for error-messages, defaulting to `False`, since this is particularly slow.

Together these seem to reduce the overhead of `check_shapes` by about 40%, which isn't as much as I'd like, but is better than nothing.
