### PR TITLE
Upgrade for TensorFlow 2.10.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,16 @@ parameters:
     default: "3.10"
   min_tf_ver:
     type: string
-    default: "2.4"
+    default: "2.4.0"
   max_tf_ver:
     type: string
-    default: "2.9"
+    default: "2.10.0"
   min_tfp_ver:
     type: string
-    default: "0.12"
+    default: "0.12.0"
   max_tfp_ver:
     type: string
-    default: "0.17"
+    default: "0.18.0"
 
 commands:
   setup_venv:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -84,6 +84,7 @@ This release contains contributions from:
 
 ## Bug Fixes and Other Changes
 
+* Tested with TensorFlow 2.10.
 * Add support for Apple Silicon Macs (`arm64`) via the `tensorflow-macos` dependency. (#1850)
 * New implementation of GPR and SGPR posterior objects. This primarily improves numerical stability.
   (#1960)

--- a/tests/gpflow/experimental/check_shapes/test_integration.py
+++ b/tests/gpflow/experimental/check_shapes/test_integration.py
@@ -183,7 +183,7 @@ def test_check_shapes__tensorflow_compilation(
 
     # See: https://github.com/tensorflow/tensorflow/issues/56414
     if err_wrapper is _RELAXED_TF_FUNCTION:
-        if Version("2.9.0") <= tf_version < Version("2.10.0"):
+        if Version("2.9.0") <= tf_version < Version("2.11.0"):
             err_wrapper = _TF_FUNCTION
 
     if Version(tf.__version__) < Version("2.5.0"):


### PR DESCRIPTION
Start testing GPflow for TensorFlow 2.10.
Also slight update to format of `pip install`.