### PR TITLE
Add an X parameter to the Likelihood.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,6 +39,8 @@ This release contains contributions from:
 
 ## Breaking Changes
 
+* All likelihood methods now take an extra `X` argument. If you have written custom likelihoods or
+  you have custom code calling likelihoods directly you will need to add this extra argument.
 * Change to `InducingVariables` API. `InducingVariables` must now have a `shape` property.
 * `gpflow.experimental.check_shapes.get_shape.register` has been replaced with
   `gpflow.experimental.check_shapes.register_get_shape`.
@@ -50,6 +52,9 @@ This release contains contributions from:
 
 ## Major Features and Improvements
 
+* Improved handling of variable noise
+  - All likelihood methods now take an `X` argument, allowing you to easily implement
+    heteroscedastic likelihoods.
 * `gpflow.experimental.check_shapes`
   - Can now be in three different states - ENABLED, EAGER_MODE_ONLY, and DISABLE.
   - Now support multiple variable-rank dimensions at the same time, e.g. `cov: [n..., n...]`.

--- a/doc/sphinx/notebooks/advanced/varying_noise.pct.py
+++ b/doc/sphinx/notebooks/advanced/varying_noise.pct.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.4.0
+#       jupytext_version: 1.13.8
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -91,9 +91,9 @@ Y_data = np.hstack([Y, NoiseVar])
 class HeteroskedasticGaussian(gpflow.likelihoods.Likelihood):
     def __init__(self, **kwargs):
         # this likelihood expects a single latent function F, and two columns in the data matrix Y:
-        super().__init__(latent_dim=1, observation_dim=2, **kwargs)
+        super().__init__(input_dim=1, latent_dim=1, observation_dim=2, **kwargs)
 
-    def _log_prob(self, F, Y):
+    def _log_prob(self, X, F, Y):
         # log_prob is used by the quadrature fallback of variational_expectations and predict_log_density.
         # Because variational_expectations is implemented analytically below, this is not actually needed,
         # but is included for pedagogical purposes.
@@ -101,7 +101,7 @@ class HeteroskedasticGaussian(gpflow.likelihoods.Likelihood):
         Y, NoiseVar = Y[:, 0], Y[:, 1]
         return gpflow.logdensities.gaussian(Y, F, NoiseVar)
 
-    def _variational_expectations(self, Fmu, Fvar, Y):
+    def _variational_expectations(self, X, Fmu, Fvar, Y):
         Y, NoiseVar = Y[:, 0], Y[:, 1]
         Fmu, Fvar = Fmu[:, 0], Fvar[:, 0]
         return (
@@ -113,10 +113,10 @@ class HeteroskedasticGaussian(gpflow.likelihoods.Likelihood):
     # The following two methods are abstract in the base class.
     # They need to be implemented even if not used.
 
-    def _predict_log_density(self, Fmu, Fvar, Y):
+    def _predict_log_density(self, X, Fmu, Fvar, Y):
         raise NotImplementedError
 
-    def _predict_mean_and_var(self, Fmu, Fvar):
+    def _predict_mean_and_var(self, X, Fmu, Fvar):
         raise NotImplementedError
 
 

--- a/gpflow/likelihoods/base.py
+++ b/gpflow/likelihoods/base.py
@@ -27,8 +27,10 @@ explicitly passed to likelihood constructor.
 """
 
 
-class Likelihood(Module, metaclass=abc.ABCMeta):
-    def __init__(self, latent_dim: Optional[int], observation_dim: Optional[int]) -> None:
+class Likelihood(Module, abc.ABC):
+    def __init__(
+        self, input_dim: Optional[int], latent_dim: Optional[int], observation_dim: Optional[int]
+    ) -> None:
         """
         A base class for likelihoods, which specifies an observation model
         connecting the latent functions ('F') to the data ('Y').
@@ -44,40 +46,55 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
         The return shapes of all functions in this class is the broadcasted shape of the arguments,
         excluding the last dimension of each argument.
 
+        :param input_dim: the dimension of the input vector X for a single data point
         :param latent_dim: the dimension of the vector F of latent functions for a single data point
         :param observation_dim: the dimension of the observation vector Y for a single data point
         """
         super().__init__()
+        self.input_dim = input_dim
         self.latent_dim = latent_dim
         self.observation_dim = observation_dim
 
-    def _check_last_dims_valid(self, F: TensorType, Y: TensorType) -> None:
+    def _check_last_dims_valid(self, X: TensorType, F: TensorType, Y: TensorType) -> None:
         """
         Assert that the dimensions of the latent functions F and the data Y are compatible.
 
-        :param F: function evaluation Tensor, with shape [..., latent_dim]
-        :param Y: observation Tensor, with shape [..., observation_dim]
+        :param X: input tensor, with shape [..., input_dim]
+        :param F: function evaluation tensor, with shape [..., latent_dim]
+        :param Y: observation tensor, with shape [..., observation_dim]
         """
+        self._check_input_dims(X)
         self._check_latent_dims(F)
         self._check_data_dims(Y)
 
-    def _check_return_shape(self, result: TensorType, F: TensorType, Y: TensorType) -> None:
+    def _check_return_shape(
+        self, result: TensorType, X: TensorType, F: TensorType, Y: TensorType
+    ) -> None:
         """
         Check that the shape of a computed statistic of the data
         is the broadcasted shape from F and Y.
 
-        :param result: result Tensor, with shape [...]
-        :param F: function evaluation Tensor, with shape [..., latent_dim]
-        :param Y: observation Tensor, with shape [..., observation_dim]
+        :param result: result tensor, with shape [...]
+        :param X: input tensor, with shape [..., input_dim]
+        :param F: function evaluation tensor, with shape [..., latent_dim]
+        :param Y: observation tensor, with shape [..., observation_dim]
         """
         expected_shape = tf.broadcast_dynamic_shape(tf.shape(F)[:-1], tf.shape(Y)[:-1])
         tf.debugging.assert_equal(tf.shape(result), expected_shape)
+
+    def _check_input_dims(self, X: TensorType) -> None:
+        """
+        Ensure that a tensor of inputs X has input_dim as right-most dimension.
+
+        :param X: function evaluation tensor, with shape [..., input_dim]
+        """
+        tf.debugging.assert_shapes([(X, (..., self.input_dim))])
 
     def _check_latent_dims(self, F: TensorType) -> None:
         """
         Ensure that a tensor of latent functions F has latent_dim as right-most dimension.
 
-        :param F: function evaluation Tensor, with shape [..., latent_dim]
+        :param F: function evaluation tensor, with shape [..., latent_dim]
         """
         tf.debugging.assert_shapes([(F, (..., self.latent_dim))])
 
@@ -85,60 +102,68 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
         """
         Ensure that a tensor of data Y has observation_dim as right-most dimension.
 
-        :param Y: observation Tensor, with shape [..., observation_dim]
+        :param Y: observation tensor, with shape [..., observation_dim]
         """
         tf.debugging.assert_shapes([(Y, (..., self.observation_dim))])
 
-    def log_prob(self, F: TensorType, Y: TensorType) -> tf.Tensor:
+    def log_prob(self, X: TensorType, F: TensorType, Y: TensorType) -> tf.Tensor:
         """
-        The log probability density log p(Y|F)
+        The log probability density log p(Y|X,F)
 
-        :param F: function evaluation Tensor, with shape [..., latent_dim]
-        :param Y: observation Tensor, with shape [..., observation_dim]:
+        :param X: input tensor, with shape [..., input_dim]
+        :param F: function evaluation tensor, with shape [..., latent_dim]
+        :param Y: observation tensor, with shape [..., observation_dim]:
         :returns: log pdf, with shape [...]
         """
-        self._check_last_dims_valid(F, Y)
-        res = self._log_prob(F, Y)
-        self._check_return_shape(res, F, Y)
+        self._check_last_dims_valid(X, F, Y)
+        res = self._log_prob(X, F, Y)
+        self._check_return_shape(res, X, F, Y)
         return res
 
     @abc.abstractmethod
-    def _log_prob(self, F: TensorType, Y: TensorType) -> tf.Tensor:
+    def _log_prob(self, X: TensorType, F: TensorType, Y: TensorType) -> tf.Tensor:
         raise NotImplementedError
 
-    def conditional_mean(self, F: TensorType) -> tf.Tensor:
+    def conditional_mean(self, X: TensorType, F: TensorType) -> tf.Tensor:
         """
-        The conditional mean of Y|F: [E[Y₁|F], ..., E[Yₖ|F]]
+        The conditional mean of Y|X,F: [E[Y₁|X,F], ..., E[Yₖ|X,F]]
         where K = observation_dim
 
-        :param F: function evaluation Tensor, with shape [..., latent_dim]
+        :param X: input tensor, with shape [..., input_dim]
+        :param F: function evaluation tensor, with shape [..., latent_dim]
         :returns: mean [..., observation_dim]
         """
+        self._check_input_dims(X)
         self._check_latent_dims(F)
-        expected_Y = self._conditional_mean(F)
+        expected_Y = self._conditional_mean(X, F)
         self._check_data_dims(expected_Y)
         return expected_Y
 
-    def _conditional_mean(self, F: TensorType) -> tf.Tensor:
+    def _conditional_mean(self, X: TensorType, F: TensorType) -> tf.Tensor:
         raise NotImplementedError
 
-    def conditional_variance(self, F: TensorType) -> tf.Tensor:
+    def conditional_variance(self, X: TensorType, F: TensorType) -> tf.Tensor:
         """
-        The conditional marginal variance of Y|F: [var(Y₁|F), ..., var(Yₖ|F)]
+        The conditional marginal variance of Y|X,F: [var(Y₁|X,F), ..., var(Yₖ|X,F)]
         where K = observation_dim
 
-        :param F: function evaluation Tensor, with shape [..., latent_dim]
+        :param X: input tensor, with shape [..., input_dim]
+        :param F: function evaluation tensor, with shape [..., latent_dim]
         :returns: variance [..., observation_dim]
         """
-        self._check_latent_dims(F)
-        var_Y = self._conditional_variance(F)
+        self._check_input_dims(X)
+        if F is not None:
+            self._check_latent_dims(F)
+        var_Y = self._conditional_variance(X, F)
         self._check_data_dims(var_Y)
         return var_Y
 
-    def _conditional_variance(self, F: TensorType) -> tf.Tensor:
+    def _conditional_variance(self, X: TensorType, F: TensorType) -> tf.Tensor:
         raise NotImplementedError
 
-    def predict_mean_and_var(self, Fmu: TensorType, Fvar: TensorType) -> MeanAndVariance:
+    def predict_mean_and_var(
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType
+    ) -> MeanAndVariance:
         """
         Given a Normal distribution for the latent function,
         return the mean and marginal variance of Y,
@@ -159,22 +184,28 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
            ∫∫ y² p(y|f)q(f) df dy  - [ ∫∫ y p(y|f)q(f) df dy ]²
 
 
-        :param Fmu: mean function evaluation Tensor, with shape [..., latent_dim]
-        :param Fvar: variance of function evaluation Tensor, with shape [..., latent_dim]
+        :param X: input tensor, with shape [..., input_dim]
+        :param Fmu: mean function evaluation tensor, with shape [..., latent_dim]
+        :param Fvar: variance of function evaluation tensor, with shape [..., latent_dim]
         :returns: mean and variance, both with shape [..., observation_dim]
         """
+        self._check_input_dims(X)
         self._check_latent_dims(Fmu)
         self._check_latent_dims(Fvar)
-        mu, var = self._predict_mean_and_var(Fmu, Fvar)
+        mu, var = self._predict_mean_and_var(X, Fmu, Fvar)
         self._check_data_dims(mu)
         self._check_data_dims(var)
         return mu, var
 
     @abc.abstractmethod
-    def _predict_mean_and_var(self, Fmu: TensorType, Fvar: TensorType) -> MeanAndVariance:
+    def _predict_mean_and_var(
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType
+    ) -> MeanAndVariance:
         raise NotImplementedError
 
-    def predict_log_density(self, Fmu: TensorType, Fvar: TensorType, Y: TensorType) -> tf.Tensor:
+    def predict_log_density(
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+    ) -> tf.Tensor:
         r"""
         Given a Normal distribution for the latent function, and a datum Y,
         compute the log predictive density of Y,
@@ -190,23 +221,26 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
 
             log ∫ p(y=Y|F)q(F) df
 
-        :param Fmu: mean function evaluation Tensor, with shape [..., latent_dim]
-        :param Fvar: variance of function evaluation Tensor, with shape [..., latent_dim]
-        :param Y: observation Tensor, with shape [..., observation_dim]:
+        :param X: input tensor, with shape [..., input_dim]
+        :param Fmu: mean function evaluation tensor, with shape [..., latent_dim]
+        :param Fvar: variance of function evaluation tensor, with shape [..., latent_dim]
+        :param Y: observation tensor, with shape [..., observation_dim]:
         :returns: log predictive density, with shape [...]
         """
         tf.debugging.assert_equal(tf.shape(Fmu), tf.shape(Fvar))
-        self._check_last_dims_valid(Fmu, Y)
-        res = self._predict_log_density(Fmu, Fvar, Y)
-        self._check_return_shape(res, Fmu, Y)
+        self._check_last_dims_valid(X, Fmu, Y)
+        res = self._predict_log_density(X, Fmu, Fvar, Y)
+        self._check_return_shape(res, X, Fmu, Y)
         return res
 
     @abc.abstractmethod
-    def _predict_log_density(self, Fmu: TensorType, Fvar: TensorType, Y: TensorType) -> tf.Tensor:
+    def _predict_log_density(
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+    ) -> tf.Tensor:
         raise NotImplementedError
 
     def variational_expectations(
-        self, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
     ) -> tf.Tensor:
         r"""
         Compute the expected log density of the data, given a Gaussian
@@ -226,35 +260,41 @@ class Likelihood(Module, metaclass=abc.ABCMeta):
         This only works if the broadcasting dimension of the statistics of q(f) (mean and variance)
         are broadcastable with that of the data Y.
 
-        :param Fmu: mean function evaluation Tensor, with shape [..., latent_dim]
-        :param Fvar: variance of function evaluation Tensor, with shape [..., latent_dim]
-        :param Y: observation Tensor, with shape [..., observation_dim]:
+        :param X: input tensor, with shape [..., input_dim]
+        :param Fmu: mean function evaluation tensor, with shape [..., latent_dim]
+        :param Fvar: variance of function evaluation tensor, with shape [..., latent_dim]
+        :param Y: observation tensor, with shape [..., observation_dim]:
         :returns: expected log density of the data given q(F), with shape [...]
         """
         tf.debugging.assert_equal(tf.shape(Fmu), tf.shape(Fvar))
-        # returns an error if Y[:-1] and Fmu[:-1] do not broadcast together
-        _ = tf.broadcast_dynamic_shape(tf.shape(Fmu)[:-1], tf.shape(Y)[:-1])
-        self._check_last_dims_valid(Fmu, Y)
-        ret = self._variational_expectations(Fmu, Fvar, Y)
-        self._check_return_shape(ret, Fmu, Y)
+        # raises an error if X[:-1], Y[:-1], and Fmu[:-1] do not broadcast together
+        tf.broadcast_dynamic_shape(tf.shape(X)[:-1], tf.shape(Fmu)[:-1])
+        tf.broadcast_dynamic_shape(tf.shape(X)[:-1], tf.shape(Y)[:-1])
+
+        self._check_last_dims_valid(X, Fmu, Y)
+        ret = self._variational_expectations(X, Fmu, Fvar, Y)
+        self._check_return_shape(ret, X, Fmu, Y)
         return ret
 
     @abc.abstractmethod
     def _variational_expectations(
-        self, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
     ) -> tf.Tensor:
         raise NotImplementedError
 
 
-class QuadratureLikelihood(Likelihood):
+class QuadratureLikelihood(Likelihood, abc.ABC):
     def __init__(
         self,
+        input_dim: Optional[int],
         latent_dim: Optional[int],
         observation_dim: Optional[int],
         *,
         quadrature: Optional[GaussianQuadrature] = None,
     ) -> None:
-        super().__init__(latent_dim=latent_dim, observation_dim=observation_dim)
+        super().__init__(
+            input_dim=input_dim, latent_dim=latent_dim, observation_dim=observation_dim
+        )
         if quadrature is None:
             with tf.init_scope():
                 quadrature = NDiagGHQuadrature(
@@ -274,7 +314,7 @@ class QuadratureLikelihood(Likelihood):
         assert self.latent_dim is not None
         return self.latent_dim
 
-    def _quadrature_log_prob(self, F: TensorType, Y: TensorType) -> tf.Tensor:
+    def _quadrature_log_prob(self, F: TensorType, X: TensorType, Y: TensorType) -> tf.Tensor:
         """
         Returns the appropriate log prob integrand for quadrature.
 
@@ -284,7 +324,7 @@ class QuadratureLikelihood(Likelihood):
 
         Also see _quadrature_reduction.
         """
-        return tf.expand_dims(self.log_prob(F, Y), axis=-1)
+        return tf.expand_dims(self.log_prob(X, F, Y), axis=-1)
 
     def _quadrature_reduction(self, quadrature_result: TensorType) -> tf.Tensor:
         """
@@ -298,53 +338,63 @@ class QuadratureLikelihood(Likelihood):
         """
         return tf.squeeze(quadrature_result, axis=-1)
 
-    def _predict_log_density(self, Fmu: TensorType, Fvar: TensorType, Y: TensorType) -> tf.Tensor:
-        r"""
-        Here, we implement a default Gauss-Hermite quadrature routine, but some
-        likelihoods (Gaussian, Poisson) will implement specific cases.
-        :param Fmu: mean function evaluation Tensor, with shape [..., latent_dim]
-        :param Fvar: variance of function evaluation Tensor, with shape [..., latent_dim]
-        :param Y: observation Tensor, with shape [..., observation_dim]:
-        :returns: log predictive density, with shape [...]
-        """
-        return self._quadrature_reduction(
-            self.quadrature.logspace(self._quadrature_log_prob, Fmu, Fvar, Y=Y)
-        )
-
-    def _variational_expectations(
-        self, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+    def _predict_log_density(
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
     ) -> tf.Tensor:
         r"""
         Here, we implement a default Gauss-Hermite quadrature routine, but some
         likelihoods (Gaussian, Poisson) will implement specific cases.
-        :param Fmu: mean function evaluation Tensor, with shape [..., latent_dim]
-        :param Fvar: variance of function evaluation Tensor, with shape [..., latent_dim]
-        :param Y: observation Tensor, with shape [..., observation_dim]:
+        :param X: input tensor, with shape [..., input_dim]
+        :param Fmu: mean function evaluation tensor, with shape [..., latent_dim]
+        :param Fvar: variance of function evaluation tensor, with shape [..., latent_dim]
+        :param Y: observation tensor, with shape [..., observation_dim]:
+        :returns: log predictive density, with shape [...]
+        """
+        return self._quadrature_reduction(
+            self.quadrature.logspace(self._quadrature_log_prob, Fmu, Fvar, X=X, Y=Y)
+        )
+
+    def _variational_expectations(
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+    ) -> tf.Tensor:
+        r"""
+        Here, we implement a default Gauss-Hermite quadrature routine, but some
+        likelihoods (Gaussian, Poisson) will implement specific cases.
+        :param X: input tensor, with shape [..., input_dim]
+        :param Fmu: mean function evaluation tensor, with shape [..., latent_dim]
+        :param Fvar: variance of function evaluation tensor, with shape [..., latent_dim]
+        :param Y: observation tensor, with shape [..., observation_dim]:
         :returns: variational expectations, with shape [...]
         """
         return self._quadrature_reduction(
-            self.quadrature(self._quadrature_log_prob, Fmu, Fvar, Y=Y)
+            self.quadrature(self._quadrature_log_prob, Fmu, Fvar, X=X, Y=Y)
         )
 
-    def _predict_mean_and_var(self, Fmu: TensorType, Fvar: TensorType) -> MeanAndVariance:
+    def _predict_mean_and_var(
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType
+    ) -> MeanAndVariance:
         r"""
         Here, we implement a default Gauss-Hermite quadrature routine, but some
         likelihoods (e.g. Gaussian) will implement specific cases.
 
-        :param Fmu: mean function evaluation Tensor, with shape [..., latent_dim]
-        :param Fvar: variance of function evaluation Tensor, with shape [..., latent_dim]
+        :param X: input tensor, with shape [..., input_dim]
+        :param Fmu: mean function evaluation tensor, with shape [..., latent_dim]
+        :param Fvar: variance of function evaluation tensor, with shape [..., latent_dim]
         :returns: mean and variance of Y, both with shape [..., observation_dim]
         """
 
-        def conditional_y_squared(*F: TensorType) -> tf.Tensor:
-            return self.conditional_variance(*F) + tf.square(self.conditional_mean(*F))
+        def conditional_mean(F: TensorType, X_: TensorType) -> tf.Tensor:
+            return self.conditional_mean(X_, F)
 
-        E_y, E_y2 = self.quadrature([self.conditional_mean, conditional_y_squared], Fmu, Fvar)
+        def conditional_y_squared(F: TensorType, X_: TensorType) -> tf.Tensor:
+            return self.conditional_variance(X_, F) + tf.square(self.conditional_mean(X_, F))
+
+        E_y, E_y2 = self.quadrature([conditional_mean, conditional_y_squared], Fmu, Fvar, X_=X)
         V_y = E_y2 - E_y ** 2
         return E_y, V_y
 
 
-class ScalarLikelihood(QuadratureLikelihood):
+class ScalarLikelihood(QuadratureLikelihood, abc.ABC):
     """
     A likelihood class that helps with scalar likelihood functions: likelihoods where
     each scalar latent function is associated with a single scalar observation variable.
@@ -353,13 +403,13 @@ class ScalarLikelihood(QuadratureLikelihood):
     check for this.
 
     The `Likelihood` class contains methods to compute marginal statistics of functions
-    of the latents and the data ϕ(y,f):
+    of the latents and the data ϕ(y,x,f):
 
-    * variational_expectations:  ϕ(y,f) = log p(y|f)
-    * predict_log_density: ϕ(y,f) = p(y|f)
+    * variational_expectations:  ϕ(y,x,f) = log p(y|x,f)
+    * predict_log_density: ϕ(y,x,f) = p(y|x,f)
 
     Those statistics are computed after having first marginalized the latent processes f
-    under a multivariate normal distribution q(f) that is fully factorized.
+    under a multivariate normal distribution q(x,f) that is fully factorized.
 
     Some univariate integrals can be done by quadrature: we implement quadrature routines for 1D
     integrals in this class, though they may be overwritten by inheriting classes where those
@@ -367,27 +417,27 @@ class ScalarLikelihood(QuadratureLikelihood):
     """
 
     def __init__(self, **kwargs: Any) -> None:
-        super().__init__(latent_dim=None, observation_dim=None, **kwargs)
+        super().__init__(input_dim=None, latent_dim=None, observation_dim=None, **kwargs)
 
-    def _check_last_dims_valid(self, F: TensorType, Y: TensorType) -> None:
+    def _check_last_dims_valid(self, X: TensorType, F: TensorType, Y: TensorType) -> None:
         """
         Assert that the dimensions of the latent functions and the data are compatible
-        :param F: function evaluation Tensor, with shape [..., latent_dim]
-        :param Y: observation Tensor, with shape [..., latent_dim]
+        :param F: function evaluation tensor, with shape [..., latent_dim]
+        :param Y: observation tensor, with shape [..., latent_dim]
         """
         tf.debugging.assert_shapes([(F, (..., "num_latent")), (Y, (..., "num_latent"))])
 
-    def _log_prob(self, F: TensorType, Y: TensorType) -> tf.Tensor:
+    def _log_prob(self, X: TensorType, F: TensorType, Y: TensorType) -> tf.Tensor:
         r"""
-        Compute log p(Y|F), where by convention we sum out the last axis as it represented
+        Compute log p(Y|X,F), where by convention we sum out the last axis as it represented
         independent latent functions and observations.
-        :param F: function evaluation Tensor, with shape [..., latent_dim]
-        :param Y: observation Tensor, with shape [..., latent_dim]
+        :param F: function evaluation tensor, with shape [..., latent_dim]
+        :param Y: observation tensor, with shape [..., latent_dim]
         """
-        return tf.reduce_sum(self._scalar_log_prob(F, Y), axis=-1)
+        return tf.reduce_sum(self._scalar_log_prob(X, F, Y), axis=-1)
 
     @abc.abstractmethod
-    def _scalar_log_prob(self, F: TensorType, Y: TensorType) -> tf.Tensor:
+    def _scalar_log_prob(self, X: TensorType, F: TensorType, Y: TensorType) -> tf.Tensor:
         raise NotImplementedError
 
     @property
@@ -400,7 +450,7 @@ class ScalarLikelihood(QuadratureLikelihood):
         """
         return 1
 
-    def _quadrature_log_prob(self, F: TensorType, Y: TensorType) -> tf.Tensor:
+    def _quadrature_log_prob(self, F: TensorType, X: TensorType, Y: TensorType) -> tf.Tensor:
         """
         Returns the appropriate log prob integrand for quadrature.
 
@@ -410,7 +460,7 @@ class ScalarLikelihood(QuadratureLikelihood):
 
         Also see _quadrature_reduction.
         """
-        return self._scalar_log_prob(F, Y)
+        return self._scalar_log_prob(X, F, Y)
 
     def _quadrature_reduction(self, quadrature_result: TensorType) -> tf.Tensor:
         """
@@ -465,31 +515,35 @@ class SwitchedLikelihood(ScalarLikelihood):
 
         return results
 
-    def _check_last_dims_valid(self, F: TensorType, Y: TensorType) -> None:
+    def _check_last_dims_valid(self, X: TensorType, F: TensorType, Y: TensorType) -> None:
         tf.assert_equal(tf.shape(F)[-1], tf.shape(Y)[-1] - 1)
 
-    def _scalar_log_prob(self, F: TensorType, Y: TensorType) -> tf.Tensor:
-        return self._partition_and_stitch([F, Y], "_scalar_log_prob")
+    def _scalar_log_prob(self, X: TensorType, F: TensorType, Y: TensorType) -> tf.Tensor:
+        return self._partition_and_stitch([X, F, Y], "_scalar_log_prob")
 
-    def _predict_log_density(self, Fmu: TensorType, Fvar: TensorType, Y: TensorType) -> tf.Tensor:
-        return self._partition_and_stitch([Fmu, Fvar, Y], "predict_log_density")
+    def _predict_log_density(
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+    ) -> tf.Tensor:
+        return self._partition_and_stitch([X, Fmu, Fvar, Y], "predict_log_density")
 
     def _variational_expectations(
-        self, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
     ) -> tf.Tensor:
-        return self._partition_and_stitch([Fmu, Fvar, Y], "variational_expectations")
+        return self._partition_and_stitch([X, Fmu, Fvar, Y], "variational_expectations")
 
-    def _predict_mean_and_var(self, Fmu: TensorType, Fvar: TensorType) -> MeanAndVariance:
-        mvs = [lik.predict_mean_and_var(Fmu, Fvar) for lik in self.likelihoods]
+    def _predict_mean_and_var(
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType
+    ) -> MeanAndVariance:
+        mvs = [lik.predict_mean_and_var(X, Fmu, Fvar) for lik in self.likelihoods]
         mu_list, var_list = zip(*mvs)
         mu = tf.concat(mu_list, axis=1)
         var = tf.concat(var_list, axis=1)
         return mu, var
 
-    def _conditional_mean(self, F: TensorType) -> tf.Tensor:
+    def _conditional_mean(self, X: TensorType, F: TensorType) -> tf.Tensor:
         raise NotImplementedError
 
-    def _conditional_variance(self, F: TensorType) -> tf.Tensor:
+    def _conditional_variance(self, X: TensorType, F: TensorType) -> tf.Tensor:
         raise NotImplementedError
 
 
@@ -510,7 +564,7 @@ class MonteCarloLikelihood(Likelihood):
         return ndiag_mc(funcs, self.num_monte_carlo_points, Fmu, Fvar, logspace, epsilon, **Ys)
 
     def _predict_mean_and_var(
-        self, Fmu: TensorType, Fvar: TensorType, epsilon: Optional[TensorType] = None
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, epsilon: Optional[TensorType] = None
     ) -> MeanAndVariance:
         r"""
         Given a Normal distribution for the latent function,
@@ -534,61 +588,86 @@ class MonteCarloLikelihood(Likelihood):
         Here, we implement a default Monte Carlo routine.
         """
 
-        def conditional_y_squared(*F: TensorType) -> TensorType:
-            return self.conditional_variance(*F) + tf.square(self.conditional_mean(*F))
+        def conditional_mean(F: TensorType, X_: TensorType) -> TensorType:
+            return self.conditional_mean(X_, F)
+
+        def conditional_y_squared(F: TensorType, X_: TensorType) -> TensorType:
+            return self.conditional_variance(X_, F) + tf.square(self.conditional_mean(X_, F))
 
         E_y, E_y2 = self._mc_quadrature(
-            [self.conditional_mean, conditional_y_squared], Fmu, Fvar, epsilon=epsilon
+            [conditional_mean, conditional_y_squared],
+            Fmu,
+            Fvar,
+            epsilon=epsilon,
+            X_=X,
         )
         V_y = E_y2 - tf.square(E_y)
         return E_y, V_y  # [N, D]
 
     def _predict_log_density(
-        self, Fmu: TensorType, Fvar: TensorType, Y: TensorType, epsilon: Optional[TensorType] = None
+        self,
+        X: TensorType,
+        Fmu: TensorType,
+        Fvar: TensorType,
+        Y: TensorType,
+        epsilon: Optional[TensorType] = None,
     ) -> tf.Tensor:
         r"""
         Given a Normal distribution for the latent function, and a datum Y,
         compute the log predictive density of Y.
 
         i.e. if
-            q(f) = N(Fmu, Fvar)
+            q(x, f) = N(Fmu, Fvar)
 
         and this object represents
 
-            p(y|f)
+            p(y|x,f)
 
         then this method computes the predictive density
 
-            log ∫ p(y=Y|f)q(f) df
+            log ∫ p(y=Y|x,f)q(x,f) df
 
         Here, we implement a default Monte Carlo routine.
         """
+
+        def log_prob(F: TensorType, X_: TensorType, Y_: TensorType) -> tf.Tensor:
+            return self.log_prob(X_, F, Y_)
+
         return tf.reduce_sum(
-            self._mc_quadrature(self.log_prob, Fmu, Fvar, Y=Y, logspace=True, epsilon=epsilon),
+            self._mc_quadrature(log_prob, Fmu, Fvar, logspace=True, epsilon=epsilon, X_=X, Y_=Y),
             axis=-1,
         )
 
     def _variational_expectations(
-        self, Fmu: TensorType, Fvar: TensorType, Y: TensorType, epsilon: Optional[TensorType] = None
+        self,
+        X: TensorType,
+        Fmu: TensorType,
+        Fvar: TensorType,
+        Y: TensorType,
+        epsilon: Optional[TensorType] = None,
     ) -> tf.Tensor:
         r"""
         Compute the expected log density of the data, given a Gaussian
         distribution for the function values.
 
         if
-            q(f) = N(Fmu, Fvar)  - Fmu: [N, D]  Fvar: [N, D]
+            q(x,f) = N(Fmu, Fvar)  - Fmu: [N, D]  Fvar: [N, D]
 
         and this object represents
 
-            p(y|f)  - Y: [N, 1]
+            p(y|x,f)  - Y: [N, 1]
 
         then this method computes
 
-           ∫ (log p(y|f)) q(f) df.
+           ∫ (log p(y|x,f)) q(x,f) df.
 
 
         Here, we implement a default Monte Carlo quadrature routine.
         """
+
+        def log_prob(F: TensorType, X_: TensorType, Y_: TensorType) -> tf.Tensor:
+            return self.log_prob(X_, F, Y_)
+
         return tf.reduce_sum(
-            self._mc_quadrature(self.log_prob, Fmu, Fvar, Y=Y, epsilon=epsilon), axis=-1
+            self._mc_quadrature(log_prob, Fmu, Fvar, epsilon=epsilon, X_=X, Y_=Y), axis=-1
         )

--- a/gpflow/likelihoods/multilatent.py
+++ b/gpflow/likelihoods/multilatent.py
@@ -33,6 +33,7 @@ class MultiLatentLikelihood(QuadratureLikelihood):
 
     def __init__(self, latent_dim: int, **kwargs: Any) -> None:
         super().__init__(
+            input_dim=None,
             latent_dim=latent_dim,
             observation_dim=1,
             **kwargs,
@@ -59,7 +60,7 @@ class MultiLatentTFPConditional(MultiLatentLikelihood):
         super().__init__(latent_dim, **kwargs)
         self.conditional_distribution = conditional_distribution
 
-    def _log_prob(self, Fs: TensorType, Y: TensorType) -> tf.Tensor:
+    def _log_prob(self, X: TensorType, Fs: TensorType, Y: TensorType) -> tf.Tensor:
         """
         The log probability density log p(Y|F)
 
@@ -69,7 +70,7 @@ class MultiLatentTFPConditional(MultiLatentLikelihood):
         """
         return tf.squeeze(self.conditional_distribution(Fs).log_prob(Y), -1)
 
-    def _conditional_mean(self, Fs: TensorType) -> tf.Tensor:
+    def _conditional_mean(self, X: TensorType, Fs: TensorType) -> tf.Tensor:
         """
         The conditional marginal mean of Y|F: [E(Y₁|F)]
 
@@ -78,7 +79,7 @@ class MultiLatentTFPConditional(MultiLatentLikelihood):
         """
         return self.conditional_distribution(Fs).mean()
 
-    def _conditional_variance(self, Fs: TensorType) -> tf.Tensor:
+    def _conditional_variance(self, X: TensorType, Fs: TensorType) -> tf.Tensor:
         """
         The conditional marginal variance of Y|F: [Var(Y₁|F)]
 

--- a/gpflow/models/cglb.py
+++ b/gpflow/models/cglb.py
@@ -257,7 +257,7 @@ class CGLB(SGPR):
         f_mean, f_var = self.predict_f(
             xnew, full_cov=full_cov, full_output_cov=full_output_cov, cg_tolerance=cg_tolerance
         )
-        return self.likelihood.predict_mean_and_var(f_mean, f_var)
+        return self.likelihood.predict_mean_and_var(xnew, f_mean, f_var)
 
     def predict_log_density(
         self,
@@ -277,7 +277,7 @@ class CGLB(SGPR):
         f_mean, f_var = self.predict_f(
             x, full_cov=full_cov, full_output_cov=full_output_cov, cg_tolerance=cg_tolerance
         )
-        return self.likelihood.predict_log_density(f_mean, f_var, y)
+        return self.likelihood.predict_log_density(x, f_mean, f_var, y)
 
 
 class NystromPreconditioner:

--- a/gpflow/models/gpmc.py
+++ b/gpflow/models/gpmc.py
@@ -92,7 +92,7 @@ class GPMC(GPModel, InternalDataTrainingLossMixin):
         )
         F = tf.linalg.matmul(L, self.V) + self.mean_function(X_data)
 
-        return tf.reduce_sum(self.likelihood.log_prob(F, Y_data))
+        return tf.reduce_sum(self.likelihood.log_prob(X_data, F, Y_data))
 
     def predict_f(
         self, Xnew: InputData, full_cov: bool = False, full_output_cov: bool = False

--- a/gpflow/models/model.py
+++ b/gpflow/models/model.py
@@ -214,7 +214,7 @@ class GPModel(BayesianModel):
         assert_params_false(self.predict_y, full_cov=full_cov, full_output_cov=full_output_cov)
 
         f_mean, f_var = self.predict_f(Xnew, full_cov=full_cov, full_output_cov=full_output_cov)
-        return self.likelihood.predict_mean_and_var(f_mean, f_var)
+        return self.likelihood.predict_mean_and_var(Xnew, f_mean, f_var)
 
     def predict_log_density(
         self, data: RegressionData, full_cov: bool = False, full_output_cov: bool = False
@@ -227,4 +227,4 @@ class GPModel(BayesianModel):
 
         X, Y = data
         f_mean, f_var = self.predict_f(X, full_cov=full_cov, full_output_cov=full_output_cov)
-        return self.likelihood.predict_log_density(f_mean, f_var, Y)
+        return self.likelihood.predict_log_density(X, f_mean, f_var, Y)

--- a/gpflow/models/sgpmc.py
+++ b/gpflow/models/sgpmc.py
@@ -98,7 +98,7 @@ class SGPMC(GPModel, InternalDataTrainingLossMixin):
         # get the (marginals of) q(f): exactly predicting!
         X_data, Y_data = self.data
         fmean, fvar = self.predict_f(X_data, full_cov=False)
-        return tf.reduce_sum(self.likelihood.variational_expectations(fmean, fvar, Y_data))
+        return tf.reduce_sum(self.likelihood.variational_expectations(X_data, fmean, fvar, Y_data))
 
     def predict_f(
         self, Xnew: InputData, full_cov: bool = False, full_output_cov: bool = False

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -152,7 +152,7 @@ class SVGP_deprecated(GPModel, ExternalDataTrainingLossMixin):
         X, Y = data
         kl = self.prior_kl()
         f_mean, f_var = self.predict_f(X, full_cov=False, full_output_cov=False)
-        var_exp = self.likelihood.variational_expectations(f_mean, f_var, Y)
+        var_exp = self.likelihood.variational_expectations(X, f_mean, f_var, Y)
         if self.num_data is not None:
             num_data = tf.cast(self.num_data, kl.dtype)
             minibatch_size = tf.cast(tf.shape(X)[0], kl.dtype)

--- a/gpflow/models/vgp.py
+++ b/gpflow/models/vgp.py
@@ -127,7 +127,7 @@ class VGP_deprecated(GPModel, InternalDataTrainingLossMixin):
         fvar = tf.transpose(fvar)
 
         # Get variational expectations.
-        var_exp = self.likelihood.variational_expectations(fmean, fvar, Y_data)
+        var_exp = self.likelihood.variational_expectations(X_data, fmean, fvar, Y_data)
 
         return tf.reduce_sum(var_exp) - KL
 
@@ -346,7 +346,7 @@ class VGPOpperArchambeau(GPModel, InternalDataTrainingLossMixin):
             + tf.reduce_sum(K_alpha * self.q_alpha)
         )
 
-        v_exp = self.likelihood.variational_expectations(f_mean, f_var, Y_data)
+        v_exp = self.likelihood.variational_expectations(X_data, f_mean, f_var, Y_data)
         return tf.reduce_sum(v_exp) - KL
 
     def predict_f(

--- a/gpflow/quadrature/deprecated.py
+++ b/gpflow/quadrature/deprecated.py
@@ -218,7 +218,7 @@ def ndiagquad(
 @check_shapes(
     "Fmu: [N, Din]",
     "Fvar: [N, Din]",
-    "Ys.values(): [broadcast N, Dout]",
+    "Ys.values(): [broadcast N, .]",
     "return: [broadcast n_funs, N, P]",
 )
 def ndiag_mc(

--- a/tests/gpflow/likelihoods/test_heteroskedastic.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic.py
@@ -24,6 +24,7 @@ tf.random.set_seed(99012)
 class Data:
     rng = np.random.RandomState(123)
     N = 5
+    X = np.linspace(0, 1, num=N)[:, None]
     Y = rng.randn(N, 1)
     f_mean = rng.randn(N, 2)
     f_var: AnyNDArray = rng.randn(N, 2) ** 2
@@ -40,7 +41,7 @@ def test_analytic_mean_and_var() -> None:
     analytic_variance = np.exp(Data.f_mean[:, [1]] + Data.f_var[:, [1]]) ** 2 + Data.f_var[:, [0]]
 
     likelihood = HeteroskedasticTFPConditional()
-    y_mean, y_var = likelihood.predict_mean_and_var(Data.f_mean, Data.f_var)
+    y_mean, y_var = likelihood.predict_mean_and_var(Data.X, Data.f_mean, Data.f_var)
 
     np.testing.assert_allclose(y_mean, analytic_mean)
     np.testing.assert_allclose(y_var, analytic_variance, rtol=1.5e-6)

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -36,6 +36,7 @@ class Data:
     g_var = 0.345
     rng = np.random.RandomState(123)
     N = 5
+    X = rng.randn(N, 2)
     Y = rng.randn(N, 1)
     # single "GP" (for the mean):
     f_mean = rng.randn(N, 1)
@@ -88,16 +89,18 @@ def test_log_prob(equivalent_likelihoods: EquivalentLikelihoods) -> None:
     """
     homoskedastic_likelihood, heteroskedastic_likelihood = equivalent_likelihoods
     np.testing.assert_array_almost_equal(
-        homoskedastic_likelihood.log_prob(Data.f_mean, Data.Y),
-        heteroskedastic_likelihood.log_prob(Data.F2_mean, Data.Y),
+        homoskedastic_likelihood.log_prob(Data.X, Data.f_mean, Data.Y),
+        heteroskedastic_likelihood.log_prob(Data.X, Data.F2_mean, Data.Y),
     )
 
 
 def test_variational_expectations(equivalent_likelihoods: EquivalentLikelihoods) -> None:
     homoskedastic_likelihood, heteroskedastic_likelihood = equivalent_likelihoods
     np.testing.assert_array_almost_equal(
-        homoskedastic_likelihood.variational_expectations(Data.f_mean, Data.f_var, Data.Y),
-        heteroskedastic_likelihood.variational_expectations(Data.F2_mean, Data.F2_var, Data.Y),
+        homoskedastic_likelihood.variational_expectations(Data.X, Data.f_mean, Data.f_var, Data.Y),
+        heteroskedastic_likelihood.variational_expectations(
+            Data.X, Data.F2_mean, Data.F2_var, Data.Y
+        ),
         decimal=2,  # student-t case has a max absolute difference of 0.0034
     )
 
@@ -105,33 +108,33 @@ def test_variational_expectations(equivalent_likelihoods: EquivalentLikelihoods)
 def test_predict_mean_and_var(equivalent_likelihoods: EquivalentLikelihoods) -> None:
     homoskedastic_likelihood, heteroskedastic_likelihood = equivalent_likelihoods
     np.testing.assert_allclose(
-        homoskedastic_likelihood.predict_mean_and_var(Data.f_mean, Data.f_var),
-        heteroskedastic_likelihood.predict_mean_and_var(Data.F2_mean, Data.F2_var),
+        homoskedastic_likelihood.predict_mean_and_var(Data.X, Data.f_mean, Data.f_var),
+        heteroskedastic_likelihood.predict_mean_and_var(Data.X, Data.F2_mean, Data.F2_var),
     )
 
 
 def test_conditional_mean(equivalent_likelihoods: EquivalentLikelihoods) -> None:
     homoskedastic_likelihood, heteroskedastic_likelihood = equivalent_likelihoods
     np.testing.assert_allclose(
-        homoskedastic_likelihood.conditional_mean(Data.f_mean),
-        heteroskedastic_likelihood.conditional_mean(Data.F2_mean),
+        homoskedastic_likelihood.conditional_mean(Data.X, Data.f_mean),
+        heteroskedastic_likelihood.conditional_mean(Data.X, Data.F2_mean),
     )
 
 
 def test_conditional_variance(equivalent_likelihoods: EquivalentLikelihoods) -> None:
     homoskedastic_likelihood, heteroskedastic_likelihood = equivalent_likelihoods
     np.testing.assert_allclose(
-        homoskedastic_likelihood.conditional_variance(Data.f_mean),
-        heteroskedastic_likelihood.conditional_variance(Data.F2_mean),
+        homoskedastic_likelihood.conditional_variance(Data.X, Data.f_mean),
+        heteroskedastic_likelihood.conditional_variance(Data.X, Data.F2_mean),
     )
 
 
 def test_predict_log_density(equivalent_likelihoods: EquivalentLikelihoods) -> None:
     homoskedastic_likelihood, heteroskedastic_likelihood = equivalent_likelihoods
-    ll1 = homoskedastic_likelihood.predict_log_density(Data.f_mean, Data.f_var, Data.Y)
-    ll2 = heteroskedastic_likelihood.predict_log_density(Data.F2_mean, Data.F2_var, Data.Y)
+    ll1 = homoskedastic_likelihood.predict_log_density(Data.X, Data.f_mean, Data.f_var, Data.Y)
+    ll2 = heteroskedastic_likelihood.predict_log_density(Data.X, Data.F2_mean, Data.F2_var, Data.Y)
     np.testing.assert_array_almost_equal(
-        homoskedastic_likelihood.predict_log_density(Data.f_mean, Data.f_var, Data.Y),
-        heteroskedastic_likelihood.predict_log_density(Data.F2_mean, Data.F2_var, Data.Y),
+        homoskedastic_likelihood.predict_log_density(Data.X, Data.f_mean, Data.f_var, Data.Y),
+        heteroskedastic_likelihood.predict_log_density(Data.X, Data.F2_mean, Data.F2_var, Data.Y),
         decimal=1,  # student-t has a max absolute difference of 0.025
     )


### PR DESCRIPTION
Add an `X` parameter to the `Likelihood` class methods.

This will make it easy/possibly to write heteroskedastic likelihoods.

I plan to do more with heteroskedastic likelihoods in downstream PRs, but I want to get the "controversial" part of it out of the way first.

Basically this is the controversial part, because this is a breaking change.
To guesstimate the scale of the breakage, consider our notebooks. We have 35 notebooks doing all kinds of advanced stuff. A single one of those breaks.