### PR TITLE
Loosen Python version requirements again.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,7 @@ parameters:
     default: "3.7"
   max_py_ver:
     type: string
-    # Using the specific Python version due to poor interactions between some versions of Python,
-    # NumPy, and MyPy. You should be able to set this to just "3.10", after MyPy "0.980" has been
-    # released. See: https://github.com/python/mypy/issues/13627
-    default: "3.10.6"
+    default: "3.10"
   min_tf_ver:
     type: string
     default: "2.4.0"


### PR DESCRIPTION
MyPy 0.981 seems to have been released, and we can get rid of our workaround.