### PR TITLE
Change likelihood defaults

### DIFF
--- a/gpflow/likelihoods/scalar_continuous.py
+++ b/gpflow/likelihoods/scalar_continuous.py
@@ -248,7 +248,7 @@ class Gamma(ScalarLikelihood):
     @inherit_check_shapes
     def _conditional_variance(self, X: TensorType, F: TensorType) -> tf.Tensor:
         scale = self.invlink(F)
-        return self._shape(X) * (scale ** 2)
+        return self._shape(X) * (scale**2)
 
     @inherit_check_shapes
     def _variational_expectations(

--- a/gpflow/likelihoods/scalar_continuous.py
+++ b/gpflow/likelihoods/scalar_continuous.py
@@ -21,6 +21,7 @@ import tensorflow as tf
 from .. import logdensities
 from ..base import MeanAndVariance, TensorType
 from ..experimental.check_shapes import check_shapes, inherit_check_shapes
+from ..config import default_likelihoods_positive_minimum
 from ..utilities.parameter_or_function import (
     ConstantOrFunction,
     ParameterOrFunction,
@@ -30,7 +31,11 @@ from ..utilities.parameter_or_function import (
 from .base import ScalarLikelihood
 from .utils import inv_probit
 
-DEFAULT_LOWER_BOUND = 1e-6
+
+def _lower_bound(value: Optional[float] = None) -> float:
+    if value is None:
+        return default_likelihoods_positive_minimum()
+    return value
 
 
 class Gaussian(ScalarLikelihood):
@@ -49,7 +54,7 @@ class Gaussian(ScalarLikelihood):
         variance: Optional[ConstantOrFunction] = None,
         *,
         scale: Optional[ConstantOrFunction] = None,
-        variance_lower_bound: float = DEFAULT_LOWER_BOUND,
+        variance_lower_bound: Optional[float] = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -62,8 +67,8 @@ class Gaussian(ScalarLikelihood):
         """
         super().__init__(**kwargs)
 
-        self.variance_lower_bound = variance_lower_bound
-        self.scale_lower_bound = sqrt(variance_lower_bound)
+        self.variance_lower_bound = _lower_bound(variance_lower_bound)
+        self.scale_lower_bound = sqrt(self.variance_lower_bound)
         if scale is None:
             if variance is None:
                 variance = 1.0
@@ -174,7 +179,7 @@ class StudentT(ScalarLikelihood):
         self,
         scale: ConstantOrFunction = 1.0,
         df: float = 3.0,
-        scale_lower_bound: float = DEFAULT_LOWER_BOUND,
+        scale_lower_bound: Optional[float] = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -183,7 +188,7 @@ class StudentT(ScalarLikelihood):
         """
         super().__init__(**kwargs)
         self.df = df
-        self.scale_lower_bound = scale_lower_bound
+        self.scale_lower_bound = _lower_bound(scale_lower_bound)
         self.scale = prepare_parameter_or_function(scale, lower_bound=self.scale_lower_bound)
 
     @check_shapes(
@@ -217,12 +222,12 @@ class Gamma(ScalarLikelihood):
         self,
         invlink: Callable[[tf.Tensor], tf.Tensor] = tf.exp,
         shape: ConstantOrFunction = 1.0,
-        shape_lower_bound: float = DEFAULT_LOWER_BOUND,
+        shape_lower_bound: Optional[float] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.invlink = invlink
-        self.shape_lower_bound = shape_lower_bound
+        self.shape_lower_bound = _lower_bound(shape_lower_bound)
         self.shape = prepare_parameter_or_function(shape, lower_bound=self.shape_lower_bound)
 
     @check_shapes(
@@ -283,11 +288,11 @@ class Beta(ScalarLikelihood):
         self,
         invlink: Callable[[tf.Tensor], tf.Tensor] = inv_probit,
         scale: ConstantOrFunction = 1.0,
-        scale_lower_bound: float = DEFAULT_LOWER_BOUND,
+        scale_lower_bound: Optional[float] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        self.scale_lower_bound = DEFAULT_LOWER_BOUND
+        self.scale_lower_bound = _lower_bound(scale_lower_bound)
         self.scale = prepare_parameter_or_function(scale, lower_bound=self.scale_lower_bound)
         self.invlink = invlink
 

--- a/tests/gpflow/config/test_config.py
+++ b/tests/gpflow/config/test_config.py
@@ -45,6 +45,7 @@ _env_values = [
     ("positive_bijector", "softplus", "softplus"),
     ("summary_fmt", "simple", "simple"),
     ("positive_minimum", "1e-3", 1e-3),
+    ("likelihoods_positive_minimum", "5e-4", 5e-4),
     ("jitter", "1e-2", 1e-2),
 ]
 


### PR DESCRIPTION
**PR type:** bugfix / enhancement

## Summary

GPflow had a feature of setting the minimal positive value using `gpflow.config.set_default_positive_minimum`. Recently, the default minimum boundary for positive values in scalar likelihoods has been changed to in module global variable with fixed value. That introduced a couple of issues:
* New approach created confusion around `positive_minimum` config value, as it was supposed to control **all** positive values in the GPflow package.
* Default global value in likelihoods module creates another way of controlling behaviour of GPflow package. `config` was supposed to be a single controlling centre.

This PR introduces `likelihoods_positive_minimum` in config that controls positive values in scalar likelihoods.

## PR checklist

- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

