### PR TITLE
Stop using singledispatch because TensorFlow cannot compile it.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -139,6 +139,8 @@ disable=missing-docstring,
         duplicate-code,
         too-many-public-methods,
         wrong-import-position,
+        unidiomatic-typecheck,
+        unused-argument,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,6 +40,8 @@ This release contains contributions from:
 ## Breaking Changes
 
 * Change to `InducingVariables` API. `InducingVariables` must now have a `shape` property.
+* `gpflow.experimental.check_shapes.get_shape.register` has been replaced with
+  `gpflow.experimental.check_shapes.register_get_shape`.
 
 ## Known Caveats
 
@@ -51,6 +53,8 @@ This release contains contributions from:
 * `gpflow.experimental.check_shapes`
   - Can now be in three different states - ENABLED, EAGER_MODE_ONLY, and DISABLE.
   - Now support multiple variable-rank dimensions at the same time, e.g. `cov: [n..., n...]`.
+  - Now uses custom function `register_get_shape` instead of `get_shape.register`, for better
+    compatibility with TensorFlow.
 
 ## Bug Fixes and Other Changes
 

--- a/gpflow/experimental/check_shapes/__init__.py
+++ b/gpflow/experimental/check_shapes/__init__.py
@@ -450,18 +450,19 @@ Supported types
 This library has built-in support for checking the shapes of:
 
 * Python built-in scalars: ``bool``, ``int``, ``float`` and ``str``.
-* Python sequences: :class:`collections.abc.Sequences`, including ``tuple`` and ``list``.
+* Python built-in sequences: ``tuple`` and ``list``.
 * NumPy ``ndarray``\ s.
 * TensorFlow ``Tensor``\ s and ``Variable``\ s.
-* TensorFlow Probability ``DeferredTensor``\ s.
+* TensorFlow Probability ``DeferredTensor``\ s, including ``TransformedVariable`` and
+  :class:`gpflow.Parameter`.
 
 
 Shapes of custom types
 ----------------------
 
 :mod:`check_shapes` uses the function :func:`get_shape` to extract the shape of an object.
-:func:`get_shape` uses :func:`functools.singledispatch` to branch on the type of object to get the
-shape from, and you can extend this to extract shapes for you own custom types:
+You can use :func:`register_get_shape` to extend :func:`get_shape` to extract shapes for you own
+custom types:
 
 .. literalinclude:: /examples/test_check_shapes_examples.py
    :start-after: [custom_type]
@@ -487,7 +488,7 @@ from .config import (
 from .decorator import check_shapes
 from .error_contexts import ErrorContext
 from .inheritance import inherit_check_shapes
-from .shapes import get_shape
+from .shapes import get_shape, register_get_shape
 
 __all__ = [
     "Dimension",
@@ -518,6 +519,7 @@ __all__ = [
     "inherit_check_shapes",
     "inheritance",
     "parser",
+    "register_get_shape",
     "set_enable_check_shapes",
     "set_enable_function_call_precompute",
     "set_rewrite_docstrings",

--- a/gpflow/inducing_variables/inducing_variables.py
+++ b/gpflow/inducing_variables/inducing_variables.py
@@ -20,7 +20,7 @@ import tensorflow_probability as tfp
 from deprecated import deprecated
 
 from ..base import Module, Parameter, TensorData, TensorType
-from ..experimental.check_shapes import ErrorContext, Shape, check_shapes, get_shape
+from ..experimental.check_shapes import ErrorContext, Shape, check_shapes, register_get_shape
 from ..utilities import positive
 
 
@@ -60,7 +60,7 @@ class InducingVariables(Module, abc.ABC):
         """
 
 
-@get_shape.register(InducingVariables)
+@register_get_shape(InducingVariables)
 def get_scalar_shape(shaped: InducingVariables, context: ErrorContext) -> Shape:
     return shaped.shape
 

--- a/tests/examples/test_check_shapes_examples.py
+++ b/tests/examples/test_check_shapes_examples.py
@@ -69,6 +69,7 @@ from gpflow.experimental.check_shapes import (
     get_rewrite_docstrings,
     get_shape,
     inherit_check_shapes,
+    register_get_shape,
     set_enable_check_shapes,
     set_enable_function_call_precompute,
     set_rewrite_docstrings,
@@ -815,7 +816,7 @@ def test_example__custom_type() -> None:
             prediction: AnyNDArray = np.einsum("...i,i -> ...", features, self._weights)
             return prediction
 
-    @get_shape.register(LinearModel)
+    @register_get_shape(LinearModel)
     def get_linear_model_shape(model: LinearModel, context: ErrorContext) -> Shape:
         shape: Shape = model._weights.shape
         return shape

--- a/tests/gpflow/experimental/check_shapes/test_error_contexts.py
+++ b/tests/gpflow/experimental/check_shapes/test_error_contexts.py
@@ -54,9 +54,9 @@ def to_str(context: ErrorContext) -> str:
 
 def check_eq(context: ErrorContext) -> None:
     # Sanity checking of __eq__ and __hash__
-    assert context == context
+    assert context == context  # pylint: disable=comparison-with-itself
     assert context != TestContext()
-    assert context != None
+    assert context != None  # pylint: disable=singleton-comparison
     assert context in {context}
 
 

--- a/tests/gpflow/experimental/check_shapes/utils.py
+++ b/tests/gpflow/experimental/check_shapes/utils.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Union
 
-from gpflow.experimental.check_shapes import Dimension, Shape, get_shape
+from gpflow.experimental.check_shapes import Dimension, Shape, register_get_shape
 from gpflow.experimental.check_shapes.argument_ref import (
     AllElementsRef,
     ArgumentRef,
@@ -62,7 +62,7 @@ class TestShaped:
     test_shape: Shape
 
 
-@get_shape.register(TestShaped)
+@register_get_shape(TestShaped)
 def get_test_shaped_shape(shaped: TestShaped, context: ErrorContext) -> Shape:
     return shaped.test_shape
 


### PR DESCRIPTION
Basically the interaction of TensorFlow and `@singledispatch` is super flaky, so I'm removing `@singledispatch` from `check_shapes`.