### PR TITLE
Experimental Apple Silicon (M1) support

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -83,5 +83,6 @@ Because GitHub's [graph of contributors](http://github.com/GPflow/GPflow/graphs/
 [@jesnie](https://github.com/jesnie)
 [@tmct](https://github.com/tmct)
 [@ltiao](https://github.com/ltiao)
+[@corwinpro](https://github.com/corwinpro)
 
 Add yourself when you first contribute to GPflow's code, tests, or documentation!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -61,12 +61,13 @@ This release contains contributions from:
 * <SIMILAR TO ABOVE SECTION, BUT FOR OTHER IMPORTANT CHANGES / BUG FIXES>
 * <IF A CHANGE CLOSES A GITHUB ISSUE, IT SHOULD BE DOCUMENTED HERE>
 * <NOTES SHOULD BE GROUPED PER AREA>
+* Add support for Apple Silicon Macs (`arm64`) via the `tensorflow-macos` dependency. (#1850)
 
 ## Thanks to our Contributors
 
 This release contains contributions from:
 
-jesnie
+jesnie, corwinpro
 
 
 # Release 2.5.2

--- a/gpflow/utilities/traversal.py
+++ b/gpflow/utilities/traversal.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import numpy as np
 import re
 from functools import lru_cache
 from typing import Any, Callable, Dict, Mapping, Optional, Pattern, Tuple, Type, TypeVar, Union
@@ -330,7 +331,7 @@ def _first_three_elements_regexp() -> Pattern[str]:
 
 
 def _str_tensor_value(value: AnyNDArray) -> str:
-    value_str = str(value)
+    value_str = str(np.around(value, 5))
     if value.size <= 3:
         return value_str
 

--- a/gpflow/utilities/traversal.py
+++ b/gpflow/utilities/traversal.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import copy
-import numpy as np
 import re
 from functools import lru_cache
 from typing import Any, Callable, Dict, Mapping, Optional, Pattern, Tuple, Type, TypeVar, Union
 
+import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 from packaging.version import Version

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ requirements = [
     "setuptools>=41.0.0",  # to satisfy dependency constraints
     "tabulate",
     "tensorflow-probability>=0.12.0",
-    "tensorflow>=2.4.0; platform_system!='Darwin' and platform_machine!='arm64'",
+    "tensorflow>=2.4.0; platform_system!='Darwin' or platform_machine!='arm64'",
     # NOTE: Support of Apple Silicon MacOS platforms is in an experimental mode
     "tensorflow-macos>=2.4.0; platform_system=='Darwin' and platform_machine=='arm64'",
     # NOTE: once we require tensorflow-probability>=0.12, we can remove our custom deepcopy handling

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ requirements = [
     "setuptools>=41.0.0",  # to satisfy dependency constraints
     "tabulate",
     "tensorflow-probability>=0.12.0",
-    "tensorflow>=2.4.0",
+    "tensorflow>=2.4.0; platform_system!='Darwin' and platform_machine!='arm64'",
+    # NOTE: Support of Apple Silicon MacOS platforms is in an experimental mode
+    "tensorflow-macos>=2.4.0; platform_system=='Darwin' and platform_machine=='arm64'",
     # NOTE: once we require tensorflow-probability>=0.12, we can remove our custom deepcopy handling
     "typing_extensions",
 ]

--- a/tests/gpflow/utilities/test_traversal.py
+++ b/tests/gpflow/utilities/test_traversal.py
@@ -328,7 +328,7 @@ def test_leaf_components_registers_variable_properties(
     for path, variable in leaf_components(module).items():
         param_name = path.split(".")[-2] + "." + path.split(".")[-1]
         assert isinstance(variable, gpflow.Parameter)
-        np.testing.assert_equal(variable.numpy(), expected_param_dicts[param_name]["value"])
+        np.testing.assert_almost_equal(variable.numpy(), expected_param_dicts[param_name]["value"])
         assert variable.trainable == expected_param_dicts[param_name]["trainable"]
         assert variable.shape == expected_param_dicts[param_name]["shape"]
 
@@ -349,7 +349,7 @@ def test_leaf_components_registers_compose_kernel_variable_properties(
         path_as_list = path.split(".")
         param_name = path_as_list[-3] + "." + path_as_list[-2] + "." + path_as_list[-1]
         assert isinstance(variable, gpflow.Parameter)
-        np.testing.assert_equal(variable.numpy(), expected_param_dicts[param_name]["value"])
+        np.testing.assert_almost_equal(variable.numpy(), expected_param_dicts[param_name]["value"])
         assert variable.trainable == expected_param_dicts[param_name]["trainable"]
         assert variable.shape == expected_param_dicts[param_name]["shape"]
 


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** enhancement

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" --> Contributes to #1850

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

This PR introduces basic support for Apple Silicon MacOS. This is achieved by pulling `tensorflow-macos` dependency instead of regular `tensorflow` at setup time.

This has been tested on an Macbook Pro 2021 M1 Pro, `python3.8`. 

<!-- A clear and concise description of the contents of this pull request. -->
* Update `setup.py` to dynamically decide on the `tensorflow` source depending on the platform
* Changes in `gpflow/utilities/traversal.py` and `test_traversal.py` come from the common type of errors that `0.999999 != 1.0` and representation of floating point numbers.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

No alternatives have been considered. Please let me know if there are any.

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```console
python3.8 -m venv gpflow-py38
source gpflow-py38/bin/activate
python -m pip install -e .
python -m pip install -r tests_requirements.txt
make format
make check-all
```

### Known problems

With `python3.8` installed via `brew`, integration tests for notebooks sometimes fail with `OSError: too many files open`. I think this is a [known issue](https://github.com/jupyter/nbclient/issues/58) and can be addressed separately.

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [x] Code has type annotations
- [x] Build checks
  - [x] I ran the black+isort formatter (`make format`)
  - [x] I locally tested that the tests pass (`make check-all`)
- [x] Release management
  - [x] RELEASE.md updated with entry for this change
  - [x] New contributors: I've added myself to CONTRIBUTORS.md

