### PR TITLE
Various build cleanups.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,7 @@ parameters:
     default: "3.7"
   max_py_ver:
     type: string
-    # Using the specific Python version due to poor interactions between some versions of Python,
-    # NumPy, and MyPy. You should be able to set this to just "3.10", after MyPy "0.980" has been
-    # released. See: https://github.com/python/mypy/issues/13627
-    default: "3.10.6"
+    default: "3.10"
   min_tf_ver:
     type: string
     default: "2.4.0"

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -11,12 +11,22 @@ types-Deprecated
 types-pkg_resources
 types-tabulate
 
-# Notebook tests:
+# Notebooks and documentation:
 ipykernel
+ipython
 jupyter_client
 jupytext
 nbconvert
 nbformat
+nbsphinx
+pandoc
+# Version 0.10.* bad: https://github.com/pydata/pydata-sphinx-theme/issues/952
+pydata-sphinx-theme!=0.10.*
+sphinx
+sphinx-autoapi
+# Version 1.19.3 bad: https://github.com/tox-dev/sphinx-autodoc-typehints/issues/259
+sphinx_autodoc_typehints!=1.19.3
+sphinxcontrib-bibtex
 tensorflow-datasets
 
 matplotlib
@@ -32,16 +42,6 @@ psutil
 py-cpuinfo
 xlrd
 
-# For documentation
-ipython
-jupytext
-nbsphinx
-pandoc
-pydata-sphinx-theme
-sphinx
-sphinx-autoapi
-sphinx_autodoc_typehints
-sphinxcontrib-bibtex
 
 # Not used directly, but at the time of this writing `Jinja2` 3.1.0 breaks our notebooks.
 Jinja2<3.1.0


### PR DESCRIPTION
Fixes: #1989

1. Most importantly: Disallow `sphinx_autodoc_typehints` 1.19.3 - it has a crashing bug that is blocking our CI pipeline.
2. Disallow `pydata-sphinx-theme` 0.10 as it mis-formats tables in our documentation.
3. Un-fix the Python 3.10 version - as there's a new, fixed, `mypy`.
4. Re-organising of requirements - and removed repeated `jupytext` dependency.