### PR TITLE
Various fixes for compatibility for GPflux.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,15 +55,15 @@ This release contains contributions from:
 
 ## Bug Fixes and Other Changes
 
-* <SIMILAR TO ABOVE SECTION, BUT FOR OTHER IMPORTANT CHANGES / BUG FIXES>
-* <IF A CHANGE CLOSES A GITHUB ISSUE, IT SHOULD BE DOCUMENTED HERE>
-* <NOTES SHOULD BE GROUPED PER AREA>
+* Extract shapes of `tfp.python.layers.internal.distribution_tensor_coercible._TensorCoercible`.
+* Allow `FallbackSeparateIndependentInducingVariables` to have children with different shapes.
+* Allow input and output batches on `GaussianQuadrature` to be different.
 
 ## Thanks to our Contributors
 
 This release contains contributions from:
 
-<INSERT>, <NAME>, <HERE>, <USING>, <GITHUB>, <HANDLE>
+jesnie
 
 
 # Release 2.6.1

--- a/gpflow/quadrature/base.py
+++ b/gpflow/quadrature/base.py
@@ -39,9 +39,9 @@ class GaussianQuadrature:
         raise NotImplementedError
 
     @check_shapes(
-        "mean: [batch..., D]",
-        "var: [batch..., D]",
-        "return: [n_funs..., batch..., broadcast D]",
+        "mean: [in_batch..., D]",
+        "var: [in_batch..., D]",
+        "return: [n_funs..., out_batch..., broadcast D]",
     )
     def __call__(
         self,
@@ -83,9 +83,9 @@ class GaussianQuadrature:
         return tf.reduce_sum(fun(X, *args, **kwargs) * W, axis=0)
 
     @check_shapes(
-        "mean: [batch..., D]",
-        "var: [batch..., D]",
-        "return: [batch..., broadcast D]",
+        "mean: [in_batch..., D]",
+        "var: [in_batch..., D]",
+        "return: [n_fun..., out_batch..., broadcast D]",
     )
     def logspace(
         self,

--- a/tests/gpflow/experimental/check_shapes/test_shapes.py
+++ b/tests/gpflow/experimental/check_shapes/test_shapes.py
@@ -16,12 +16,26 @@ from typing import Any
 import numpy as np
 import pytest
 import tensorflow as tf
+import tensorflow_probability as tfp
 
 from gpflow.base import Parameter
 from gpflow.experimental.check_shapes import Shape, get_shape
 from gpflow.experimental.check_shapes.exceptions import NoShapeError
 
 from .utils import TestContext
+
+
+def make_tensor_coercible(
+    shape: Shape, concrete: bool
+) -> tfp.python.layers.internal.distribution_tensor_coercible._TensorCoercible:
+    loc = tf.zeros(shape)
+    scale = tf.ones(shape)
+    dist = tfp.python.layers.internal.distribution_tensor_coercible._TensorCoercible(
+        tfp.distributions.Normal(loc, scale), lambda self: loc
+    )
+    if concrete:
+        tf.convert_to_tensor(dist)  # Triggers some caching within `dist`.
+    return dist
 
 
 @pytest.mark.parametrize(
@@ -46,6 +60,10 @@ from .utils import TestContext
         (tf.Variable(np.zeros((2, 4)), shape=tf.TensorShape(None)), None),
         (Parameter(3), ()),
         (Parameter(np.zeros((4, 2))), (4, 2)),
+        (make_tensor_coercible((), True), ()),
+        (make_tensor_coercible((4, 5), True), (4, 5)),
+        (make_tensor_coercible((), False), None),
+        (make_tensor_coercible((4, 5), False), None),
     ],
 )
 def test_get_shape(shaped: Any, expected_shape: Shape) -> None:


### PR DESCRIPTION
Various smaller stuff to better support GPflux:

1. Extract shapes of `tfp.python.layers.internal.distribution_tensor_coercible._TensorCoercible`.
2. Allow `FallbackSeparateIndependentInducingVariables` to have children with different shapes.
3. Allow input and output batches on `GaussianQuadrature` to be different.