### PR TITLE
Reformat notebooks to width 80.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+NOTEBOOK_BLACK_CONFIG=-t py37 -l 80
+NOTEBOOK_BLACK_TARGETS=doc/sphinx/notebooks
+NOTEBOOK_ISORT_CONFIG=--atomic -l 80 --trailing-comma --remove-redundant-aliases --multi-line 3
+NOTEBOOK_ISORT_TARGETS=doc/sphinx/notebooks
+
 BLACK_CONFIG=-t py37 -l 100
-BLACK_TARGETS=gpflow tests benchmark doc setup.py
+BLACK_TARGETS=gpflow tests benchmark doc/*.py setup.py
 ISORT_CONFIG=--atomic -l 100 --trailing-comma --remove-redundant-aliases --multi-line 3
 ISORT_TARGETS=gpflow tests benchmark doc/*.py setup.py
 MYPY_TARGETS=gpflow tests benchmark doc/*.py setup.py
@@ -32,11 +37,15 @@ package:
 
 format:
 	black $(BLACK_CONFIG) $(BLACK_TARGETS)
+	black $(NOTEBOOK_BLACK_CONFIG) $(NOTEBOOK_BLACK_TARGETS)
 	isort $(ISORT_CONFIG) $(ISORT_TARGETS)
+	isort $(NOTEBOOK_ISORT_CONFIG) $(NOTEBOOK_ISORT_TARGETS)
 
 format-check:
 	black --check $(BLACK_CONFIG) $(BLACK_TARGETS)
+	black --check $(NOTEBOOK_BLACK_CONFIG) $(NOTEBOOK_BLACK_TARGETS)
 	isort --check-only $(ISORT_CONFIG) $(ISORT_TARGETS)
+	isort --check-only $(NOTEBOOK_ISORT_CONFIG) $(NOTEBOOK_ISORT_TARGETS)
 
 type-check:
 	mypy `python -m gpflow.mypy_flags` $(MYPY_TARGETS)

--- a/doc/generate_module_rst.py
+++ b/doc/generate_module_rst.py
@@ -18,7 +18,7 @@ import inspect
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, Deque, Dict, List, Mapping, Optional, Set, TextIO, Type, Union
+from typing import Any, Callable, Deque, Dict, List, Mapping, Set, TextIO, Type, Union
 
 from gpflow.utilities import Dispatcher
 

--- a/doc/sphinx/notebooks/advanced/changepoints.pct.py
+++ b/doc/sphinx/notebooks/advanced/changepoints.pct.py
@@ -27,9 +27,10 @@
 # where $\sigma(x, y) = \sigma(x)\cdot\sigma(y)$ and $\bar{\sigma}(x, y) = (1 - \sigma(x))\cdot(1 - \sigma(y))$. The sigmoid ($\sigma$) is parameterized by a location ($l$) and a width ($w$).
 
 # %%
-import gpflow
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
+import gpflow
 
 np.random.seed(123)  # for reproducibility of this notebook
 
@@ -64,7 +65,9 @@ np.random.seed(3)
 
 base_k1 = gpflow.kernels.Matern32(lengthscales=0.3)
 base_k2 = gpflow.kernels.Constant()
-k = gpflow.kernels.ChangePoints([base_k1, base_k2, base_k1], locations=[-1, 1], steepness=10.0)
+k = gpflow.kernels.ChangePoints(
+    [base_k1, base_k2, base_k1], locations=[-1, 1], steepness=10.0
+)
 
 f, ax = plt.subplots(1, 1, figsize=(10, 3))
 plotkernelsample(k, ax)

--- a/doc/sphinx/notebooks/advanced/convolutional.pct.py
+++ b/doc/sphinx/notebooks/advanced/convolutional.pct.py
@@ -27,13 +27,13 @@
 
 # %%
 import time
-import numpy as np
-import matplotlib.pyplot as plt
 
-import gpflow
+import matplotlib.pyplot as plt
+import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 
+import gpflow
 from gpflow import set_trainable
 from gpflow.ci_utils import is_continuous_integration
 
@@ -56,8 +56,12 @@ IMAGE_SHAPE = [H, W]
 
 # %%
 def affine_scalar_bijector(shift=None, scale=None):
-    scale_bijector = tfp.bijectors.Scale(scale) if scale else tfp.bijectors.Identity()
-    shift_bijector = tfp.bijectors.Shift(shift) if shift else tfp.bijectors.Identity()
+    scale_bijector = (
+        tfp.bijectors.Scale(scale) if scale else tfp.bijectors.Identity()
+    )
+    shift_bijector = (
+        tfp.bijectors.Shift(shift) if shift else tfp.bijectors.Identity()
+    )
     return shift_bijector(scale_bijector)
 
 
@@ -142,15 +146,23 @@ print("RBF elbo after training: %.4e" % rbf_elbo())
 
 # %%
 f64 = lambda x: np.array(x, dtype=np.float64)
-positive_with_min = lambda: affine_scalar_bijector(shift=f64(1e-4))(tfp.bijectors.Softplus())
+positive_with_min = lambda: affine_scalar_bijector(shift=f64(1e-4))(
+    tfp.bijectors.Softplus()
+)
 constrained = lambda: affine_scalar_bijector(shift=f64(1e-4), scale=f64(100.0))(
     tfp.bijectors.Sigmoid()
 )
-max_abs_1 = lambda: affine_scalar_bijector(shift=f64(-2.0), scale=f64(4.0))(tfp.bijectors.Sigmoid())
+max_abs_1 = lambda: affine_scalar_bijector(shift=f64(-2.0), scale=f64(4.0))(
+    tfp.bijectors.Sigmoid()
+)
 
 patch_shape = [3, 3]
-conv_k = gpflow.kernels.Convolutional(gpflow.kernels.SquaredExponential(), IMAGE_SHAPE, patch_shape)
-conv_k.base_kernel.lengthscales = gpflow.Parameter(1.0, transform=positive_with_min())
+conv_k = gpflow.kernels.Convolutional(
+    gpflow.kernels.SquaredExponential(), IMAGE_SHAPE, patch_shape
+)
+conv_k.base_kernel.lengthscales = gpflow.Parameter(
+    1.0, transform=positive_with_min()
+)
 # Weight scale and variance are non-identifiable. We also need to prevent variance from shooting off crazily.
 conv_k.base_kernel.variance = gpflow.Parameter(1.0, transform=constrained())
 conv_k.weights = gpflow.Parameter(conv_k.weights.numpy(), transform=max_abs_1())
@@ -190,7 +202,9 @@ res = gpflow.optimizers.Scipy().minimize(
     options={"disp": True, "maxiter": MAXITER},
 )
 train_acc = np.mean((conv_m.predict_y(X)[0] > 0.5).numpy().astype("float") == Y)
-test_acc = np.mean((conv_m.predict_y(Xt)[0] > 0.5).numpy().astype("float") == Yt)
+test_acc = np.mean(
+    (conv_m.predict_y(Xt)[0] > 0.5).numpy().astype("float") == Yt
+)
 print(f"Train acc: {train_acc * 100}%\nTest acc : {test_acc*100}%")
 print("conv elbo after training: %.4e" % conv_elbo())
 
@@ -202,7 +216,9 @@ res = gpflow.optimizers.Scipy().minimize(
     options={"disp": True, "maxiter": MAXITER},
 )
 train_acc = np.mean((conv_m.predict_y(X)[0] > 0.5).numpy().astype("float") == Y)
-test_acc = np.mean((conv_m.predict_y(Xt)[0] > 0.5).numpy().astype("float") == Yt)
+test_acc = np.mean(
+    (conv_m.predict_y(Xt)[0] > 0.5).numpy().astype("float") == Yt
+)
 print(f"Train acc: {train_acc * 100}%\nTest acc : {test_acc*100}%")
 print("conv elbo after training: %.4e" % conv_elbo())
 
@@ -215,7 +231,9 @@ res = gpflow.optimizers.Scipy().minimize(
     options={"disp": True, "maxiter": MAXITER},
 )
 train_acc = np.mean((conv_m.predict_y(X)[0] > 0.5).numpy().astype("float") == Y)
-test_acc = np.mean((conv_m.predict_y(Xt)[0] > 0.5).numpy().astype("float") == Yt)
+test_acc = np.mean(
+    (conv_m.predict_y(Xt)[0] > 0.5).numpy().astype("float") == Yt
+)
 print(f"Train acc: {train_acc * 100}%\nTest acc : {test_acc*100}%")
 print("conv elbo after training: %.4e" % conv_elbo())
 

--- a/doc/sphinx/notebooks/advanced/coregionalisation.pct.py
+++ b/doc/sphinx/notebooks/advanced/coregionalisation.pct.py
@@ -40,14 +40,13 @@
 #  * Augment the training data Y with an extra column that contains an integer index to indicate which likelihood an observation is associated with.
 
 # %%
-import gpflow
-import tensorflow as tf
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
+import gpflow
+from gpflow.ci_utils import reduce_in_tests
 
 # %matplotlib inline
-
-from gpflow.ci_utils import reduce_in_tests
 
 plt.rcParams["figure.figsize"] = (12, 6)
 np.random.seed(123)
@@ -80,10 +79,14 @@ _ = plt.plot(X2, Y2, "x", mew=2)
 
 # %%
 # Augment the input with ones or zeros to indicate the required output dimension
-X_augmented = np.vstack((np.hstack((X1, np.zeros_like(X1))), np.hstack((X2, np.ones_like(X2)))))
+X_augmented = np.vstack(
+    (np.hstack((X1, np.zeros_like(X1))), np.hstack((X2, np.ones_like(X2))))
+)
 
 # Augment the Y data with ones or zeros that specify a likelihood from the list of likelihoods
-Y_augmented = np.vstack((np.hstack((Y1, np.zeros_like(Y1))), np.hstack((Y2, np.ones_like(Y2)))))
+Y_augmented = np.vstack(
+    (np.hstack((Y1, np.zeros_like(Y1))), np.hstack((Y2, np.ones_like(Y2))))
+)
 
 # %% [markdown]
 # ## Building the coregionalization kernel
@@ -97,7 +100,9 @@ rank = 1  # Rank of W
 k = gpflow.kernels.Matern32(active_dims=[0])
 
 # Coregion kernel
-coreg = gpflow.kernels.Coregion(output_dim=output_dim, rank=rank, active_dims=[1])
+coreg = gpflow.kernels.Coregion(
+    output_dim=output_dim, rank=rank, active_dims=[1]
+)
 
 kern = k * coreg
 

--- a/doc/sphinx/notebooks/advanced/fast_predictions.pct.py
+++ b/doc/sphinx/notebooks/advanced/fast_predictions.pct.py
@@ -77,8 +77,9 @@
 # Note that in the (S)VGP case, $\alpha$ is the parameter as proposed by Opper and Archambeau for the mean of the predictive distribution.
 
 # +
-import gpflow
 import numpy as np
+
+import gpflow
 from gpflow.ci_utils import reduce_in_tests
 
 # Create some data
@@ -140,7 +141,9 @@ posterior.predict_f(Xnew)
 #
 # And finally, we follow the same approach this time for the SGPR case.
 
-model = gpflow.models.SGPR((X, Y), gpflow.kernels.SquaredExponential(), inducing_points)
+model = gpflow.models.SGPR(
+    (X, Y), gpflow.kernels.SquaredExponential(), inducing_points
+)
 
 # The predict_f method on the instance performs no caching.
 

--- a/doc/sphinx/notebooks/advanced/gps_for_big_data.pct.py
+++ b/doc/sphinx/notebooks/advanced/gps_for_big_data.pct.py
@@ -22,11 +22,13 @@
 # %%
 # %matplotlib inline
 import itertools
-import numpy as np
 import time
-import gpflow
-import tensorflow as tf
+
 import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+
+import gpflow
 from gpflow.ci_utils import reduce_in_tests
 
 plt.style.use("ggplot")
@@ -44,7 +46,11 @@ tf.random.set_seed(42)
 
 # %%
 def func(x):
-    return np.sin(x * 3 * 3.14) + 0.3 * np.cos(x * 9 * 3.14) + 0.5 * np.sin(x * 7 * 3.14)
+    return (
+        np.sin(x * 3 * 3.14)
+        + 0.3 * np.cos(x * 9 * 3.14)
+        + 0.5 * np.sin(x * 7 * 3.14)
+    )
 
 
 N = 10000  # Number of training observations
@@ -70,7 +76,9 @@ _ = plt.plot(Xt, Yt, c="k")
 M = 50  # Number of inducing locations
 
 kernel = gpflow.kernels.SquaredExponential()
-Z = X[:M, :].copy()  # Initialize inducing locations to the first M inputs in the dataset
+Z = X[
+    :M, :
+].copy()  # Initialize inducing locations to the first M inputs in the dataset
 
 m = gpflow.models.SVGP(kernel, gpflow.likelihoods.Gaussian(), Z, num_data=N)
 
@@ -111,7 +119,9 @@ elbo(next(train_iter))
 # The minibatch estimate should be an unbiased estimator of the `ground_truth`. Here we show a histogram of the value from different evaluations, together with its mean and the ground truth. The small difference between the mean of the minibatch estimations and the ground truth shows that the minibatch estimator is working as expected.
 
 # %%
-evals = [elbo(minibatch).numpy() for minibatch in itertools.islice(train_iter, 100)]
+evals = [
+    elbo(minibatch).numpy() for minibatch in itertools.islice(train_iter, 100)
+]
 
 # %%
 plt.hist(evals, label="Minibatch estimations")
@@ -119,7 +129,10 @@ plt.axvline(ground_truth, c="k", label="Ground truth")
 plt.axvline(np.mean(evals), c="g", ls="--", label="Minibatch mean")
 plt.legend()
 plt.title("Histogram of ELBO evaluations using minibatches")
-print("Discrepancy between ground truth and minibatch estimate:", ground_truth - np.mean(evals))
+print(
+    "Discrepancy between ground truth and minibatch estimate:",
+    ground_truth - np.mean(evals),
+)
 
 # %% [markdown]
 # ### Minibatches speed up computation
@@ -134,7 +147,9 @@ for mbp in minibatch_proportions:
     batchsize = int(N * mbp)
     train_iter = iter(train_dataset.batch(batchsize))
     start_time = time.time()
-    objs.append([elbo(minibatch) for minibatch in itertools.islice(train_iter, 20)])
+    objs.append(
+        [elbo(minibatch) for minibatch in itertools.islice(train_iter, 20)]
+    )
     times.append(time.time() - start_time)
 
 # %%

--- a/doc/sphinx/notebooks/advanced/heteroskedastic.pct.py
+++ b/doc/sphinx/notebooks/advanced/heteroskedastic.pct.py
@@ -39,8 +39,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
-import gpflow as gpf
 
+import gpflow as gpf
 
 # %% [markdown]
 # ## Data Generation

--- a/doc/sphinx/notebooks/advanced/kernels.pct.py
+++ b/doc/sphinx/notebooks/advanced/kernels.pct.py
@@ -20,15 +20,13 @@
 # GPflow comes with a range of kernels. In this notebook, we examine some of them, show how you can combine them to make new kernels, and discuss the `active_dims` feature.
 
 # %%
-import gpflow
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
-plt.style.use("ggplot")
-import tensorflow as tf
-
+import gpflow
 from gpflow.ci_utils import reduce_in_tests
 
+plt.style.use("ggplot")
 # %matplotlib inline
 
 # %% [markdown]
@@ -90,7 +88,9 @@ plotkernelsample(gpflow.kernels.RBF(), axes[0, 3])
 plotkernelsample(gpflow.kernels.Constant(), axes[1, 0])
 plotkernelsample(gpflow.kernels.Linear(), axes[1, 1])
 plotkernelsample(gpflow.kernels.Cosine(), axes[1, 2])
-plotkernelsample(gpflow.kernels.Periodic(gpflow.kernels.SquaredExponential()), axes[1, 3])
+plotkernelsample(
+    gpflow.kernels.Periodic(gpflow.kernels.SquaredExponential()), axes[1, 3]
+)
 _ = axes[0, 0].set_ylim(-3, 3)
 
 # %% [markdown]
@@ -131,7 +131,9 @@ X1 = np.array([[0.0]])
 X2 = np.linspace(-2, 2, 101).reshape(-1, 1)
 
 K21 = k(X2, X1)  # cov(f(X2), f(X1)): matrix with shape [101, 1]
-K22 = k(X2)  # equivalent to k(X2, X2) (but more efficient): matrix with shape [101, 101]
+K22 = k(
+    X2
+)  # equivalent to k(X2, X2) (but more efficient): matrix with shape [101, 101]
 
 # plotting
 plt.figure()
@@ -194,9 +196,9 @@ k = k1 + k2
 # `active_dims` makes it easy to create additive models. Here we build an additive Matern 5/2 kernel:
 
 # %%
-k = gpflow.kernels.Matern52(active_dims=[0], lengthscales=2) + gpflow.kernels.Matern52(
-    active_dims=[1], lengthscales=2
-)
+k = gpflow.kernels.Matern52(
+    active_dims=[0], lengthscales=2
+) + gpflow.kernels.Matern52(active_dims=[1], lengthscales=2)
 
 # %% [markdown]
 # Let's plot this kernel and sample from it:

--- a/doc/sphinx/notebooks/advanced/mcmc.pct.py
+++ b/doc/sphinx/notebooks/advanced/mcmc.pct.py
@@ -20,16 +20,16 @@
 # GPflow allows you to approximate the posterior over the latent functions of its models (and over the hyperparameters after setting a prior for those) using Hamiltonian Monte Carlo (HMC)
 
 # %%
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
+from multiclass_classification import colors, plot_from_samples
 from tensorflow_probability import distributions as tfd
 
 import gpflow
-from gpflow.ci_utils import reduce_in_tests
 from gpflow import set_trainable
-from multiclass_classification import plot_from_samples, colors
+from gpflow.ci_utils import reduce_in_tests
 
 gpflow.config.set_default_float(np.float64)
 gpflow.config.set_default_jitter(1e-4)
@@ -140,10 +140,15 @@ hmc_helper = gpflow.optimizers.SamplingHelper(
 )
 
 hmc = tfp.mcmc.HamiltonianMonteCarlo(
-    target_log_prob_fn=hmc_helper.target_log_prob_fn, num_leapfrog_steps=10, step_size=0.01
+    target_log_prob_fn=hmc_helper.target_log_prob_fn,
+    num_leapfrog_steps=10,
+    step_size=0.01,
 )
 adaptive_hmc = tfp.mcmc.SimpleStepSizeAdaptation(
-    hmc, num_adaptation_steps=10, target_accept_prob=f64(0.75), adaptation_rate=0.1
+    hmc,
+    num_adaptation_steps=10,
+    target_accept_prob=f64(0.75),
+    adaptation_rate=0.1,
 )
 
 
@@ -161,7 +166,10 @@ def run_chain_fn():
 samples, traces = run_chain_fn()
 parameter_samples = hmc_helper.convert_to_constrained_values(samples)
 
-param_to_name = {param: name for name, param in gpflow.utilities.parameter_dict(model).items()}
+param_to_name = {
+    param: name
+    for name, param in gpflow.utilities.parameter_dict(model).items()
+}
 
 
 # %% [markdown]
@@ -181,7 +189,11 @@ def plot_samples(samples, parameters, y_axis_label):
 
 
 plot_samples(samples, model.trainable_parameters, "unconstrained values")
-plot_samples(parameter_samples, model.trainable_parameters, "constrained parameter values")
+plot_samples(
+    parameter_samples,
+    model.trainable_parameters,
+    "constrained parameter values",
+)
 
 
 # %% [markdown]
@@ -189,7 +201,9 @@ plot_samples(parameter_samples, model.trainable_parameters, "constrained paramet
 
 # %%
 def marginal_samples(samples, parameters, y_axis_label):
-    fig, axes = plt.subplots(1, len(param_to_name), figsize=(15, 3), constrained_layout=True)
+    fig, axes = plt.subplots(
+        1, len(param_to_name), figsize=(15, 3), constrained_layout=True
+    )
     for ax, val, param in zip(axes, samples, parameters):
         ax.hist(np.stack(val).flatten(), bins=20)
         ax.set_title(param_to_name[param])
@@ -197,8 +211,14 @@ def marginal_samples(samples, parameters, y_axis_label):
     plt.show()
 
 
-marginal_samples(samples, model.trainable_parameters, "unconstrained variable samples")
-marginal_samples(parameter_samples, model.trainable_parameters, "constrained parameter samples")
+marginal_samples(
+    samples, model.trainable_parameters, "unconstrained variable samples"
+)
+marginal_samples(
+    parameter_samples,
+    model.trainable_parameters,
+    "constrained parameter samples",
+)
 
 
 # %% [markdown]
@@ -211,7 +231,9 @@ marginal_samples(parameter_samples, model.trainable_parameters, "constrained par
 
 # %%
 def plot_joint_marginals(samples, parameters, y_axis_label):
-    name_to_index = {param_to_name[param]: i for i, param in enumerate(parameters)}
+    name_to_index = {
+        param_to_name[param]: i for i, param in enumerate(parameters)
+    }
     f, axs = plt.subplots(1, 3, figsize=(12, 4), constrained_layout=True)
 
     axs[0].plot(
@@ -244,8 +266,12 @@ def plot_joint_marginals(samples, parameters, y_axis_label):
     plt.show()
 
 
-plot_joint_marginals(samples, model.trainable_parameters, "unconstrained variable samples")
-plot_joint_marginals(parameter_samples, model.trainable_parameters, "parameter samples")
+plot_joint_marginals(
+    samples, model.trainable_parameters, "unconstrained variable samples"
+)
+plot_joint_marginals(
+    parameter_samples, model.trainable_parameters, "parameter samples"
+)
 
 
 # %% [markdown]
@@ -323,7 +349,9 @@ plt.show()
 # We then build the SGPMC model.
 
 # %%
-kernel = gpflow.kernels.Matern32(lengthscales=0.1) + gpflow.kernels.White(variance=0.01)
+kernel = gpflow.kernels.Matern32(lengthscales=0.1) + gpflow.kernels.White(
+    variance=0.01
+)
 
 model = gpflow.models.SGPMC(
     data,
@@ -347,7 +375,9 @@ set_trainable(model.inducing_variable, False)
 
 # %%
 optimizer = gpflow.optimizers.Scipy()
-optimizer.minimize(model.training_loss, model.trainable_variables, options={"maxiter": 20})
+optimizer.minimize(
+    model.training_loss, model.trainable_variables, options={"maxiter": 20}
+)
 print(f"log posterior density at optimum: {model.log_posterior_density()}")
 
 # %% [markdown]
@@ -363,11 +393,16 @@ hmc_helper = gpflow.optimizers.SamplingHelper(
 )
 
 hmc = tfp.mcmc.HamiltonianMonteCarlo(
-    target_log_prob_fn=hmc_helper.target_log_prob_fn, num_leapfrog_steps=10, step_size=0.01
+    target_log_prob_fn=hmc_helper.target_log_prob_fn,
+    num_leapfrog_steps=10,
+    step_size=0.01,
 )
 
 adaptive_hmc = tfp.mcmc.SimpleStepSizeAdaptation(
-    hmc, num_adaptation_steps=10, target_accept_prob=f64(0.75), adaptation_rate=0.1
+    hmc,
+    num_adaptation_steps=10,
+    target_accept_prob=f64(0.75),
+    adaptation_rate=0.1,
 )
 
 
@@ -389,15 +424,26 @@ constrained_samples = hmc_helper.convert_to_constrained_values(samples)
 # Statistics of the posterior samples can now be reported.
 
 # %%
-plot_from_samples(model, X, Y, model.trainable_parameters, constrained_samples, thin=10)
+plot_from_samples(
+    model, X, Y, model.trainable_parameters, constrained_samples, thin=10
+)
 
 # %% [markdown]
 # You can also display the sequence of sampled hyperparameters.
 
 # %%
-param_to_name = {param: name for name, param in gpflow.utilities.parameter_dict(model).items()}
-name_to_index = {param_to_name[param]: i for i, param in enumerate(model.trainable_parameters)}
-hyperparameters = [".kernel.kernels[0].lengthscales", ".kernel.kernels[0].variance"]
+param_to_name = {
+    param: name
+    for name, param in gpflow.utilities.parameter_dict(model).items()
+}
+name_to_index = {
+    param_to_name[param]: i
+    for i, param in enumerate(model.trainable_parameters)
+}
+hyperparameters = [
+    ".kernel.kernels[0].lengthscales",
+    ".kernel.kernels[0].variance",
+]
 
 plt.figure(figsize=(8, 4))
 for param_name in hyperparameters:
@@ -487,7 +533,9 @@ gpflow.utilities.print_summary(model)
 optimizer = gpflow.optimizers.Scipy()
 maxiter = reduce_in_tests(3000)
 _ = optimizer.minimize(
-    model.training_loss, model.trainable_variables, options=dict(maxiter=maxiter)
+    model.training_loss,
+    model.trainable_variables,
+    options=dict(maxiter=maxiter),
 )
 # We can now start HMC near maximum a posteriori (MAP)
 
@@ -504,11 +552,16 @@ hmc_helper = gpflow.optimizers.SamplingHelper(
 )
 
 hmc = tfp.mcmc.HamiltonianMonteCarlo(
-    target_log_prob_fn=hmc_helper.target_log_prob_fn, num_leapfrog_steps=10, step_size=0.01
+    target_log_prob_fn=hmc_helper.target_log_prob_fn,
+    num_leapfrog_steps=10,
+    step_size=0.01,
 )
 
 adaptive_hmc = tfp.mcmc.SimpleStepSizeAdaptation(
-    hmc, num_adaptation_steps=10, target_accept_prob=f64(0.75), adaptation_rate=0.1
+    hmc,
+    num_adaptation_steps=10,
+    target_accept_prob=f64(0.75),
+    adaptation_rate=0.1,
 )
 
 
@@ -560,8 +613,14 @@ _ = plt.ylim(-0.1, np.max(np.percentile(rate_samples, 95, axis=0)))
 
 # %%
 parameter_samples = hmc_helper.convert_to_constrained_values(samples)
-param_to_name = {param: name for name, param in gpflow.utilities.parameter_dict(model).items()}
-name_to_index = {param_to_name[param]: i for i, param in enumerate(model.trainable_parameters)}
+param_to_name = {
+    param: name
+    for name, param in gpflow.utilities.parameter_dict(model).items()
+}
+name_to_index = {
+    param_to_name[param]: i
+    for i, param in enumerate(model.trainable_parameters)
+}
 hyperparameters = [
     ".kernel.kernels[0].lengthscales",
     ".kernel.kernels[0].variance",
@@ -654,10 +713,15 @@ hmc_helper = gpflow.optimizers.SamplingHelper(
 )
 
 hmc = tfp.mcmc.HamiltonianMonteCarlo(
-    target_log_prob_fn=hmc_helper.target_log_prob_fn, num_leapfrog_steps=10, step_size=0.01
+    target_log_prob_fn=hmc_helper.target_log_prob_fn,
+    num_leapfrog_steps=10,
+    step_size=0.01,
 )
 adaptive_hmc = tfp.mcmc.SimpleStepSizeAdaptation(
-    hmc, num_adaptation_steps=10, target_accept_prob=f64(0.75), adaptation_rate=0.1
+    hmc,
+    num_adaptation_steps=10,
+    target_accept_prob=f64(0.75),
+    adaptation_rate=0.1,
 )
 
 
@@ -675,6 +739,15 @@ def run_chain_fn_unconstrained():
 samples, traces = run_chain_fn_unconstrained()
 parameter_samples = hmc_helper.convert_to_constrained_values(samples)
 
-param_to_name = {param: name for name, param in gpflow.utilities.parameter_dict(model).items()}
-marginal_samples(samples, model.trainable_parameters, "unconstrained variable samples")
-marginal_samples(parameter_samples, model.trainable_parameters, "constrained parameter samples")
+param_to_name = {
+    param: name
+    for name, param in gpflow.utilities.parameter_dict(model).items()
+}
+marginal_samples(
+    samples, model.trainable_parameters, "unconstrained variable samples"
+)
+marginal_samples(
+    parameter_samples,
+    model.trainable_parameters,
+    "constrained parameter samples",
+)

--- a/doc/sphinx/notebooks/advanced/multiclass_classification.pct.py
+++ b/doc/sphinx/notebooks/advanced/multiclass_classification.pct.py
@@ -44,23 +44,21 @@
 #
 
 # %%
-import numpy as np
-import tensorflow as tf
-
 import warnings
 
 warnings.filterwarnings("ignore")  # ignore DeprecationWarnings from tensorflow
 
 import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+from multiclass_classification import colors, plot_posterior_predictions
+
+import gpflow
+from gpflow.ci_utils import reduce_in_tests
+from gpflow.utilities import print_summary, set_trainable
 
 # %matplotlib inline
 
-import gpflow
-
-from gpflow.utilities import print_summary, set_trainable
-from gpflow.ci_utils import reduce_in_tests
-
-from multiclass_classification import plot_posterior_predictions, colors
 
 # reproducibility:
 np.random.seed(0)
@@ -149,7 +147,9 @@ kernel = gpflow.kernels.Matern32() + gpflow.kernels.White(variance=0.01)
 
 # Robustmax Multiclass Likelihood
 invlink = gpflow.likelihoods.RobustMax(C)  # Robustmax inverse link function
-likelihood = gpflow.likelihoods.MultiClass(3, invlink=invlink)  # Multiclass likelihood
+likelihood = gpflow.likelihoods.MultiClass(
+    3, invlink=invlink
+)  # Multiclass likelihood
 Z = X[::5].copy()  # inducing inputs
 
 m = gpflow.models.SVGP(

--- a/doc/sphinx/notebooks/advanced/multiclass_classification.py
+++ b/doc/sphinx/notebooks/advanced/multiclass_classification.py
@@ -4,7 +4,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-
 colors = ["#1f77b4", "#ff7f0e", "#2ca02c"]
 
 

--- a/doc/sphinx/notebooks/advanced/multioutput.pct.py
+++ b/doc/sphinx/notebooks/advanced/multioutput.pct.py
@@ -89,13 +89,12 @@
 # - $f_{1..P}$, $P$ are correlated  $\GP$s  with $\vf = \vW \vg$
 
 # %%
-import numpy as np
 import matplotlib.pyplot as plt
-import gpflow as gpf
-import tensorflow as tf
+import numpy as np
 
-from gpflow.utilities import print_summary
+import gpflow as gpf
 from gpflow.ci_utils import reduce_in_tests
+from gpflow.utilities import print_summary
 
 gpf.config.set_default_float(np.float64)
 gpf.config.set_default_summary_fmt("notebook")
@@ -180,7 +179,9 @@ iv = gpf.inducing_variables.SharedIndependentInducingVariables(
 
 # %%
 # create SVGP model as usual and optimize
-m = gpf.models.SVGP(kernel, gpf.likelihoods.Gaussian(), inducing_variable=iv, num_latent_gps=P)
+m = gpf.models.SVGP(
+    kernel, gpf.likelihoods.Gaussian(), inducing_variable=iv, num_latent_gps=P
+)
 print_summary(m)
 
 
@@ -214,7 +215,9 @@ m.kernel.kernel.kernels[0].lengthscales
 
 # %%
 # Create list of kernels for each output
-kern_list = [gpf.kernels.SquaredExponential() + gpf.kernels.Linear() for _ in range(P)]
+kern_list = [
+    gpf.kernels.SquaredExponential() + gpf.kernels.Linear() for _ in range(P)
+]
 # Create multi-output kernel from kernel list
 kernel = gpf.kernels.SeparateIndependent(kern_list)
 # initialization of inducing input locations (M random points from the training inputs)
@@ -226,7 +229,9 @@ iv = gpf.inducing_variables.SharedIndependentInducingVariables(
 
 # %%
 # create SVGP model as usual and optimize
-m = gpf.models.SVGP(kernel, gpf.likelihoods.Gaussian(), inducing_variable=iv, num_latent_gps=P)
+m = gpf.models.SVGP(
+    kernel, gpf.likelihoods.Gaussian(), inducing_variable=iv, num_latent_gps=P
+)
 
 # %%
 optimize_model_with_scipy(m)
@@ -246,7 +251,9 @@ plot_model(m)
 
 # %%
 # Create list of kernels for each output
-kern_list = [gpf.kernels.SquaredExponential() + gpf.kernels.Linear() for _ in range(P)]
+kern_list = [
+    gpf.kernels.SquaredExponential() + gpf.kernels.Linear() for _ in range(P)
+]
 # Create multi-output kernel from kernel list
 kernel = gpf.kernels.SeparateIndependent(kern_list)
 # initialization of inducing input locations, one set of locations per output
@@ -261,7 +268,9 @@ iv = gpf.inducing_variables.SeparateIndependentInducingVariables(iv_list)
 
 # %%
 # create SVGP model as usual and optimize
-m = gpf.models.SVGP(kernel, gpf.likelihoods.Gaussian(), inducing_variable=iv, num_latent_gps=P)
+m = gpf.models.SVGP(
+    kernel, gpf.likelihoods.Gaussian(), inducing_variable=iv, num_latent_gps=P
+)
 
 # %%
 optimize_model_with_scipy(m)
@@ -274,7 +283,9 @@ plot_model(m)
 
 # %%
 for i in range(len(m.inducing_variable.inducing_variable_list)):
-    q_mu_unwhitened, q_var_unwhitened = m.predict_f(m.inducing_variable.inducing_variable_list[i].Z)
+    q_mu_unwhitened, q_var_unwhitened = m.predict_f(
+        m.inducing_variable.inducing_variable_list[i].Z
+    )
     plt.plot(
         m.inducing_variable.inducing_variable_list[i].Z.numpy(),
         q_mu_unwhitened[:, i, None].numpy(),
@@ -300,7 +311,9 @@ m.inducing_variable.inducing_variable_list
 
 # %%
 # Create list of kernels for each output
-kern_list = [gpf.kernels.SquaredExponential() + gpf.kernels.Linear() for _ in range(L)]
+kern_list = [
+    gpf.kernels.SquaredExponential() + gpf.kernels.Linear() for _ in range(L)
+]
 # Create multi-output kernel from kernel list
 kernel = gpf.kernels.LinearCoregionalization(
     kern_list, W=np.random.randn(P, L)
@@ -320,7 +333,11 @@ q_sqrt = np.repeat(np.eye(M)[None, ...], L, axis=0) * 1.0
 
 # create SVGP model as usual and optimize
 m = gpf.models.SVGP(
-    kernel, gpf.likelihoods.Gaussian(), inducing_variable=iv, q_mu=q_mu, q_sqrt=q_sqrt
+    kernel,
+    gpf.likelihoods.Gaussian(),
+    inducing_variable=iv,
+    q_mu=q_mu,
+    q_sqrt=q_sqrt,
 )
 
 # %%
@@ -407,16 +424,20 @@ def inspect_conditional(inducing_variable_type, kernel_type):
         implementation.
     """
     import inspect
+
     from gpflow.conditionals import conditional
 
-    implementation = conditional.dispatch(object, inducing_variable_type, kernel_type, object)
+    implementation = conditional.dispatch(
+        object, inducing_variable_type, kernel_type, object
+    )
     info = dict(inspect.getmembers(implementation))
     return info["__code__"]
 
 
 # Example:
 inspect_conditional(
-    gpf.inducing_variables.SharedIndependentInducingVariables, gpf.kernels.SharedIndependent
+    gpf.inducing_variables.SharedIndependentInducingVariables,
+    gpf.kernels.SharedIndependent,
 )
 
 # %% [markdown]

--- a/doc/sphinx/notebooks/advanced/ordinal_regression.pct.py
+++ b/doc/sphinx/notebooks/advanced/ordinal_regression.pct.py
@@ -19,11 +19,10 @@
 # Ordinal regression aims to fit a model to some data $(X, Y)$, where $Y$ is an ordinal variable. To do so, we use a `VPG` model with a specific likelihood (`gpflow.likelihoods.Ordinal`).
 
 # %%
-import gpflow
-
-import tensorflow as tf
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+
+import gpflow
 
 # %matplotlib inline
 plt.rcParams["figure.figsize"] = (12, 6)
@@ -45,7 +44,9 @@ def generate_data(num_data):
     # Now generate values of a latent GP
     kern = gpflow.kernels.SquaredExponential(lengthscales=0.1)
     K = kern(X)
-    f = np.random.multivariate_normal(mean=np.zeros(num_data), cov=K).reshape(-1, 1)
+    f = np.random.multivariate_normal(mean=np.zeros(num_data), cov=K).reshape(
+        -1, 1
+    )
 
     # Finally convert f values into ordinal values Y
     Y = np.round((f + f.min()) * 3)
@@ -74,7 +75,9 @@ bin_edges = bin_edges - bin_edges.mean()
 likelihood = gpflow.likelihoods.Ordinal(bin_edges)
 
 # build a model with this likelihood
-m = gpflow.models.VGP(data=(X, Y), kernel=gpflow.kernels.Matern32(), likelihood=likelihood)
+m = gpflow.models.VGP(
+    data=(X, Y), kernel=gpflow.kernels.Matern32(), likelihood=likelihood
+)
 
 # fit the model
 opt = gpflow.optimizers.Scipy()

--- a/doc/sphinx/notebooks/advanced/variational_fourier_features.pct.py
+++ b/doc/sphinx/notebooks/advanced/variational_fourier_features.pct.py
@@ -24,16 +24,17 @@
 # We cannot directly use Fourier features within the multi-output framework without losing the computational advantages, as `Kuu` and `Kuf` for SharedIndependent and SeparateIndependent inducing variables assume that the sub-inducing variable's covariances are simply computed as dense Tensors. However, there is nothing preventing a dedicated implementation of multi-output Fourier features that is computationally more efficient - feel free to discuss this within [the GPflow community](https://github.com/GPflow/GPflow/#the-gpflow-community)!
 
 # %%
-import tensorflow as tf
 import numpy as np
+import tensorflow as tf
+
 import gpflow
-from gpflow.inducing_variables import InducingVariables
-from gpflow.base import TensorLike
-from gpflow.utilities import to_default_float
 from gpflow import covariances as cov
 from gpflow import kullback_leiblers as kl
+from gpflow.base import TensorLike
 from gpflow.ci_utils import reduce_in_tests
 from gpflow.experimental.check_shapes import Shape
+from gpflow.inducing_variables import InducingVariables
+from gpflow.utilities import to_default_float
 
 # %%
 # VFF give structured covariance matrices that are computationally efficient.
@@ -90,15 +91,27 @@ def Kuu_matern12_fourierfeatures1d(inducing_variable, kernel, jitter=None):
     lamb = 1.0 / kernel.lengthscales
     two_or_four = to_default_float(tf.where(omegas == 0, 2.0, 4.0))
     d_cos = (
-        (b - a) * (tf.square(lamb) + tf.square(omegas)) / lamb / kernel.variance / two_or_four
+        (b - a)
+        * (tf.square(lamb) + tf.square(omegas))
+        / lamb
+        / kernel.variance
+        / two_or_four
     )  # eq. (111)
     v_cos = tf.ones_like(d_cos) / tf.sqrt(kernel.variance)  # eq. (110)
-    cosine_block = LowRank(Diag(d_cos, is_positive_definite=True), v_cos[:, None])
+    cosine_block = LowRank(
+        Diag(d_cos, is_positive_definite=True), v_cos[:, None]
+    )
 
     # Sine block:
-    omegas = omegas[tf.not_equal(omegas, 0)]  # the sine block does not include omega=0
+    omegas = omegas[
+        tf.not_equal(omegas, 0)
+    ]  # the sine block does not include omega=0
     d_sin = (
-        (b - a) * (tf.square(lamb) + tf.square(omegas)) / lamb / kernel.variance / 4.0
+        (b - a)
+        * (tf.square(lamb) + tf.square(omegas))
+        / lamb
+        / kernel.variance
+        / 4.0
     )  # eq. (113)
     sine_block = Diag(d_sin, is_positive_definite=True)
 
@@ -116,7 +129,9 @@ def Kuf_matern12_fourierfeatures1d(inducing_variable, kernel, X):
     Kuf_sin = tf.sin(omegas_sin[:, None] * (X[None, :] - a))
 
     # correct Kuf outside [a, b] -- see Table 1
-    Kuf_sin = tf.where((X < a) | (X > b), tf.zeros_like(Kuf_sin), Kuf_sin)  # just zero
+    Kuf_sin = tf.where(
+        (X < a) | (X > b), tf.zeros_like(Kuf_sin), Kuf_sin
+    )  # just zero
 
     left_tail = tf.exp(-tf.abs(X - a) / kernel.lengthscales)[None, :]
     right_tail = tf.exp(-tf.abs(X - b) / kernel.lengthscales)[None, :]
@@ -142,7 +157,9 @@ def Kuu_matern32_fourierfeatures1d(inducing_variable, kernel, jitter=None):
         / four_or_eight
     )
     v_cos = tf.ones_like(d_cos) / tf.sqrt(kernel.variance)
-    cosine_block = LowRank(Diag(d_cos, is_positive_definite=True), v_cos[:, None])
+    cosine_block = LowRank(
+        Diag(d_cos, is_positive_definite=True), v_cos[:, None]
+    )
 
     # Sine block: eq. (115)
     omegas = omegas[tf.not_equal(omegas, 0)]  # don't compute omega=0
@@ -192,7 +209,9 @@ def Kuf_matern32_fourierfeatures1d(inducing_variable, kernel, X):
 # In principle, this is all we need; however, to be able to take advantage of the structure of `Kuu`, we need to also implement new versions of the KL divergence from the prior to the approximate posterior (`prior_kl`) and the computation of the Gaussian process conditional (posterior) equations:
 
 # %%
-@kl.prior_kl.register(FourierFeatures1D, gpflow.kernels.Kernel, TensorLike, TensorLike)
+@kl.prior_kl.register(
+    FourierFeatures1D, gpflow.kernels.Kernel, TensorLike, TensorLike
+)
 def prior_kl_vff(inducing_variable, kernel, q_mu, q_sqrt, whiten=False):
     if whiten:
         raise NotImplementedError
@@ -229,7 +248,9 @@ def gauss_kl_vff(q_mu, q_sqrt, K):
     num_latent_gps = to_default_float(tf.shape(q_mu)[1])
     logdet_prior = num_latent_gps * K.log_abs_determinant()
 
-    product_of_dimensions__int = tf.reduce_prod(tf.shape(q_sqrt)[:-1])  # dimensions are integers
+    product_of_dimensions__int = tf.reduce_prod(
+        tf.shape(q_sqrt)[:-1]
+    )  # dimensions are integers
     constant_term = to_default_float(product_of_dimensions__int)
 
     Lq = tf.linalg.band_part(q_sqrt, -1, 0)  # force lower triangle
@@ -241,7 +262,9 @@ def gauss_kl_vff(q_mu, q_sqrt, K):
         tf.reduce_sum(Lq * K.solve(Lq), axis=[-1, -2])
     )  # [O(N²) instead of O(N³)
 
-    twoKL = trace_term + mahalanobis_term - constant_term + logdet_prior - logdet_q
+    twoKL = (
+        trace_term + mahalanobis_term - constant_term + logdet_prior - logdet_q
+    )
     return 0.5 * twoKL
 
 
@@ -270,7 +293,9 @@ class VFFPosterior(gpflow.posteriors.BasePosterior):
 
         # compute the covariance due to the conditioning
         if full_cov:
-            fvar = self.kernel(Xnew) - tf.matmul(Kuf, KuuInv_Kuf, transpose_a=True)
+            fvar = self.kernel(Xnew) - tf.matmul(
+                Kuf, KuuInv_Kuf, transpose_a=True
+            )
             shape = (num_func, 1, 1)
         else:
             KufT_KuuInv_Kuf_diag = tf.reduce_sum(Kuf * KuuInv_Kuf, axis=-2)
@@ -305,7 +330,10 @@ class VFFPosterior(gpflow.posteriors.BasePosterior):
                 # LTA = (A.T @ DenseMatrix(q_sqrt[:,:,0])).T.get()[None, :, :]
                 ATL = tf.matmul(A, q_sqrt, transpose_a=True)
             else:
-                raise ValueError("Bad dimension for q_sqrt: %s" % str(q_sqrt.get_shape().ndims))
+                raise ValueError(
+                    "Bad dimension for q_sqrt: %s"
+                    % str(q_sqrt.get_shape().ndims)
+                )
             if full_cov:
                 # fvar = fvar + tf.matmul(LTA, LTA, transpose_a=True)  # K x N x N
                 fvar = fvar + tf.matmul(ATL, ATL, transpose_b=True)  # K x N x N
@@ -338,13 +366,17 @@ class VFFPosterior(gpflow.posteriors.BasePosterior):
         else:
             # Qinv = Kuu⁻¹ - Kuu⁻¹ S Kuu⁻¹
             KuuInv_qsqrt = Kuu.solve(q_sqrt)
-            KuuInv_covu_KuuInv = tf.matmul(KuuInv_qsqrt, KuuInv_qsqrt, transpose_b=True)
+            KuuInv_covu_KuuInv = tf.matmul(
+                KuuInv_qsqrt, KuuInv_qsqrt, transpose_b=True
+            )
 
         Qinv = Kuu.inverse().to_dense() - KuuInv_covu_KuuInv
 
         return gpflow.posteriors.PrecomputedValue.wrap_alpha_Qinv(alpha, Qinv)
 
-    def _conditional_with_precompute(self, cache, Xnew, full_cov, full_output_cov):
+    def _conditional_with_precompute(
+        self, cache, Xnew, full_cov, full_output_cov
+    ):
         alpha, Qinv = cache
 
         if full_output_cov:
@@ -360,7 +392,9 @@ class VFFPosterior(gpflow.posteriors.BasePosterior):
 
         # compute the covariance due to the conditioning
         if full_cov:
-            fvar = self.kernel(Xnew) - tf.matmul(Kuf, Qinv_Kuf, transpose_a=True)
+            fvar = self.kernel(Xnew) - tf.matmul(
+                Kuf, Qinv_Kuf, transpose_a=True
+            )
         else:
             KufT_Qinv_Kuf_diag = tf.reduce_sum(Kuf * Qinv_Kuf, axis=-2)
             fvar = self.kernel(Xnew, full_cov=False) - KufT_Qinv_Kuf_diag
@@ -373,7 +407,9 @@ class VFFPosterior(gpflow.posteriors.BasePosterior):
 # We now have to register our Posterior object:
 
 # %%
-@gpflow.posteriors.get_posterior_class.register(gpflow.kernels.Kernel, FourierFeatures1D)
+@gpflow.posteriors.get_posterior_class.register(
+    gpflow.kernels.Kernel, FourierFeatures1D
+)
 def _get_posterior_vff(kernel, inducing_variable):
     return VFFPosterior
 
@@ -392,11 +428,21 @@ f = np.random.randn(M, 1)
 q_sqrt = tf.convert_to_tensor(np.tril(np.random.randn(1, M, M)))
 
 conditional_f_mean, conditional_f_var = gpflow.conditionals.conditional(
-    Xnew, inducing_variable, kernel, f, q_sqrt=q_sqrt, white=False, full_cov=True
+    Xnew,
+    inducing_variable,
+    kernel,
+    f,
+    q_sqrt=q_sqrt,
+    white=False,
+    full_cov=True,
 )
 
-posterior = VFFPosterior(kernel, inducing_variable, f, q_sqrt, whiten=False, precompute_cache=None)
-posterior_f_mean, posterior_f_var = posterior.fused_predict_f(Xnew, full_cov=True)
+posterior = VFFPosterior(
+    kernel, inducing_variable, f, q_sqrt, whiten=False, precompute_cache=None
+)
+posterior_f_mean, posterior_f_var = posterior.fused_predict_f(
+    Xnew, full_cov=True
+)
 
 np.testing.assert_array_equal(conditional_f_mean, posterior_f_mean)
 np.testing.assert_array_equal(conditional_f_var, posterior_f_var)
@@ -407,7 +453,9 @@ np.testing.assert_array_equal(conditional_f_var, posterior_f_var)
 
 # %%
 posterior.update_cache(gpflow.posteriors.PrecomputeCacheType.TENSOR)
-precomputed_posterior_f_mean, precomputed_posterior_f_var = posterior.predict_f(Xnew, full_cov=True)
+precomputed_posterior_f_mean, precomputed_posterior_f_var = posterior.predict_f(
+    Xnew, full_cov=True
+)
 
 np.testing.assert_allclose(precomputed_posterior_f_mean, posterior_f_mean)
 np.testing.assert_allclose(precomputed_posterior_f_var, posterior_f_var)
@@ -453,7 +501,9 @@ m = gpflow.models.SVGP(
 )
 gpflow.set_trainable(m.kernel, False)
 gpflow.set_trainable(m.likelihood, False)
-gpflow.set_trainable(m.inducing_variable, True)  # whether to optimize bounds [a, b]
+gpflow.set_trainable(
+    m.inducing_variable, True
+)  # whether to optimize bounds [a, b]
 
 # %%
 opt = gpflow.optimizers.Scipy()
@@ -478,7 +528,9 @@ m_ip = gpflow.models.SVGP(
 )
 gpflow.set_trainable(m_ip.kernel, False)
 gpflow.set_trainable(m_ip.likelihood, False)
-gpflow.set_trainable(m_ip.inducing_variable, True)  # whether to optimize inducing point locations
+gpflow.set_trainable(
+    m_ip.inducing_variable, True
+)  # whether to optimize inducing point locations
 
 # %%
 opt = gpflow.optimizers.Scipy()
@@ -491,7 +543,9 @@ opt.minimize(
 gpflow.utilities.print_summary(m_ip, fmt="notebook")
 
 # %%
-m_ref = gpflow.models.GPR((X.reshape(-1, 1), Y.reshape(-1, 1)), kernel=gpflow.kernels.Matern32())
+m_ref = gpflow.models.GPR(
+    (X.reshape(-1, 1), Y.reshape(-1, 1)), kernel=gpflow.kernels.Matern32()
+)
 m_ref.likelihood.variance = np.array(noise_scale ** 2).astype(np.float64)
 gpflow.set_trainable(m_ref.kernel, False)
 gpflow.set_trainable(m_ref.likelihood, False)
@@ -515,7 +569,11 @@ def plot_gp(m, Xnew, name=""):
     Fvar = Fvar.numpy().squeeze()
     (p,) = plt.plot(Xnew, Fmean, label=name)
     plt.fill_between(
-        Xnew, Fmean - 2 * np.sqrt(Fvar), Fmean + 2 * np.sqrt(Fvar), alpha=0.3, color=p.get_color()
+        Xnew,
+        Fmean - 2 * np.sqrt(Fvar),
+        Fmean + 2 * np.sqrt(Fvar),
+        alpha=0.3,
+        color=p.get_color(),
     )
 
 

--- a/doc/sphinx/notebooks/advanced/varying_noise.pct.py
+++ b/doc/sphinx/notebooks/advanced/varying_noise.pct.py
@@ -90,7 +90,9 @@ def plot_distribution(
         mean_plot = mean_plot.squeeze(axis=-1)
         var_plot = var_plot.squeeze(axis=-1)
         lower_plot, upper_plot = get_confidence_bounds(mean_plot, var_plot)
-        plt.fill_between(X_plot, lower_plot, upper_plot, color="silver", alpha=0.25)
+        plt.fill_between(
+            X_plot, lower_plot, upper_plot, color="silver", alpha=0.25
+        )
         plt.plot(X_plot, lower_plot, color="silver")
         plt.plot(X_plot, upper_plot, color="silver")
         plt.plot(X_plot, mean_plot, color="black")
@@ -275,7 +277,9 @@ n_data = reduce_in_tests(20)
 n_repeats = reduce_in_tests(10)
 
 
-def generate_empiricial_noise_data() -> Tuple[gf.base.AnyNDArray, gf.base.AnyNDArray]:
+def generate_empiricial_noise_data() -> Tuple[
+    gf.base.AnyNDArray, gf.base.AnyNDArray
+]:
     rng = np.random.default_rng(42)  # for reproducibility
     X = rng.uniform(0.0, 1.0, (n_data, 1))
     signal = np.sin(6 * X)

--- a/doc/sphinx/notebooks/basics/GPLVM.pct.py
+++ b/doc/sphinx/notebooks/basics/GPLVM.pct.py
@@ -18,16 +18,18 @@
 # This notebook shows how to use the Bayesian GPLVM model. This is an unsupervised learning method usually used for dimensionality reduction. For an in-depth overview of GPLVMs,see **[1, 2]**.
 
 # %%
-import gpflow
-import numpy as np
-
 import matplotlib.pyplot as plt
+import numpy as np
 import tensorflow as tf
 
 import gpflow
-from gpflow.utilities import ops, print_summary
-from gpflow.config import set_default_float, default_float, set_default_summary_fmt
 from gpflow.ci_utils import reduce_in_tests
+from gpflow.config import (
+    default_float,
+    set_default_float,
+    set_default_summary_fmt,
+)
+from gpflow.utilities import ops, print_summary
 
 set_default_float(np.float64)
 set_default_summary_fmt("notebook")
@@ -54,7 +56,11 @@ Y = tf.convert_to_tensor(data["Y"], dtype=default_float())
 labels = tf.convert_to_tensor(data["labels"])
 
 # %%
-print("Number of points: {} and Number of dimensions: {}".format(Y.shape[0], Y.shape[1]))
+print(
+    "Number of points: {} and Number of dimensions: {}".format(
+        Y.shape[0], Y.shape[1]
+    )
+)
 
 # %% [markdown]
 # ## Model construction
@@ -79,7 +85,8 @@ X_var_init = tf.ones((num_data, latent_dim), dtype=default_float())
 # %%
 np.random.seed(1)  # for reproducibility
 inducing_variable = tf.convert_to_tensor(
-    np.random.permutation(X_mean_init.numpy())[:num_inducing], dtype=default_float()
+    np.random.permutation(X_mean_init.numpy())[:num_inducing],
+    dtype=default_float(),
 )
 
 # %% [markdown]
@@ -143,7 +150,9 @@ f, ax = plt.subplots(1, 2, figsize=(10, 6))
 
 for i in np.unique(labels):
     ax[0].scatter(X_pca[labels == i, 0], X_pca[labels == i, 1], label=i)
-    ax[1].scatter(gplvm_X_mean[labels == i, 0], gplvm_X_mean[labels == i, 1], label=i)
+    ax[1].scatter(
+        gplvm_X_mean[labels == i, 0], gplvm_X_mean[labels == i, 1], label=i
+    )
     ax[0].set_title("PCA")
     ax[1].set_title("Bayesian GPLVM")
 

--- a/doc/sphinx/notebooks/basics/classification.pct.py
+++ b/doc/sphinx/notebooks/basics/classification.pct.py
@@ -22,11 +22,11 @@
 # We first look at a one-dimensional example, and then show how you can adapt this when the input space is two-dimensional.
 
 # %%
+import matplotlib.pyplot as plt
 import numpy as np
-import gpflow
 import tensorflow as tf
 
-import matplotlib.pyplot as plt
+import gpflow
 
 # %matplotlib inline
 
@@ -113,7 +113,9 @@ _ = plt.plot(X_gen, Y_gen, "C3x", ms=8, mew=2)
 
 # %%
 m = gpflow.models.VGP(
-    (X, Y), likelihood=gpflow.likelihoods.Bernoulli(), kernel=gpflow.kernels.Matern52()
+    (X, Y),
+    likelihood=gpflow.likelihoods.Bernoulli(),
+    kernel=gpflow.kernels.Matern52(),
 )
 
 opt = gpflow.optimizers.Scipy()
@@ -177,19 +179,30 @@ mask = Y[:, 0] == 1
 
 plt.figure(figsize=(6, 6))
 plt.plot(X[mask, 0], X[mask, 1], "oC0", mew=0, alpha=0.5)
-_ = plt.plot(X[np.logical_not(mask), 0], X[np.logical_not(mask), 1], "oC1", mew=0, alpha=0.5)
+_ = plt.plot(
+    X[np.logical_not(mask), 0],
+    X[np.logical_not(mask), 1],
+    "oC1",
+    mew=0,
+    alpha=0.5,
+)
 
 # %% [markdown]
 # The model definition is the same as above; the only important difference is that we now specify that the kernel operates over a two-dimensional input space:
 
 # %%
 m = gpflow.models.VGP(
-    (X, Y), kernel=gpflow.kernels.SquaredExponential(), likelihood=gpflow.likelihoods.Bernoulli()
+    (X, Y),
+    kernel=gpflow.kernels.SquaredExponential(),
+    likelihood=gpflow.likelihoods.Bernoulli(),
 )
 
 opt = gpflow.optimizers.Scipy()
 opt.minimize(
-    m.training_loss, variables=m.trainable_variables, options=dict(maxiter=25), method="L-BFGS-B"
+    m.training_loss,
+    variables=m.trainable_variables,
+    options=dict(maxiter=25),
+    method="L-BFGS-B",
 )
 # in practice, the optimization needs around 250 iterations to converge
 
@@ -206,7 +219,13 @@ Xplot = np.vstack((xx.flatten(), yy.flatten())).T
 p, _ = m.predict_y(Xplot)  # here we only care about the mean
 plt.figure(figsize=(7, 7))
 plt.plot(X[mask, 0], X[mask, 1], "oC0", mew=0, alpha=0.5)
-plt.plot(X[np.logical_not(mask), 0], X[np.logical_not(mask), 1], "oC1", mew=0, alpha=0.5)
+plt.plot(
+    X[np.logical_not(mask), 0],
+    X[np.logical_not(mask), 1],
+    "oC1",
+    mew=0,
+    alpha=0.5,
+)
 
 _ = plt.contour(
     xx,

--- a/doc/sphinx/notebooks/basics/monitoring.pct.py
+++ b/doc/sphinx/notebooks/basics/monitoring.pct.py
@@ -21,8 +21,8 @@
 # ## Setup
 
 # %%
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import tensorflow as tf
 
 import gpflow
@@ -57,13 +57,18 @@ optimisation_steps = reduce_in_tests(100)
 # Create dummy data.
 
 X = np.random.randn(num_data, 1)  # [N, 2]
-Y = np.sin(X) + 0.5 * np.cos(X) + np.random.randn(*X.shape) * noise_std  # [N, 1]
+Y = (
+    np.sin(X) + 0.5 * np.cos(X) + np.random.randn(*X.shape) * noise_std
+)  # [N, 1]
 plt.plot(X, Y, "o")
 
 # %%
 # Set up model and print
 
-kernel = gpflow.kernels.SquaredExponential(lengthscales=[1.0, 2.0]) + gpflow.kernels.Linear()
+kernel = (
+    gpflow.kernels.SquaredExponential(lengthscales=[1.0, 2.0])
+    + gpflow.kernels.Linear()
+)
 model = gpflow.models.GPR((X, Y), kernel, noise_variance=noise_std ** 2)
 model
 
@@ -99,7 +104,9 @@ plt.show()
 log_dir = "logs"  # Directory where TensorBoard files will be written.
 model_task = ModelToTensorBoard(log_dir, model)
 image_task = ImageToTensorBoard(log_dir, plot_prediction, "image_samples")
-lml_task = ScalarToTensorBoard(log_dir, lambda: model.training_loss(), "training_objective")
+lml_task = ScalarToTensorBoard(
+    log_dir, lambda: model.training_loss(), "training_objective"
+)
 
 # %% [markdown]
 # We now group the tasks in a set of fast and slow tasks and pass them to the monitor.
@@ -178,11 +185,14 @@ opt = gpflow.optimizers.Scipy()
 
 log_dir_scipy = f"{log_dir}/scipy"
 model_task = ModelToTensorBoard(log_dir_scipy, model)
-lml_task = ScalarToTensorBoard(log_dir_scipy, lambda: model.training_loss(), "training_objective")
+lml_task = ScalarToTensorBoard(
+    log_dir_scipy, lambda: model.training_loss(), "training_objective"
+)
 image_task = ImageToTensorBoard(log_dir_scipy, plot_prediction, "image_samples")
 
 monitor = Monitor(
-    MonitorTaskGroup([model_task, lml_task], period=1), MonitorTaskGroup(image_task, period=5)
+    MonitorTaskGroup([model_task, lml_task], period=1),
+    MonitorTaskGroup(image_task, period=5),
 )
 
 # %%

--- a/doc/sphinx/notebooks/basics/regression.pct.py
+++ b/doc/sphinx/notebooks/basics/regression.pct.py
@@ -30,10 +30,11 @@
 #
 
 # %%
-import gpflow
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import tensorflow as tf
+
+import gpflow
 from gpflow.utilities import print_summary
 
 # The lines below are specific to the notebook format
@@ -125,7 +126,9 @@ opt = gpflow.optimizers.Scipy()
 # `m.trainable_variables`, and the number of iterations.
 
 # %%
-opt_logs = opt.minimize(m.training_loss, m.trainable_variables, options=dict(maxiter=100))
+opt_logs = opt.minimize(
+    m.training_loss, m.trainable_variables, options=dict(maxiter=100)
+)
 print_summary(m)
 
 # %% [markdown]
@@ -154,7 +157,9 @@ print_summary(m)
 
 # %%
 ## generate test points for prediction
-xx = np.linspace(-0.1, 1.1, 100).reshape(100, 1)  # test points must be of shape (N, D)
+xx = np.linspace(-0.1, 1.1, 100).reshape(
+    100, 1
+)  # test points must be of shape (N, D)
 
 ## predict mean and variance of latent GP at test points
 mean, var = m.predict_f(xx)

--- a/doc/sphinx/notebooks/intro_to_gpflow2.pct.py
+++ b/doc/sphinx/notebooks/intro_to_gpflow2.pct.py
@@ -24,25 +24,21 @@
 #
 
 # %%
-from typing import Tuple, Optional
-import tempfile
-import pathlib
-
-import datetime
-import io
-import matplotlib.pyplot as plt
-
-import numpy as np
-import tensorflow as tf
-import gpflow
-
-from gpflow.config import default_float
-from gpflow.ci_utils import reduce_in_tests
-from gpflow.utilities import to_default_float
-
 import warnings
 
 warnings.filterwarnings("ignore")
+
+import pathlib
+import tempfile
+from typing import Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+
+import gpflow
+from gpflow.ci_utils import reduce_in_tests
+from gpflow.config import default_float
 
 # %% [markdown]
 # Make `tensorboard` work inside notebook:
@@ -79,7 +75,9 @@ tf.random.set_seed(0)
 
 # %%
 def noisy_sin(x):
-    return tf.math.sin(x) + 0.1 * tf.random.normal(x.shape, dtype=default_float())
+    return tf.math.sin(x) + 0.1 * tf.random.normal(
+        x.shape, dtype=default_float()
+    )
 
 
 num_train_data = reduce_in_tests(100)
@@ -210,7 +208,9 @@ optimizer.minimize(
 # %%
 vgp_model.training_loss_closure()  # compiled
 vgp_model.training_loss_closure(compile=True)  # compiled
-vgp_model.training_loss_closure(compile=False)  # uncompiled, same as vgp_model.training_loss
+vgp_model.training_loss_closure(
+    compile=False
+)  # uncompiled, same as vgp_model.training_loss
 
 # %% [markdown]
 # ### External data
@@ -230,7 +230,9 @@ optimizer = tf.optimizers.Adam()
 training_loss = model.training_loss_closure(
     data
 )  # We save the compiled closure in a variable so as not to re-compile it each step
-optimizer.minimize(training_loss, model.trainable_variables)  # Note that this does a single step
+optimizer.minimize(
+    training_loss, model.trainable_variables
+)  # Note that this does a single step
 
 # %% [markdown]
 # SVGP can handle mini-batching, and an iterator from a batched tf.data.Dataset can be passed to the model's training_loss_closure():
@@ -240,7 +242,9 @@ batch_size = 5
 batched_dataset = tf.data.Dataset.from_tensor_slices(data).batch(batch_size)
 training_loss = model.training_loss_closure(iter(batched_dataset))
 
-optimizer.minimize(training_loss, model.trainable_variables)  # Note that this does a single step
+optimizer.minimize(
+    training_loss, model.trainable_variables
+)  # Note that this does a single step
 
 # %% [markdown]
 # As previously, training_loss_closure takes an optional `compile` argument for tf.function compilation (True by default).
@@ -253,7 +257,9 @@ optimizer.minimize(training_loss, model.trainable_variables)  # Note that this d
 # The `optimization_step` can (and should) be wrapped in `tf.function` to be compiled to a graph if executing it many times.
 
 # %%
-def optimization_step(model: gpflow.models.SVGP, batch: Tuple[tf.Tensor, tf.Tensor]):
+def optimization_step(
+    model: gpflow.models.SVGP, batch: Tuple[tf.Tensor, tf.Tensor]
+):
     with tf.GradientTape(watch_accessed_variables=False) as tape:
         tape.watch(model.trainable_variables)
         loss = model.training_loss(batch)
@@ -266,7 +272,9 @@ def optimization_step(model: gpflow.models.SVGP, batch: Tuple[tf.Tensor, tf.Tens
 # We can use the functionality of TensorFlow Datasets to define a simple training loop that iterates over batches of the training dataset:
 
 # %%
-def simple_training_loop(model: gpflow.models.SVGP, epochs: int = 1, logging_epoch_freq: int = 10):
+def simple_training_loop(
+    model: gpflow.models.SVGP, epochs: int = 1, logging_epoch_freq: int = 10
+):
     tf_optimization_step = tf.function(optimization_step)
 
     batches = iter(train_dataset)
@@ -290,14 +298,13 @@ simple_training_loop(model, epochs=10, logging_epoch_freq=2)
 
 # %%
 from gpflow.monitor import (
+    ExecuteCallback,
     ImageToTensorBoard,
     ModelToTensorBoard,
-    ExecuteCallback,
     Monitor,
     MonitorTaskGroup,
     ScalarToTensorBoard,
 )
-
 
 samples_input = np.linspace(0, 10, reduce_in_tests(100)).reshape(-1, 1)
 
@@ -447,7 +454,9 @@ def checkpointing_training_loop(
         epoch_id = epoch + 1
         if epoch_id % logging_epoch_freq == 0:
             ckpt_path = manager.save()
-            tf.print(f"Epoch {epoch_id}: ELBO (train) {model.elbo(data)}, saved at {ckpt_path}")
+            tf.print(
+                f"Epoch {epoch_id}: ELBO (train) {model.elbo(data)}, saved at {ckpt_path}"
+            )
 
 
 # %%
@@ -485,7 +494,9 @@ for i, recorded_checkpoint in enumerate(manager.checkpoints):
 # The following returns a dictionary of all parameters within
 
 # %%
-model = gpflow.models.SGPR(data, kernel=kernel, inducing_variable=inducing_variable)
+model = gpflow.models.SGPR(
+    data, kernel=kernel, inducing_variable=inducing_variable
+)
 
 # %%
 gpflow.utilities.parameter_dict(model)
@@ -505,7 +516,8 @@ gpflow.utilities.multiple_assign(model, params)
 # %%
 predict_f = lambda Xnew: model.predict_f(Xnew)
 model.predict_f_compiled = tf.function(
-    predict_f, input_signature=[tf.TensorSpec(shape=[None, 1], dtype=tf.float64)]
+    predict_f,
+    input_signature=[tf.TensorSpec(shape=[None, 1], dtype=tf.float64)],
 )
 
 # %% [markdown]
@@ -542,13 +554,19 @@ user_str = "User config\t"
 global_str = "Global config\t"
 
 with gpflow.config.as_context(user_config):
-    print(f"{user_str} gpflow.config.default_float = {gpflow.config.default_float()}")
+    print(
+        f"{user_str} gpflow.config.default_float = {gpflow.config.default_float()}"
+    )
     print(
         f"{user_str} gpflow.config.positive_bijector = {gpflow.config.default_positive_bijector()}"
     )
 
-print(f"{global_str} gpflow.config.default_float = {gpflow.config.default_float()}")
-print(f"{global_str} gpflow.config.positive_bijector = {gpflow.config.default_positive_bijector()}")
+print(
+    f"{global_str} gpflow.config.default_float = {gpflow.config.default_float()}"
+)
+print(
+    f"{global_str} gpflow.config.positive_bijector = {gpflow.config.default_positive_bijector()}"
+)
 
 # %%
 with gpflow.config.as_context(user_config):

--- a/doc/sphinx/notebooks/tailor/external-mean-function.pct.py
+++ b/doc/sphinx/notebooks/tailor/external-mean-function.pct.py
@@ -23,18 +23,14 @@
 # For an in-depth discussion on this topic, see *(Fortuin and Rätsch, 2019)*. This notebook reproduces section 4.2 of this paper.
 
 # %%
+import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
-import matplotlib.pyplot as plt
 
 import gpflow
-from gpflow.kernels import RBF
-from gpflow.likelihoods import Gaussian
-from gpflow.mean_functions import MeanFunction
-from gpflow.models import GPR
-from gpflow.base import Parameter
-
 from gpflow.ci_utils import reduce_in_tests
+from gpflow.kernels import RBF
+from gpflow.models import GPR
 
 # for reproducibility of this notebook:
 np.random.seed(1)
@@ -284,7 +280,9 @@ for i, test_task in enumerate(test):
 # %%
 mean_mse = np.mean(mean_squared_errors)
 std_mse = np.std(mean_squared_errors) / np.sqrt(num_test_tasks)
-print(f"The mean MSE over all {num_test_tasks} test tasks is {mean_mse:.2f} +/- {std_mse:.2f}")
+print(
+    f"The mean MSE over all {num_test_tasks} test tasks is {mean_mse:.2f} +/- {std_mse:.2f}"
+)
 
 # %% [markdown]
 # We achieve comparable results to those reported in the paper.

--- a/doc/sphinx/notebooks/tailor/kernel_design.pct.py
+++ b/doc/sphinx/notebooks/tailor/kernel_design.pct.py
@@ -23,11 +23,12 @@
 # where $\sigma^2$ is a variance parameter.
 
 # %%
-import gpflow
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 import tensorflow as tf
-from gpflow.utilities import print_summary, positive
+
+import gpflow
+from gpflow.utilities import positive, print_summary
 
 plt.style.use("ggplot")
 # %matplotlib inline
@@ -58,7 +59,9 @@ class Brownian(gpflow.kernels.Kernel):
     def K(self, X, X2=None):
         if X2 is None:
             X2 = X
-        return self.variance * tf.minimum(X, tf.transpose(X2))  # this returns a 2D tensor
+        return self.variance * tf.minimum(
+            X, tf.transpose(X2)
+        )  # this returns a 2D tensor
 
     def K_diag(self, X):
         return self.variance * tf.reshape(X, (-1,))  # this returns a 1D tensor

--- a/doc/sphinx/notebooks/tailor/mdn_plotting.py
+++ b/doc/sphinx/notebooks/tailor/mdn_plotting.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from scipy.stats import norm
 
 
@@ -21,14 +20,22 @@ def plot(model, X, Y, axes, cmap, N_plot=100):
     yy = np.linspace(Y.min() - 1, Y.max() + 1, N_plot)
     pis, mus, sigmas = [v.numpy() for v in model.eval_network(xx)]
 
-    probs = norm.pdf(yy[:, None, None], loc=mus[None, :, :], scale=sigmas[None, :, :])
+    probs = norm.pdf(
+        yy[:, None, None], loc=mus[None, :, :], scale=sigmas[None, :, :]
+    )
     probs = np.sum(probs * pis[None, :, :], axis=-1)
     plot_x, plot_y = make_grid(xx, yy)
     axes[0].set_title("Posterior density and trainings data")
-    axes[0].contourf(plot_x, plot_y, np.log(probs), 500, cmap=cmap, vmin=-5, vmax=5)
+    axes[0].contourf(
+        plot_x, plot_y, np.log(probs), 500, cmap=cmap, vmin=-5, vmax=5
+    )
     axes[0].plot(X, Y, "ro", alpha=0.2, ms=3, label="data")
     axes[0].legend(loc=4)
-    axes[1].set_title(r"$\mu_m(x)$ and their relative contribution shown by size")
+    axes[1].set_title(
+        r"$\mu_m(x)$ and their relative contribution shown by size"
+    )
     axes[1].scatter(
-        np.repeat(xx.flatten(), repeats=mus.shape[1]), mus.flatten(), s=pis.flatten() * 20
+        np.repeat(xx.flatten(), repeats=mus.shape[1]),
+        mus.flatten(),
+        s=pis.flatten() * 20,
     )

--- a/doc/sphinx/notebooks/theory/FITCvsVFE.pct.py
+++ b/doc/sphinx/notebooks/theory/FITCvsVFE.pct.py
@@ -17,25 +17,22 @@
 # # Comparing FITC approximation to VFE approximation
 # This notebook examines why we prefer the Variational Free Energy (VFE) objective to the Fully Independent Training Conditional (FITC) approximation for our sparse approximations.
 #
-
 # %%
-import gpflow
-import tensorflow as tf
-from gpflow.ci_utils import reduce_in_tests
 import matplotlib.pyplot as plt
+from FITCvsVFE import (
+    getTrainingTestData,
+    plotComparisonFigure,
+    plotPredictions,
+    printModelParameters,
+    repeatMinimization,
+    stretch,
+)
+
+import gpflow
+from gpflow.ci_utils import reduce_in_tests
 
 # %matplotlib inline
 
-from FITCvsVFE import (
-    getTrainingTestData,
-    printModelParameters,
-    plotPredictions,
-    repeatMinimization,
-    stretch,
-    plotComparisonFigure,
-)
-
-import logging
 
 # logging.disable(logging.WARN)  # do not clutter up the notebook with optimization warnings
 
@@ -83,11 +80,15 @@ def initializeHyperparametersFromExactSolution(sparse_model):
 
 # %%
 # Train VFE model initialized from the perfect solution.
-VFEmodel = gpflow.models.SGPR((Xtrain, Ytrain), kernel=getKernel(), inducing_variable=Xtrain.copy())
+VFEmodel = gpflow.models.SGPR(
+    (Xtrain, Ytrain), kernel=getKernel(), inducing_variable=Xtrain.copy()
+)
 
 initializeHyperparametersFromExactSolution(VFEmodel)
 
-VFEcb = repeatMinimization(VFEmodel, Xtest, Ytest)  # optimize with several restarts
+VFEcb = repeatMinimization(
+    VFEmodel, Xtest, Ytest
+)  # optimize with several restarts
 print("Sparse model parameters after VFE optimization:")
 printModelParameters(VFEmodel)
 
@@ -99,7 +100,9 @@ FITCmodel = gpflow.models.GPRFITC(
 
 initializeHyperparametersFromExactSolution(FITCmodel)
 
-FITCcb = repeatMinimization(FITCmodel, Xtest, Ytest)  # optimize with several restarts
+FITCcb = repeatMinimization(
+    FITCmodel, Xtest, Ytest
+)  # optimize with several restarts
 print("Sparse model parameters after FITC optimization:")
 printModelParameters(FITCmodel)
 

--- a/doc/sphinx/notebooks/theory/FITCvsVFE.py
+++ b/doc/sphinx/notebooks/theory/FITCvsVFE.py
@@ -1,7 +1,8 @@
+import numpy as np
+import tensorflow as tf
+
 import gpflow
 from gpflow.ci_utils import reduce_in_tests
-import tensorflow as tf
-import numpy as np
 
 nRepeats = reduce_in_tests(50)
 
@@ -62,16 +63,30 @@ def getRegressionModel(X, Y):
 
 def getSparseModel(X, Y, isFITC=False):
     if isFITC:
-        m = gpflow.models.GPRFITC((X, Y), kernel=getKernel(), inducing_variable=X.copy())
+        m = gpflow.models.GPRFITC(
+            (X, Y), kernel=getKernel(), inducing_variable=X.copy()
+        )
     else:
-        m = gpflow.models.SGPR((X, Y), kernel=getKernel(), inducing_variable=X.copy())
+        m = gpflow.models.SGPR(
+            (X, Y), kernel=getKernel(), inducing_variable=X.copy()
+        )
     return m
 
 
 def printModelParameters(model):
-    print("  Likelihood variance = {:.5g}".format(model.likelihood.variance.numpy()))
-    print("  Kernel variance     = {:.5g}".format(model.kernel.variance.numpy()))
-    print("  Kernel lengthscale  = {:.5g}".format(model.kernel.lengthscales.numpy()))
+    print(
+        "  Likelihood variance = {:.5g}".format(
+            model.likelihood.variance.numpy()
+        )
+    )
+    print(
+        "  Kernel variance     = {:.5g}".format(model.kernel.variance.numpy())
+    )
+    print(
+        "  Kernel lengthscale  = {:.5g}".format(
+            model.kernel.lengthscales.numpy()
+        )
+    )
 
 
 def plotPredictions(ax, model, color, label=None):
@@ -125,11 +140,17 @@ def plotComparisonFigure(
     plotPredictions(ax_predictions, sparse_model, "b", label="Approximate")
     ax_predictions.legend(loc=9)
     ax_predictions.plot(
-        sparse_model.inducing_variable.Z.numpy(), -1.0 * np.ones(Xtrain.shape), "ko"
+        sparse_model.inducing_variable.Z.numpy(),
+        -1.0 * np.ones(Xtrain.shape),
+        "ko",
     )
     ax_predictions.set_ylim(predict_limits)
-    ax_inducing_points.plot(Xtrain, sparse_model.inducing_variable.Z.numpy(), "bo")
-    xs = np.linspace(ax_inducing_points.get_xlim()[0], ax_inducing_points.get_xlim()[1], 200)
+    ax_inducing_points.plot(
+        Xtrain, sparse_model.inducing_variable.Z.numpy(), "bo"
+    )
+    xs = np.linspace(
+        ax_inducing_points.get_xlim()[0], ax_inducing_points.get_xlim()[1], 200
+    )
     ax_inducing_points.plot(xs, xs, "g")
     ax_inducing_points.set_xlabel("Optimal inducing point position")
     ax_inducing_points.set_ylabel("Learnt inducing point position")
@@ -163,11 +184,17 @@ class Callback:
                 var.assign(val)
 
             self.n_iters.append(self.counter)
-            self.log_likelihoods.append(self.model.maximum_log_likelihood_objective().numpy())
+            self.log_likelihoods.append(
+                self.model.maximum_log_likelihood_objective().numpy()
+            )
 
-            predictive_mean, predictive_variance = self.model.predict_y(self.Xtest)
+            predictive_mean, predictive_variance = self.model.predict_y(
+                self.Xtest
+            )
             test_log_likelihood = tf.reduce_mean(
-                getLogPredictiveDensities(self.Ytest, predictive_mean, predictive_variance)
+                getLogPredictiveDensities(
+                    self.Ytest, predictive_mean, predictive_variance
+                )
             )
             self.hold_out_likelihood.append(test_log_likelihood.numpy())
 
@@ -181,8 +208,8 @@ def stretch(lenNIters, initialValues):
 
 
 def snelsonDemo():
-    from matplotlib import pyplot as plt
     from IPython import embed
+    from matplotlib import pyplot as plt
 
     Xtrain, Ytrain, Xtest, Ytest = getTrainingTestData()
 
@@ -199,8 +226,12 @@ def snelsonDemo():
     figB, axes = plt.subplots(3, 2)
 
     # run sparse model on training data initialized from exact optimal solution.
-    VFEmodel, VFEcb = trainSparseModel(Xtrain, Ytrain, exact_model, False, Xtest, Ytest)
-    FITCmodel, FITCcb = trainSparseModel(Xtrain, Ytrain, exact_model, True, Xtest, Ytest)
+    VFEmodel, VFEcb = trainSparseModel(
+        Xtrain, Ytrain, exact_model, False, Xtest, Ytest
+    )
+    FITCmodel, FITCcb = trainSparseModel(
+        Xtrain, Ytrain, exact_model, True, Xtest, Ytest
+    )
 
     print("Exact model parameters \n")
     printModelParameters(exact_model)

--- a/doc/sphinx/notebooks/theory/Sanity_check.pct.py
+++ b/doc/sphinx/notebooks/theory/Sanity_check.pct.py
@@ -35,15 +35,18 @@
 # In all cases the parameters are estimated by the method of maximum likelihood (or approximate maximum likelihood, as appropriate). The parameter estimates should all be the same.
 
 # %%
-import gpflow
+import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
-import matplotlib.pyplot as plt
 
+import gpflow
 from gpflow import set_trainable
-from gpflow.models import maximum_log_likelihood_objective, training_loss_closure
-from gpflow.config import default_float
 from gpflow.ci_utils import reduce_in_tests
+from gpflow.config import default_float
+from gpflow.models import (
+    maximum_log_likelihood_objective,
+    training_loss_closure,
+)
 
 # %matplotlib inline
 plt.rcParams["figure.figsize"] = (12, 6)
@@ -64,7 +67,9 @@ inducing_variable = tf.convert_to_tensor(X, dtype=default_float())
 
 m1 = gpflow.models.GPR(data, kernel=gpflow.kernels.SquaredExponential())
 m2 = gpflow.models.VGP(
-    data, kernel=gpflow.kernels.SquaredExponential(), likelihood=gpflow.likelihoods.Gaussian()
+    data,
+    kernel=gpflow.kernels.SquaredExponential(),
+    likelihood=gpflow.likelihoods.Gaussian(),
 )
 m3 = gpflow.models.SVGP(
     gpflow.kernels.SquaredExponential(),
@@ -84,12 +89,16 @@ m4 = gpflow.models.SVGP(
 set_trainable(m4.inducing_variable, False)
 
 m5 = gpflow.models.SGPR(
-    data, kernel=gpflow.kernels.SquaredExponential(), inducing_variable=inducing_variable
+    data,
+    kernel=gpflow.kernels.SquaredExponential(),
+    inducing_variable=inducing_variable,
 )
 set_trainable(m5.inducing_variable, False)
 
 m6 = gpflow.models.GPRFITC(
-    data, kernel=gpflow.kernels.SquaredExponential(), inducing_variable=inducing_variable
+    data,
+    kernel=gpflow.kernels.SquaredExponential(),
+    inducing_variable=inducing_variable,
 )
 set_trainable(m6.inducing_variable, False)
 
@@ -158,4 +167,6 @@ for m in models:
 
 # %%
 for m in models:
-    print(f"{m.__class__.__name__:30}  {maximum_log_likelihood_objective(m, data)}")
+    print(
+        f"{m.__class__.__name__:30}  {maximum_log_likelihood_objective(m, data)}"
+    )

--- a/doc/sphinx/notebooks/theory/cglb.pct.py
+++ b/doc/sphinx/notebooks/theory/cglb.pct.py
@@ -15,13 +15,13 @@
 # ---
 
 # %%
+import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
-import matplotlib.pyplot as plt
 from cglb import load_snelson_data, plot_prediction
-from pathlib import Path
-from gpflow.models import CGLB, SGPR, GPR
+
 from gpflow.kernels import SquaredExponential
+from gpflow.models import CGLB, GPR, SGPR
 from gpflow.optimizers import Scipy
 
 # %%
@@ -50,8 +50,18 @@ iv = x[iv_indices, :]
 
 noise = 0.1
 gpr = GPR(data, kernel=SquaredExponential(), noise_variance=noise)
-cglb = CGLB(data, kernel=SquaredExponential(), noise_variance=noise, inducing_variable=iv)
-sgpr = SGPR(data, kernel=SquaredExponential(), noise_variance=noise, inducing_variable=iv)
+cglb = CGLB(
+    data,
+    kernel=SquaredExponential(),
+    noise_variance=noise,
+    inducing_variable=iv,
+)
+sgpr = SGPR(
+    data,
+    kernel=SquaredExponential(),
+    noise_variance=noise,
+    inducing_variable=iv,
+)
 
 
 def loss_with_changed_parameter(model, parameter, value: float):
@@ -63,7 +73,9 @@ def loss_with_changed_parameter(model, parameter, value: float):
 
 
 ls = np.linspace(0.01, 3, 100)
-losses_fn = lambda m: [loss_with_changed_parameter(m, m.kernel.lengthscales, l) for l in ls]
+losses_fn = lambda m: [
+    loss_with_changed_parameter(m, m.kernel.lengthscales, l) for l in ls
+]
 gpr_obj = losses_fn(gpr)
 sgpr_obj = losses_fn(sgpr)
 cglb_obj = losses_fn(cglb)
@@ -105,7 +117,10 @@ opt = Scipy()
 # %%
 variables = cglb.trainable_variables
 _ = opt.minimize(
-    cglb.training_loss_closure(compile=False), variables, compile=False, options=dict(maxiter=100)
+    cglb.training_loss_closure(compile=False),
+    variables,
+    compile=False,
+    options=dict(maxiter=100),
 )
 
 # %% [markdown]
@@ -133,12 +148,23 @@ xnew = xnew.squeeze()
 
 mu_no_tol = pred_no_tol[0].numpy().squeeze()
 std_no_tol = np.sqrt(pred_no_tol[1].numpy().squeeze())
-plot_prediction(axes[0], x, y, xnew, mu_no_tol, std_no_tol, "tab:blue", "CGLB, use cached $v=0$")
+plot_prediction(
+    axes[0],
+    x,
+    y,
+    xnew,
+    mu_no_tol,
+    std_no_tol,
+    "tab:blue",
+    "CGLB, use cached $v=0$",
+)
 
 
 mu_tol = pred_tol[0].numpy().squeeze()
 std_tol = np.sqrt(pred_tol[1].numpy().squeeze())
-plot_prediction(axes[1], x, y, xnew, mu_tol, std_tol, "tab:green", "CGLB, tol=0.01")
+plot_prediction(
+    axes[1], x, y, xnew, mu_tol, std_tol, "tab:green", "CGLB, tol=0.01"
+)
 
 axes[0].legend()
 axes[1].legend()

--- a/doc/sphinx/notebooks/theory/cglb.py
+++ b/doc/sphinx/notebooks/theory/cglb.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import numpy as np
 
 

--- a/doc/sphinx/notebooks/understanding/models.pct.py
+++ b/doc/sphinx/notebooks/understanding/models.pct.py
@@ -33,8 +33,9 @@
 
 # %%
 import numpy as np
-import gpflow
 import tensorflow_probability as tfp
+
+import gpflow
 from gpflow.utilities import print_summary, set_trainable, to_default_float
 
 # %% [markdown]
@@ -46,7 +47,9 @@ np.random.seed(1)
 X = np.random.rand(20, 1)
 Y = np.sin(12 * X) + 0.66 * np.cos(25 * X) + np.random.randn(20, 1) * 0.01
 
-m = gpflow.models.GPR((X, Y), kernel=gpflow.kernels.Matern32() + gpflow.kernels.Linear())
+m = gpflow.models.GPR(
+    (X, Y), kernel=gpflow.kernels.Matern32() + gpflow.kernels.Linear()
+)
 
 # %% [markdown]
 # ## Viewing, getting, and setting parameters
@@ -107,7 +110,9 @@ new_parameter = gpflow.Parameter(
     old_parameter,
     trainable=old_parameter.trainable,
     prior=old_parameter.prior,
-    name=old_parameter.name.split(":")[0],  # tensorflow is weird and adds ':0' to the name
+    name=old_parameter.name.split(":")[
+        0
+    ],  # tensorflow is weird and adds ':0' to the name
     transform=tfp.bijectors.Exp(),
 )
 m.kernel.kernels[0].lengthscales = new_parameter
@@ -123,7 +128,9 @@ p.transform.inverse(p)
 
 # %%
 p = m.kernel.kernels[0].variance
-m.kernel.kernels[0].variance = gpflow.Parameter(p.numpy(), transform=tfp.bijectors.Exp())
+m.kernel.kernels[0].variance = gpflow.Parameter(
+    p.numpy(), transform=tfp.bijectors.Exp()
+)
 
 # %%
 print_summary(m, fmt="notebook")
@@ -169,7 +176,9 @@ print_summary(m)
 
 # %%
 k = gpflow.kernels.Matern32()
-k.variance.prior = tfp.distributions.Gamma(to_default_float(2), to_default_float(3))
+k.variance.prior = tfp.distributions.Gamma(
+    to_default_float(2), to_default_float(3)
+)
 
 print_summary(k)
 
@@ -219,7 +228,9 @@ opt.minimize(m.training_loss, variables=m.trainable_variables)
 import tensorflow as tf
 
 
-class LinearMulticlass(gpflow.models.BayesianModel, gpflow.models.InternalDataTrainingLossMixin):
+class LinearMulticlass(
+    gpflow.models.BayesianModel, gpflow.models.InternalDataTrainingLossMixin
+):
     # The InternalDataTrainingLossMixin provides the training_loss method.
     # (There is also an ExternalDataTrainingLossMixin for models that do not encapsulate data.)
 
@@ -227,13 +238,17 @@ class LinearMulticlass(gpflow.models.BayesianModel, gpflow.models.InternalDataTr
         super().__init__(name=name)  # always call the parent constructor
 
         self.X = X.copy()  # X is a NumPy array of inputs
-        self.Y = Y.copy()  # Y is a 1-of-k (one-hot) representation of the labels
+        self.Y = (
+            Y.copy()
+        )  # Y is a 1-of-k (one-hot) representation of the labels
 
         self.num_data, self.input_dim = X.shape
         _, self.num_classes = Y.shape
 
         # make some parameters
-        self.W = gpflow.Parameter(np.random.randn(self.input_dim, self.num_classes))
+        self.W = gpflow.Parameter(
+            np.random.randn(self.input_dim, self.num_classes)
+        )
         self.b = gpflow.Parameter(np.random.randn(self.num_classes))
 
         # ^^ You must make the parameters attributes of the class for
@@ -245,7 +260,9 @@ class LinearMulticlass(gpflow.models.BayesianModel, gpflow.models.InternalDataTr
         p = tf.nn.softmax(
             tf.matmul(self.X, self.W) + self.b
         )  # Parameters can be used like a tf.Tensor
-        return tf.reduce_sum(tf.math.log(p) * self.Y)  # be sure to return a scalar
+        return tf.reduce_sum(
+            tf.math.log(p) * self.Y
+        )  # be sure to return a scalar
 
 
 # %% [markdown]
@@ -268,7 +285,9 @@ plt.style.use("ggplot")
 # %matplotlib inline
 
 plt.rcParams["figure.figsize"] = (12, 6)
-_ = plt.scatter(X[:, 0], X[:, 1], 100, np.argmax(Y, 1), lw=2, cmap=plt.cm.viridis)
+_ = plt.scatter(
+    X[:, 0], X[:, 1], 100, np.argmax(Y, 1), lw=2, cmap=plt.cm.viridis
+)
 
 # %%
 m = LinearMulticlass(X, Y)
@@ -289,8 +308,12 @@ p_test /= p_test.sum(1)[:, None]
 # %%
 plt.figure(figsize=(12, 6))
 for i in range(3):
-    plt.contour(xx, yy, p_test[:, i].reshape(200, 200), [0.5], colors="k", linewidths=1)
-_ = plt.scatter(X[:, 0], X[:, 1], 100, np.argmax(Y, 1), lw=2, cmap=plt.cm.viridis)
+    plt.contour(
+        xx, yy, p_test[:, i].reshape(200, 200), [0.5], colors="k", linewidths=1
+    )
+_ = plt.scatter(
+    X[:, 0], X[:, 1], 100, np.argmax(Y, 1), lw=2, cmap=plt.cm.viridis
+)
 
 # %% [markdown]
 # That concludes the new model example and this notebook. You might want to see for yourself that the `LinearMulticlass` model and its parameters have all the functionality demonstrated here. You could also add some priors and run Hamiltonian Monte Carlo using the HMC optimizer `gpflow.train.HMC` and its `sample` method. See [Markov Chain Monte Carlo (MCMC)](../advanced/mcmc.ipynb) for more information on running the sampler.

--- a/gpflow/posteriors.py
+++ b/gpflow/posteriors.py
@@ -52,7 +52,7 @@ from .kernels import Kernel
 from .likelihoods import Gaussian
 from .mean_functions import MeanFunction
 from .utilities import Dispatcher, add_likelihood_noise_cov, assert_params_false
-from .utilities.ops import eye, leading_transpose
+from .utilities.ops import eye
 
 
 class _QDistribution(Module):


### PR DESCRIPTION
Reformat notebooks to width 80, because that is the width that is available in the compiled documentation, and this avoids horizontal scrolling in the compiled documentation.

Also remove some unused imports.