### PR TITLE
Make `tf_decorator.make_decorator` configurable.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -50,6 +50,10 @@ This release contains contributions from:
 * Change to `InducingVariables` API. `InducingVariables` must now have a `shape` property.
 * `gpflow.experimental.check_shapes.get_shape.register` has been replaced with
   `gpflow.experimental.check_shapes.register_get_shape`.
+* `check_shapes` will, no longer automatically wrap shape checking in
+  `tf.compat.v1.flags.tf_decorator.make_decorator`. This is likely to affect you if you use
+  `check_shapes` with Keras custom models. If you require the decorator you can manually enable it
+  with `check_shapes(..., tf_decorator=True)`.
 
 ## Known Caveats
 


### PR DESCRIPTION
Fixes: #1864
Fixes: #1936
Related to: #1858

Make `tf_decorator.make_decorator` configurable.
It was initially added to play better with Keras. However, it seems to also cause problems. So, I suggest hiding it behind a function parameter.