### PR TITLE
Consistently raise errors where full_output_cov isn't supported.

### DIFF
--- a/gpflow/models/cglb.py
+++ b/gpflow/models/cglb.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 from ..base import InputData, MeanAndVariance, Parameter, RegressionData, TensorType
 from ..config import default_float, default_int
 from ..covariances import Kuf
-from ..utilities import add_noise_cov, to_default_float
+from ..utilities import add_noise_cov, assert_params_false, to_default_float
 from .sgpr import SGPR
 
 
@@ -181,6 +181,8 @@ class CGLB(SGPR):
         :param cg_tolerance: float or None: If None, the cached value of
             :math:`v` is used. If float, conjugate gradient is run until :math:`rᵀQ⁻¹r < ϵ`.
         """
+        assert_params_false(self.predict_f, full_output_cov=full_output_cov)
+
         x, y = self.data
         err = y - self.mean_function(x)
         kxx = self.kernel(x, x)
@@ -250,12 +252,7 @@ class CGLB(SGPR):
         Compute the mean and variance of the held-out data at the
         input points.
         """
-        if full_cov or full_output_cov:
-            # See https://github.com/GPflow/GPflow/issues/1461
-            raise NotImplementedError(
-                "The predict_y method currently supports only the argument values full_cov=False"
-                " and full_output_cov=False"
-            )
+        assert_params_false(self.predict_y, full_cov=full_cov, full_output_cov=full_output_cov)
 
         f_mean, f_var = self.predict_f(
             xnew, full_cov=full_cov, full_output_cov=full_output_cov, cg_tolerance=cg_tolerance
@@ -272,11 +269,9 @@ class CGLB(SGPR):
         """
         Compute the log density of the data at the new data points.
         """
-        if full_cov or full_output_cov:
-            raise NotImplementedError(
-                "The predict_log_density method currently supports only the argument values"
-                " full_cov=False and full_output_cov=False"
-            )
+        assert_params_false(
+            self.predict_log_density, full_cov=full_cov, full_output_cov=full_output_cov
+        )
 
         x, y = data
         f_mean, f_var = self.predict_f(

--- a/gpflow/models/gplvm.py
+++ b/gpflow/models/gplvm.py
@@ -25,7 +25,7 @@ from ..inducing_variables import InducingPoints
 from ..kernels import Kernel
 from ..mean_functions import MeanFunction, Zero
 from ..probability_distributions import DiagonalGaussian
-from ..utilities import positive, to_default_float
+from ..utilities import assert_params_false, positive, to_default_float
 from ..utilities.ops import pca_reduce
 from .gpr import GPR
 from .model import GPModel
@@ -221,8 +221,7 @@ class BayesianGPLVM(GPModel, InternalDataTrainingLossMixin):
 
         :param Xnew: points at which to predict
         """
-        if full_output_cov:
-            raise NotImplementedError
+        assert_params_false(self.predict_f, full_output_cov=full_output_cov)
 
         pX = DiagonalGaussian(self.X_data_mean, self.X_data_var)
 

--- a/gpflow/models/gpmc.py
+++ b/gpflow/models/gpmc.py
@@ -24,7 +24,7 @@ from ..config import default_float, default_jitter
 from ..kernels import Kernel
 from ..likelihoods import Likelihood
 from ..mean_functions import MeanFunction
-from ..utilities import to_default_float
+from ..utilities import assert_params_false, to_default_float
 from .model import GPModel
 from .training_mixins import InternalDataTrainingLossMixin
 from .util import data_input_to_tensor
@@ -107,6 +107,8 @@ class GPMC(GPModel, InternalDataTrainingLossMixin):
         where F* are points on the GP at Xnew, F=LV are points on the GP at X.
 
         """
+        assert_params_false(self.predict_f, full_output_cov=full_output_cov)
+
         X_data, _Y_data = self.data
         mu, var = conditional(
             Xnew, X_data, self.kernel, self.V, full_cov=full_cov, q_sqrt=None, white=True

--- a/gpflow/models/gpr.py
+++ b/gpflow/models/gpr.py
@@ -23,7 +23,7 @@ from ..base import InputData, MeanAndVariance, RegressionData
 from ..kernels import Kernel
 from ..logdensities import multivariate_normal
 from ..mean_functions import MeanFunction
-from ..utilities.model_utils import add_noise_cov
+from ..utilities import add_noise_cov, assert_params_false
 from .model import GPModel
 from .training_mixins import InternalDataTrainingLossMixin
 from .util import data_input_to_tensor
@@ -105,6 +105,8 @@ class GPR_deprecated(GPModel, InternalDataTrainingLossMixin):
         where F* are points on the GP at new data points, Y are noisy observations at training data
         points.
         """
+        assert_params_false(self.predict_f, full_output_cov=full_output_cov)
+
         X, Y = self.data
         err = Y - self.mean_function(X)
 

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -22,7 +22,7 @@ from ..conditionals.util import sample_mvn
 from ..kernels import Kernel, MultioutputKernel
 from ..likelihoods import Likelihood, SwitchedLikelihood
 from ..mean_functions import MeanFunction, Zero
-from ..utilities import to_default_float
+from ..utilities import assert_params_false, to_default_float
 
 
 class BayesianModel(Module, metaclass=abc.ABCMeta):
@@ -210,12 +210,8 @@ class GPModel(BayesianModel):
         """
         Compute the mean and variance of the held-out data at the input points.
         """
-        if full_cov or full_output_cov:
-            # See https://github.com/GPflow/GPflow/issues/1461
-            raise NotImplementedError(
-                "The predict_y method currently supports only the argument values full_cov=False"
-                " and full_output_cov=False"
-            )
+        # See https://github.com/GPflow/GPflow/issues/1461
+        assert_params_false(self.predict_y, full_cov=full_cov, full_output_cov=full_output_cov)
 
         f_mean, f_var = self.predict_f(Xnew, full_cov=full_cov, full_output_cov=full_output_cov)
         return self.likelihood.predict_mean_and_var(f_mean, f_var)
@@ -226,12 +222,8 @@ class GPModel(BayesianModel):
         """
         Compute the log density of the data at the new data points.
         """
-        if full_cov or full_output_cov:
-            # See https://github.com/GPflow/GPflow/issues/1461
-            raise NotImplementedError(
-                "The predict_log_density method currently supports only the argument values"
-                " full_cov=False and full_output_cov=False"
-            )
+        # See https://github.com/GPflow/GPflow/issues/1461
+        assert_params_false(self.predict_y, full_cov=full_cov, full_output_cov=full_output_cov)
 
         X, Y = data
         f_mean, f_var = self.predict_f(X, full_cov=full_cov, full_output_cov=full_output_cov)

--- a/gpflow/models/sgpr.py
+++ b/gpflow/models/sgpr.py
@@ -25,7 +25,7 @@ from ..covariances.dispatch import Kuf, Kuu
 from ..inducing_variables import InducingPoints
 from ..kernels import Kernel
 from ..mean_functions import MeanFunction
-from ..utilities import add_noise_cov, to_default_float
+from ..utilities import add_noise_cov, assert_params_false, to_default_float
 from .model import GPModel
 from .training_mixins import InternalDataTrainingLossMixin
 from .util import InducingPointsLike, data_input_to_tensor, inducingpoint_wrapper
@@ -235,13 +235,15 @@ class SGPR_deprecated(SGPRBase_deprecated):
     def predict_f(
         self, Xnew: InputData, full_cov: bool = False, full_output_cov: bool = False
     ) -> MeanAndVariance:
-
-        # could copy into posterior into a fused version
         """
         Compute the mean and variance of the latent function at some new points
         Xnew. For a derivation of the terms in here, see the associated SGPR
         notebook.
         """
+        # could copy into posterior into a fused version
+
+        assert_params_false(self.predict_f, full_output_cov=full_output_cov)
+
         X_data, Y_data = self.data
         num_inducing = self.inducing_variable.num_inducing
         err = Y_data - self.mean_function(X_data)
@@ -409,6 +411,8 @@ class GPRFITC(SGPRBase_deprecated):
         Compute the mean and variance of the latent function at some new points
         Xnew.
         """
+        assert_params_false(self.predict_f, full_output_cov=full_output_cov)
+
         _, _, Luu, L, _, _, gamma = self.common_terms()
         Kus = Kuf(self.inducing_variable, self.kernel, Xnew)  # [M, N]
 

--- a/gpflow/models/vgp.py
+++ b/gpflow/models/vgp.py
@@ -27,7 +27,7 @@ from ..kernels import Kernel
 from ..kullback_leiblers import gauss_kl
 from ..likelihoods import Likelihood
 from ..mean_functions import MeanFunction
-from ..utilities import is_variable, triangular, triangular_size
+from ..utilities import assert_params_false, is_variable, triangular, triangular_size
 from .model import GPModel
 from .training_mixins import InternalDataTrainingLossMixin
 from .util import data_input_to_tensor
@@ -134,6 +134,8 @@ class VGP_deprecated(GPModel, InternalDataTrainingLossMixin):
     def predict_f(
         self, Xnew: InputData, full_cov: bool = False, full_output_cov: bool = False
     ) -> MeanAndVariance:
+        assert_params_false(self.predict_f, full_output_cov=full_output_cov)
+
         X_data, _Y_data = self.data
         mu, var = conditional(
             Xnew,
@@ -368,8 +370,7 @@ class VGPOpperArchambeau(GPModel, InternalDataTrainingLossMixin):
 
         Note: This model currently does not allow full output covariances
         """
-        if full_output_cov:
-            raise NotImplementedError
+        assert_params_false(self.predict_f, full_output_cov=full_output_cov)
 
         X_data, _ = self.data
         # compute kernel things

--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -42,7 +42,7 @@ from .inducing_variables import (
 )
 from .kernels import Kernel
 from .mean_functions import MeanFunction
-from .utilities import Dispatcher, add_noise_cov
+from .utilities import Dispatcher, add_noise_cov, assert_params_false
 from .utilities.ops import eye, leading_transpose
 
 
@@ -318,6 +318,8 @@ class GPRPosterior(AbstractPosterior):
         Computes predictive mean and (co)variance at Xnew, *excluding* mean_function.
         Relies on cached alpha and Qinv.
         """
+        assert_params_false(self._conditional_with_precompute, full_output_cov=full_output_cov)
+
         (alpha,) = cache
         (Qinv,) = cache
 
@@ -388,6 +390,7 @@ class GPRPosterior(AbstractPosterior):
         Computes predictive mean and (co)variance at Xnew, *excluding* mean_function
         Does not make use of caching
         """
+        assert_params_false(self._conditional_fused, full_output_cov=full_output_cov)
 
         # taken directly from the deprecated GPR implementation
         assert self.mean_function is not None
@@ -471,6 +474,8 @@ class SGPRPosterior(AbstractPosterior):
         Computes predictive mean and (co)variance at Xnew, *excluding* mean_function.
         Relies on cached alpha and Qinv.
         """
+        assert_params_false(self._conditional_with_precompute, full_output_cov=full_output_cov)
+
         alpha, Qinv = cache
 
         Kus = Kuf(self.inducing_variable, self.kernel, Xnew)
@@ -496,6 +501,7 @@ class SGPRPosterior(AbstractPosterior):
         Compute the mean and variance of the latent function at some new points
         Xnew. Does not make use of caching
         """
+        assert_params_false(self._conditional_fused, full_output_cov=full_output_cov)
 
         # taken directly from the deprecated SGPR implementation
         num_inducing = self.inducing_variable.num_inducing
@@ -561,6 +567,8 @@ class VGPPosterior(AbstractPosterior):
         full_cov: bool = False,
         full_output_cov: bool = False,
     ) -> MeanAndVariance:
+        assert_params_false(self._conditional_with_precompute, full_output_cov=full_output_cov)
+
         (Lm,) = cache
         Kmn = self.kernel(self.X_data, Xnew)  # [M, ..., N]
         Knn = self.kernel(

--- a/gpflow/utilities/__init__.py
+++ b/gpflow/utilities/__init__.py
@@ -1,6 +1,6 @@
 from .bijectors import positive, triangular, triangular_size
 from .misc import is_variable, set_trainable, to_default_float, to_default_int, training_loop
-from .model_utils import add_noise_cov
+from .model_utils import add_noise_cov, assert_params_false
 from .multipledispatch import Dispatcher
 from .traversal import (
     deepcopy,
@@ -19,6 +19,7 @@ from .traversal import (
 __all__ = [
     "Dispatcher",
     "add_noise_cov",
+    "assert_params_false",
     "bijectors",
     "deepcopy",
     "freeze",

--- a/gpflow/utilities/model_utils.py
+++ b/gpflow/utilities/model_utils.py
@@ -1,7 +1,27 @@
+from typing import Any, Callable
+
 import tensorflow as tf
 
 from ..base import TensorType
 from ..experimental.check_shapes import check_shapes
+
+
+def assert_params_false(
+    called_method: Callable[..., Any],
+    **kwargs: bool,
+) -> None:
+    """
+    Asserts that parameters are ``False``.
+
+    :param called_method: The method or function that is calling this. Used for nice error messages.
+    :param kwargs: Parameters that must be ``False``.
+    :raises NotImplementedError: If any ``kwargs`` are ``True``.
+    """
+    errors_str = ", ".join(f"{param}={value}" for param, value in kwargs.items() if value)
+    if errors_str:
+        raise NotImplementedError(
+            f"{called_method.__qualname__} does not currently support: {errors_str}"
+        )
 
 
 @check_shapes(

--- a/tests/gpflow/models/test_gpr_posterior.py
+++ b/tests/gpflow/models/test_gpr_posterior.py
@@ -30,7 +30,7 @@ def _get_data_for_tests() -> Tuple[AnyNDArray, AnyNDArray, AnyNDArray]:
 
 
 @pytest.mark.parametrize("full_cov", [True, False])
-@pytest.mark.parametrize("full_output_cov", [True, False])
+@pytest.mark.parametrize("full_output_cov", [False])
 def test_old_vs_new_gp_fused(full_cov: bool, full_output_cov: bool) -> None:
     X, X_new, Y = _get_data_for_tests()
     mold, mnew = make_models((X, Y))
@@ -46,7 +46,7 @@ def test_old_vs_new_gp_fused(full_cov: bool, full_output_cov: bool) -> None:
 
 @pytest.mark.parametrize("cache_type", [PrecomputeCacheType.TENSOR, PrecomputeCacheType.VARIABLE])
 @pytest.mark.parametrize("full_cov", [True, False])
-@pytest.mark.parametrize("full_output_cov", [True, False])
+@pytest.mark.parametrize("full_output_cov", [False])
 def test_old_vs_new_with_posterior(
     cache_type: PrecomputeCacheType, full_cov: bool, full_output_cov: bool
 ) -> None:

--- a/tests/gpflow/models/test_sgpr_posterior.py
+++ b/tests/gpflow/models/test_sgpr_posterior.py
@@ -59,7 +59,7 @@ def sgpr_model(dummy_data: Tuple[InputData, InputData, OutputData]) -> SGPR:
 
 
 @pytest.mark.parametrize("full_cov", [True, False])
-@pytest.mark.parametrize("full_output_cov", [True, False])
+@pytest.mark.parametrize("full_output_cov", [False])
 def test_old_vs_new_gp_fused(
     sgpr_deprecated_model: SGPR_deprecated,
     sgpr_model: SGPR,
@@ -84,7 +84,7 @@ def test_old_vs_new_gp_fused(
 # TODO: move to common test_model_utils
 @pytest.mark.parametrize("cache_type", [PrecomputeCacheType.TENSOR, PrecomputeCacheType.VARIABLE])
 @pytest.mark.parametrize("full_cov", [True, False])
-@pytest.mark.parametrize("full_output_cov", [True, False])
+@pytest.mark.parametrize("full_output_cov", [False])
 def test_old_vs_new_with_posterior(
     sgpr_deprecated_model: SGPR_deprecated,
     sgpr_model: SGPR,

--- a/tests/gpflow/models/test_vgp_posterior.py
+++ b/tests/gpflow/models/test_vgp_posterior.py
@@ -34,7 +34,7 @@ def _get_data_for_tests() -> Tuple[AnyNDArray, AnyNDArray, AnyNDArray]:
     "likelihood", [gpflow.likelihoods.Gaussian(), gpflow.likelihoods.Exponential()]
 )
 @pytest.mark.parametrize("full_cov", [True, False])
-@pytest.mark.parametrize("full_output_cov", [True, False])
+@pytest.mark.parametrize("full_output_cov", [False])
 def test_old_vs_new_gp_fused(
     likelihood: gpflow.likelihoods.Likelihood,
     full_cov: bool,
@@ -57,7 +57,7 @@ def test_old_vs_new_gp_fused(
     "likelihood", [gpflow.likelihoods.Gaussian(), gpflow.likelihoods.Exponential()]
 )
 @pytest.mark.parametrize("full_cov", [True, False])
-@pytest.mark.parametrize("full_output_cov", [True, False])
+@pytest.mark.parametrize("full_output_cov", [False])
 def test_old_vs_new_with_posterior(
     cache_type: PrecomputeCacheType,
     likelihood: gpflow.likelihoods.Likelihood,

--- a/tests/gpflow/utilities/test_model_utils.py
+++ b/tests/gpflow/utilities/test_model_utils.py
@@ -3,7 +3,16 @@ import tensorflow as tf
 
 import gpflow
 from gpflow.base import TensorType
-from gpflow.utilities import add_noise_cov
+from gpflow.utilities import add_noise_cov, assert_params_false
+
+
+def test_assert_params_false__False() -> None:
+    assert_params_false(test_assert_params_false__False, foo=False, bar=False)
+
+
+def test_assert_params_false__True() -> None:
+    with pytest.raises(NotImplementedError):
+        assert_params_false(test_assert_params_false__True, foo=False, bar=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We have some methods that do not support `full_cov=True` and many that do not support `full_output_cov=True`. Right now some of those methods raise various error messages, but many also silently ignore the invalid argument.

With this PR we systematically raise the same error message in these cases.

