### PR TITLE
Support determistic randomness.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -41,6 +41,10 @@ This release contains contributions from:
 
 * `gpflow.experimental.check_shapes` has been removed, in favour of an independent release. Use
   `pip install check_shapes` and `import check_shapes` instead.
+* Many model methods now take an extra parameter, `seed`, and any custom models you have will need
+  to be updated to accept this parameter.
+* Many likelihood methods now take an extra parameter, `seed`, and any custom likelihoods you have
+  will need to be updated to accept this parameter.
 
 ## Known Caveats
 
@@ -51,6 +55,10 @@ This release contains contributions from:
 ## Major Features and Improvements
 
 * Major rework of documentation landing page and "getting started" section.
+* Deterministic randomness. Many model and likelihood methods now take a `seed` parameter that can
+  be used to get deterministic randomness. Seed the
+  [new notebook](https://gpflow.github.io/GPflow/2.7.0/notebooks/advanced/random_state.html) for
+  details.
 
 ## Bug Fixes and Other Changes
 

--- a/doc/sphinx/notebooks/advanced/random_state.pct.py
+++ b/doc/sphinx/notebooks/advanced/random_state.pct.py
@@ -1,0 +1,210 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.14.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Managing random state
+#
+# Many GPflow methods take an optional `seed` parameter. This can take three types of values:
+# * `None`.
+# * An integer.
+# * A tensor of shape `[2]` and `dtype=tf.int32`.
+#
+# Below we will go over how these are interpreted, and what that means.
+
+# %%
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+import gpflow
+
+# %% [markdown]
+# Let us quickly create a model to test on:
+
+# %%
+model = gpflow.models.GPR(
+    (np.zeros((0, 1)), np.zeros((0, 1))),
+    kernel=gpflow.kernels.SquaredExponential(),
+)
+Xplot = np.linspace(0.0, 10.0, 100)[:, None]
+
+# %% [markdown]
+# ## Seed `None`
+#
+# When the seed is set to `None`, the randomness depends on the state of the TensorFlow global seed. This is the default behaviour.
+
+# %%
+tf.random.set_seed(123)
+Yplot = model.predict_f_samples(Xplot, seed=None)
+plt.plot(Xplot, Yplot)
+
+tf.random.set_seed(123)
+Yplot = model.predict_f_samples(Xplot, seed=None)
+plt.plot(Xplot, Yplot, ls=":")
+
+tf.random.set_seed(456)
+Yplot = model.predict_f_samples(Xplot, seed=None)
+_ = plt.plot(Xplot, Yplot, ls="-.")
+
+# %% [markdown]
+# ## Integer seed
+# When the seed is set to an integer, the randomness depends on both the TensorFlow global seed, and the `seed` passed to the method.
+
+# %%
+tf.random.set_seed(123)
+Yplot = model.predict_f_samples(Xplot, seed=1)
+plt.plot(Xplot, Yplot)
+
+tf.random.set_seed(123)
+Yplot = model.predict_f_samples(Xplot, seed=1)
+plt.plot(Xplot, Yplot, ls=":")
+
+tf.random.set_seed(123)
+Yplot = model.predict_f_samples(Xplot, seed=2)
+plt.plot(Xplot, Yplot, ls="-.")
+
+tf.random.set_seed(456)
+Yplot = model.predict_f_samples(Xplot, seed=2)
+_ = plt.plot(Xplot, Yplot, ls="--")
+
+# %% [markdown]
+# ## Full random state as seed
+# If you set the `seed` to a tensor of shape `[2]` and `dtype=tf.int32`, that will completely define the randomness used, and the TensorFlow global seed will be ignored.
+
+# %%
+tf.random.set_seed(123)
+Yplot = model.predict_f_samples(
+    Xplot, seed=tf.constant([12, 34], dtype=tf.int32)
+)
+plt.plot(Xplot, Yplot)
+
+tf.random.set_seed(456)
+Yplot = model.predict_f_samples(
+    Xplot, seed=tf.constant([12, 34], dtype=tf.int32)
+)
+plt.plot(Xplot, Yplot, ls=":")
+
+tf.random.set_seed(456)
+Yplot = model.predict_f_samples(
+    Xplot, seed=tf.constant([56, 78], dtype=tf.int32)
+)
+_ = plt.plot(Xplot, Yplot, ls="-.")
+
+
+# %% [markdown]
+# When using the full state as random seed it is important you are careful about when you do and do not reuse the seed. If you write a function, that takes a seed, and that function makes multiple calls, that also takes seeds, you should generally be careful to pass different seeds to the called functions. You can use [tfp.random.split_seed](https://www.tensorflow.org/probability/api_docs/python/tfp/random/split_seed) to create multiple new seeds from one seed. For example:
+
+# %%
+def calls_two(seed: tf.Tensor) -> None:
+    s1, s2 = tfp.random.split_seed(seed)
+    model.predict_f_samples(Xplot, seed=s1)
+    model.predict_f_samples(Xplot, seed=s2)
+
+
+def calls_in_loop(seed: tf.Tensor) -> None:
+    for _ in range(5):
+        seed, s = tfp.random.split_seed(seed)
+        calls_two(s)
+
+
+calls_in_loop(tf.constant([12, 34], dtype=tf.int32))
+
+# %% [markdown]
+# ## Stable randomness in model optimisation
+#
+# By default the `training_loss` method has `seed = None`, which means that every call to it will have different randomness. Some of the GPflow likelihoods rely on randomness, and this means your loss function will become noisy. You can get a deterministic loss function by using `training_loss_closure` instead, which allows you to bind a fixed seed to your loss:
+
+# %%
+X = np.array([[1.0], [3.0], [9.0]])
+Y = np.array([[0.0], [2.0], [2.0]])
+model = gpflow.models.GPR(
+    (X, Y),
+    kernel=gpflow.kernels.SquaredExponential(),
+)
+fixed_seed = tf.constant([12, 34], dtype=tf.int32)
+opt = gpflow.optimizers.Scipy()
+opt.minimize(
+    model.training_loss_closure(seed=fixed_seed), model.trainable_variables
+)
+
+
+# %% [markdown]
+# ## Stable randomness used in optimisation
+#
+# Generally random sampling with a fixed random state is stable enough to be used over changing model parameters. For example, observe how adding data to a model warps the random sample:
+
+# %%
+model1 = gpflow.models.GPR(
+    (np.zeros((0, 1)), np.zeros((0, 1))),
+    kernel=gpflow.kernels.SquaredExponential(),
+)
+
+X = np.array([[1.0], [3.0], [9.0]])
+Y = np.array([[0.0], [2.0], [2.0]])
+
+model2 = gpflow.models.GPR(
+    (X, Y),
+    kernel=gpflow.kernels.SquaredExponential(),
+)
+
+fixed_seed = tf.constant([12, 34], dtype=tf.int32)
+
+plt.scatter(X, Y, c="C1")
+
+Yplot = model1.predict_f_samples(Xplot, seed=fixed_seed)
+plt.plot(Xplot, Yplot)
+
+Yplot = model2.predict_f_samples(Xplot, seed=fixed_seed)
+_ = plt.plot(Xplot, Yplot)
+
+# %% [markdown]
+# Or, let us try optimising model parameters to fit a random sample to data:
+
+# %%
+model = gpflow.models.GPR(
+    (np.zeros((0, 1)), np.zeros((0, 1))),
+    kernel=gpflow.kernels.SquaredExponential(),
+)
+
+X = np.array([[1.0], [3.0], [9.0]])
+Y = np.array([[0.0], [-1.0], [2.0]])
+fixed_seed = tf.constant([12, 34], dtype=tf.int32)
+
+plt.scatter(X, Y, c="black")
+
+Yplot = model.predict_f_samples(Xplot, seed=fixed_seed)
+plt.plot(Xplot, Yplot)
+
+data_indices = tf.searchsorted(Xplot[:, 0], X[:, 0])
+
+
+def loss() -> tf.Tensor:
+    Yplot = model.predict_f_samples(Xplot, seed=fixed_seed)
+    Ypred = tf.gather(Yplot, data_indices)
+    delta = Ypred - Y
+    return tf.reduce_sum(delta ** 2)
+
+
+opt = gpflow.optimizers.Scipy()
+opt.minimize(loss, model.trainable_variables)
+
+Yplot = model.predict_f_samples(Xplot, seed=fixed_seed)
+_ = plt.plot(Xplot, Yplot)
+
+# %% [markdown]
+# ## Implementation details
+#
+# Behind the scenes any `seed` is pushed through [tfp.random.sanitize_seed](https://www.tensorflow.org/probability/api_docs/python/tfp/random/sanitize_seed), and fed to `tf.random.stateless_*`.

--- a/doc/sphinx/notebooks/tailor/mixture_density_network.pct.py
+++ b/doc/sphinx/notebooks/tailor/mixture_density_network.pct.py
@@ -88,7 +88,7 @@ from typing import Callable, Optional, Tuple
 
 import tensorflow as tf
 
-from gpflow.base import Parameter
+from gpflow.base import Parameter, Seed
 from gpflow.models import BayesianModel, ExternalDataTrainingLossMixin
 
 # %% [markdown]
@@ -140,7 +140,7 @@ class MDN(BayesianModel, ExternalDataTrainingLossMixin):
         return pis, mus, sigmas
 
     def maximum_log_likelihood_objective(
-        self, data: Tuple[tf.Tensor, tf.Tensor]
+        self, data: Tuple[tf.Tensor, tf.Tensor], seed: Seed = None
     ):
         x, y = data
         pis, mus, sigmas = self.eval_network(x)

--- a/doc/sphinx/user_guide.rst
+++ b/doc/sphinx/user_guide.rst
@@ -75,6 +75,13 @@ This section explains the more complex models and features that are available in
 .. toctree::
    :maxdepth: 1
 
+   notebooks/advanced/random_state
+
+How to manage GPflow's random state, and how to get deterministic randomness.
+
+.. toctree::
+   :maxdepth: 1
+
    notebooks/advanced/mcmc
 
 Using Hamiltonian Monte Carlo to sample the posterior GP and hyperparameters.

--- a/gpflow/base.py
+++ b/gpflow/base.py
@@ -41,6 +41,18 @@ else:
     else:
         AnyNDArray = Union[np.ndarray]  # type: ignore[misc]
 
+Seed = Union[None, int, tf.Tensor]
+"""
+Type of optional random seeds.
+
+Use a tensor of shape ``[2]`` to use that as a deterministic seed.
+Alternatively use an integer or ``None`` to use the TensorFlow global random seed.
+
+See also:
+* https://www.tensorflow.org/probability/api_docs/python/tfp/random/sanitize_seed
+* https://www.tensorflow.org/api_docs/python/tf/random/create_rng_state
+"""
+
 VariableData = Union[List[Any], Tuple[Any], AnyNDArray, int, float]  # deprecated
 Transform = Union[tfp.bijectors.Bijector]
 Prior = Union[tfp.distributions.Distribution]

--- a/gpflow/likelihoods/multiclass.py
+++ b/gpflow/likelihoods/multiclass.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 from check_shapes import check_shapes, inherit_check_shapes
 
-from ..base import MeanAndVariance, Module, Parameter, TensorType
+from ..base import MeanAndVariance, Module, Parameter, Seed, TensorType
 from ..config import default_float
 from ..quadrature import hermgauss
 from ..utilities import to_default_float, to_default_int
@@ -188,7 +188,7 @@ class MultiClass(Likelihood):
 
     @inherit_check_shapes
     def _variational_expectations(
-        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType, seed: Seed
     ) -> tf.Tensor:
         gh_x, gh_w = hermgauss(self.num_gauss_hermite_points)
         p = self.invlink.prob_is_largest(Y, Fmu, Fvar, gh_x, gh_w)
@@ -199,7 +199,7 @@ class MultiClass(Likelihood):
 
     @inherit_check_shapes
     def _predict_mean_and_var(
-        self, X: TensorType, Fmu: TensorType, Fvar: TensorType
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, seed: Seed
     ) -> MeanAndVariance:
         possible_outputs = [
             tf.fill(tf.stack([tf.shape(Fmu)[0], 1]), np.array(i, dtype=np.int64))
@@ -211,7 +211,7 @@ class MultiClass(Likelihood):
 
     @inherit_check_shapes
     def _predict_log_density(
-        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType, seed: Seed
     ) -> tf.Tensor:
         return tf.reduce_sum(
             tf.math.log(self._predict_non_logged_density(X, Fmu, Fvar, Y)), axis=-1

--- a/gpflow/likelihoods/scalar_continuous.py
+++ b/gpflow/likelihoods/scalar_continuous.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 from check_shapes import check_shapes, inherit_check_shapes
 
 from .. import logdensities
-from ..base import MeanAndVariance, TensorType
+from ..base import MeanAndVariance, Seed, TensorType
 from ..utilities.parameter_or_function import (
     ConstantOrFunction,
     ParameterOrFunction,
@@ -120,19 +120,19 @@ class Gaussian(ScalarLikelihood):
 
     @inherit_check_shapes
     def _predict_mean_and_var(
-        self, X: TensorType, Fmu: TensorType, Fvar: TensorType
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, seed: Seed
     ) -> MeanAndVariance:
         return tf.identity(Fmu), Fvar + self._variance(X)
 
     @inherit_check_shapes
     def _predict_log_density(
-        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType, seed: Seed
     ) -> tf.Tensor:
         return tf.reduce_sum(logdensities.gaussian(Y, Fmu, Fvar + self._variance(X)), axis=-1)
 
     @inherit_check_shapes
     def _variational_expectations(
-        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType, seed: Seed
     ) -> tf.Tensor:
         variance = self._variance(X)
         return tf.reduce_sum(
@@ -162,11 +162,11 @@ class Exponential(ScalarLikelihood):
 
     @inherit_check_shapes
     def _variational_expectations(
-        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType, seed: Seed
     ) -> tf.Tensor:
         if self.invlink is tf.exp:
             return tf.reduce_sum(-tf.exp(-Fmu + Fvar / 2) * Y - Fmu, axis=-1)
-        return super()._variational_expectations(X, Fmu, Fvar, Y)
+        return super()._variational_expectations(X, Fmu, Fvar, Y, seed)
 
 
 class StudentT(ScalarLikelihood):
@@ -247,7 +247,7 @@ class Gamma(ScalarLikelihood):
 
     @inherit_check_shapes
     def _variational_expectations(
-        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType
+        self, X: TensorType, Fmu: TensorType, Fvar: TensorType, Y: TensorType, seed: Seed
     ) -> tf.Tensor:
         if self.invlink is tf.exp:
             shape = self._shape(X)
@@ -259,7 +259,7 @@ class Gamma(ScalarLikelihood):
                 axis=-1,
             )
         else:
-            return super()._variational_expectations(X, Fmu, Fvar, Y)
+            return super()._variational_expectations(X, Fmu, Fvar, Y, seed)
 
 
 class Beta(ScalarLikelihood):

--- a/gpflow/models/cglb.py
+++ b/gpflow/models/cglb.py
@@ -17,7 +17,7 @@ from typing import Any, List, NamedTuple, Optional, Tuple
 import tensorflow as tf
 from check_shapes import check_shapes, inherit_check_shapes
 
-from ..base import InputData, MeanAndVariance, Parameter, RegressionData, TensorType
+from ..base import InputData, MeanAndVariance, Parameter, RegressionData, Seed, TensorType
 from ..config import default_float, default_int
 from ..covariances import Kuf
 from ..utilities import add_noise_cov, assert_params_false, to_default_float
@@ -258,6 +258,7 @@ class CGLB(SGPR):
         Xnew: InputData,
         full_cov: bool = False,
         full_output_cov: bool = False,
+        seed: Seed = None,
         cg_tolerance: Optional[float] = 1e-3,
     ) -> MeanAndVariance:
         """
@@ -269,7 +270,7 @@ class CGLB(SGPR):
         f_mean, f_var = self.predict_f(
             Xnew, full_cov=full_cov, full_output_cov=full_output_cov, cg_tolerance=cg_tolerance
         )
-        return self.likelihood.predict_mean_and_var(Xnew, f_mean, f_var)
+        return self.likelihood.predict_mean_and_var(Xnew, f_mean, f_var, seed=seed)
 
     @inherit_check_shapes
     def predict_log_density(
@@ -277,6 +278,7 @@ class CGLB(SGPR):
         data: RegressionData,
         full_cov: bool = False,
         full_output_cov: bool = False,
+        seed: Seed = None,
         cg_tolerance: Optional[float] = 1e-3,
     ) -> tf.Tensor:
         """
@@ -290,7 +292,7 @@ class CGLB(SGPR):
         f_mean, f_var = self.predict_f(
             x, full_cov=full_cov, full_output_cov=full_output_cov, cg_tolerance=cg_tolerance
         )
-        return self.likelihood.predict_log_density(x, f_mean, f_var, y)
+        return self.likelihood.predict_log_density(x, f_mean, f_var, y, seed=seed)
 
 
 class NystromPreconditioner:

--- a/gpflow/models/gpmc.py
+++ b/gpflow/models/gpmc.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 from check_shapes import check_shapes, inherit_check_shapes
 
-from ..base import InputData, MeanAndVariance, Parameter, RegressionData
+from ..base import InputData, MeanAndVariance, Parameter, RegressionData, Seed
 from ..conditionals import conditional
 from ..config import default_float, default_jitter
 from ..kernels import Kernel
@@ -72,17 +72,17 @@ class GPMC(GPModel, InternalDataTrainingLossMixin):
 
     # type-ignore is because of changed method signature:
     @inherit_check_shapes
-    def log_posterior_density(self) -> tf.Tensor:  # type: ignore[override]
+    def log_posterior_density(self, seed: Seed = None) -> tf.Tensor:  # type: ignore[override]
         return self.log_likelihood() + self.log_prior_density()
 
     # type-ignore is because of changed method signature:
     @inherit_check_shapes
-    def _training_loss(self) -> tf.Tensor:  # type: ignore[override]
-        return -self.log_posterior_density()
+    def _training_loss(self, seed: Seed = None) -> tf.Tensor:  # type: ignore[override]
+        return -self.log_posterior_density(seed)
 
     # type-ignore is because of changed method signature:
     @inherit_check_shapes
-    def maximum_log_likelihood_objective(self) -> tf.Tensor:  # type: ignore[override]
+    def maximum_log_likelihood_objective(self, seed: Seed = None) -> tf.Tensor:  # type: ignore[override]
         return self.log_likelihood()
 
     @check_shapes(

--- a/gpflow/models/gpr.py
+++ b/gpflow/models/gpr.py
@@ -20,7 +20,7 @@ from check_shapes import check_shapes, inherit_check_shapes
 import gpflow
 
 from .. import posteriors
-from ..base import InputData, MeanAndVariance, RegressionData, TensorData
+from ..base import InputData, MeanAndVariance, RegressionData, Seed, TensorData
 from ..kernels import Kernel
 from ..likelihoods import Gaussian
 from ..logdensities import multivariate_normal
@@ -80,7 +80,7 @@ class GPR_deprecated(GPModel, InternalDataTrainingLossMixin):
 
     # type-ignore is because of changed method signature:
     @inherit_check_shapes
-    def maximum_log_likelihood_objective(self) -> tf.Tensor:  # type: ignore[override]
+    def maximum_log_likelihood_objective(self, seed: Seed = None) -> tf.Tensor:  # type: ignore[override]
         return self.log_marginal_likelihood()
 
     @check_shapes(

--- a/gpflow/models/sgpr.py
+++ b/gpflow/models/sgpr.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 from check_shapes import check_shapes, inherit_check_shapes
 
 from .. import posteriors
-from ..base import InputData, MeanAndVariance, RegressionData, TensorData
+from ..base import InputData, MeanAndVariance, RegressionData, Seed, TensorData
 from ..config import default_float, default_jitter
 from ..covariances.dispatch import Kuf, Kuu
 from ..inducing_variables import InducingPoints
@@ -165,8 +165,8 @@ class SGPR_deprecated(SGPRBase_deprecated):
 
     # type-ignore is because of changed method signature:
     @inherit_check_shapes
-    def maximum_log_likelihood_objective(self) -> tf.Tensor:  # type: ignore[override]
-        return self.elbo()
+    def maximum_log_likelihood_objective(self, seed: Seed = None) -> tf.Tensor:  # type: ignore[override]
+        return self.elbo(seed=seed)
 
     @check_shapes(
         "return.sigma_sq: [N]",
@@ -271,7 +271,7 @@ class SGPR_deprecated(SGPRBase_deprecated):
     @check_shapes(
         "return: []",
     )
-    def elbo(self) -> tf.Tensor:
+    def elbo(self, seed: Seed = None) -> tf.Tensor:
         """
         Construct a tensorflow function to compute the bound on the marginal
         likelihood. For a derivation of the terms in here, see the associated
@@ -425,7 +425,7 @@ class GPRFITC(SGPRBase_deprecated):
 
     # type-ignore is because of changed method signature:
     @inherit_check_shapes
-    def maximum_log_likelihood_objective(self) -> tf.Tensor:  # type: ignore[override]
+    def maximum_log_likelihood_objective(self, seed: Seed = None) -> tf.Tensor:  # type: ignore[override]
         return self.fitc_log_marginal_likelihood()
 
     @check_shapes(

--- a/gpflow/models/svgp.py
+++ b/gpflow/models/svgp.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 from check_shapes import check_shapes, inherit_check_shapes
 
 from .. import kullback_leiblers, posteriors
-from ..base import AnyNDArray, InputData, MeanAndVariance, Parameter, RegressionData
+from ..base import AnyNDArray, InputData, MeanAndVariance, Parameter, RegressionData, Seed
 from ..conditionals import conditional
 from ..config import default_float
 from ..inducing_variables import InducingVariables
@@ -154,13 +154,13 @@ class SVGP_deprecated(GPModel, ExternalDataTrainingLossMixin):
 
     # type-ignore is because of changed method signature:
     @inherit_check_shapes
-    def maximum_log_likelihood_objective(self, data: RegressionData) -> tf.Tensor:  # type: ignore[override]
-        return self.elbo(data)
+    def maximum_log_likelihood_objective(self, data: RegressionData, seed: Seed = None) -> tf.Tensor:  # type: ignore[override]
+        return self.elbo(data, seed)
 
     @check_shapes(
         "return: []",
     )
-    def elbo(self, data: RegressionData) -> tf.Tensor:
+    def elbo(self, data: RegressionData, seed: Seed = None) -> tf.Tensor:
         """
         This gives a variational bound (the evidence lower bound or ELBO) on
         the log marginal likelihood of the model.
@@ -168,7 +168,7 @@ class SVGP_deprecated(GPModel, ExternalDataTrainingLossMixin):
         X, Y = data
         kl = self.prior_kl()
         f_mean, f_var = self.predict_f(X, full_cov=False, full_output_cov=False)
-        var_exp = self.likelihood.variational_expectations(X, f_mean, f_var, Y)
+        var_exp = self.likelihood.variational_expectations(X, f_mean, f_var, Y, seed)
         if self.num_data is not None:
             num_data = tf.cast(self.num_data, kl.dtype)
             minibatch_size = tf.cast(tf.shape(X)[0], kl.dtype)

--- a/gpflow/models/util.py
+++ b/gpflow/models/util.py
@@ -18,7 +18,7 @@ import numpy as np
 import tensorflow as tf
 from check_shapes import check_shapes
 
-from ..base import AnyNDArray
+from ..base import AnyNDArray, Seed
 from ..config import default_float
 from ..inducing_variables import InducingPoints, InducingVariables
 from .model import BayesianModel
@@ -53,13 +53,13 @@ def _assert_equal_data(
     "data[1]: [N, P]",
 )
 def training_loss_closure(
-    model: BayesianModel, data: Data, **closure_kwargs: Any
+    model: BayesianModel, data: Data, seed: Seed = None, **closure_kwargs: Any
 ) -> Callable[[], tf.Tensor]:
     if isinstance(model, ExternalDataTrainingLossMixin):
-        return model.training_loss_closure(data, **closure_kwargs)  # type: ignore[no-any-return]
+        return model.training_loss_closure(data, seed=seed, **closure_kwargs)  # type: ignore[no-any-return]
     else:
         _assert_equal_data(model.data, data)
-        return model.training_loss_closure(**closure_kwargs)  # type: ignore[no-any-return]
+        return model.training_loss_closure(seed=seed, **closure_kwargs)  # type: ignore[no-any-return]
 
 
 @check_shapes(
@@ -67,12 +67,12 @@ def training_loss_closure(
     "data[1]: [N, P]",
     "return: []",
 )
-def training_loss(model: BayesianModel, data: Data) -> tf.Tensor:
+def training_loss(model: BayesianModel, data: Data, seed: Seed = None) -> tf.Tensor:
     if isinstance(model, ExternalDataTrainingLossMixin):
-        return model.training_loss(data)
+        return model.training_loss(data, seed=seed)
     else:
         _assert_equal_data(model.data, data)
-        return model.training_loss()
+        return model.training_loss(seed=seed)
 
 
 @check_shapes(
@@ -80,12 +80,14 @@ def training_loss(model: BayesianModel, data: Data) -> tf.Tensor:
     "data[1]: [N, P]",
     "return: []",
 )
-def maximum_log_likelihood_objective(model: BayesianModel, data: Data) -> tf.Tensor:
+def maximum_log_likelihood_objective(
+    model: BayesianModel, data: Data, seed: Seed = None
+) -> tf.Tensor:
     if isinstance(model, ExternalDataTrainingLossMixin):
-        return model.maximum_log_likelihood_objective(data)
+        return model.maximum_log_likelihood_objective(data, seed=seed)
     else:
         _assert_equal_data(model.data, data)
-        return model.maximum_log_likelihood_objective()
+        return model.maximum_log_likelihood_objective(seed=seed)
 
 
 def data_input_to_tensor(structure: Any) -> Any:

--- a/gpflow/models/vgp.py
+++ b/gpflow/models/vgp.py
@@ -21,7 +21,7 @@ from check_shapes import check_shapes, inherit_check_shapes
 import gpflow
 
 from .. import posteriors
-from ..base import InputData, MeanAndVariance, Parameter, RegressionData
+from ..base import InputData, MeanAndVariance, Parameter, RegressionData, Seed
 from ..conditionals import conditional
 from ..config import default_float, default_jitter
 from ..kernels import Kernel
@@ -100,13 +100,13 @@ class VGP_deprecated(GPModel, InternalDataTrainingLossMixin):
 
     # type-ignore is because of changed method signature:
     @inherit_check_shapes
-    def maximum_log_likelihood_objective(self) -> tf.Tensor:  # type: ignore[override]
-        return self.elbo()
+    def maximum_log_likelihood_objective(self, seed: Seed = None) -> tf.Tensor:  # type: ignore[override]
+        return self.elbo(seed)
 
     @check_shapes(
         "return: []",
     )
-    def elbo(self) -> tf.Tensor:
+    def elbo(self, seed: Seed = None) -> tf.Tensor:
         r"""
         This method computes the variational lower bound on the likelihood,
         which is:
@@ -136,7 +136,7 @@ class VGP_deprecated(GPModel, InternalDataTrainingLossMixin):
         fvar = tf.transpose(fvar)
 
         # Get variational expectations.
-        var_exp = self.likelihood.variational_expectations(X_data, fmean, fvar, Y_data)
+        var_exp = self.likelihood.variational_expectations(X_data, fmean, fvar, Y_data, seed)
 
         return tf.reduce_sum(var_exp) - KL
 
@@ -313,13 +313,13 @@ class VGPOpperArchambeau(GPModel, InternalDataTrainingLossMixin):
 
     # type-ignore is because of changed method signature:
     @inherit_check_shapes
-    def maximum_log_likelihood_objective(self) -> tf.Tensor:  # type: ignore[override]
-        return self.elbo()
+    def maximum_log_likelihood_objective(self, seed: Seed = None) -> tf.Tensor:  # type: ignore[override]
+        return self.elbo(seed)
 
     @check_shapes(
         "return: []",
     )
-    def elbo(self) -> tf.Tensor:
+    def elbo(self, seed: Seed = None) -> tf.Tensor:
         r"""
         q_alpha, q_lambda are variational parameters, size [N, R]
         This method computes the variational lower bound on the likelihood,
@@ -369,7 +369,7 @@ class VGPOpperArchambeau(GPModel, InternalDataTrainingLossMixin):
             + tf.reduce_sum(K_alpha * self.q_alpha)
         )
 
-        v_exp = self.likelihood.variational_expectations(X_data, f_mean, f_var, Y_data)
+        v_exp = self.likelihood.variational_expectations(X_data, f_mean, f_var, Y_data, seed)
         return tf.reduce_sum(v_exp) - KL
 
     @inherit_check_shapes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Iterable
+from typing import Callable, Iterable
 
 import pytest
+import tensorflow as tf
+import tensorflow_probability as tfp
 from _pytest.logging import LogCaptureFixture
 from check_shapes.config import (
     DocstringFormat,
@@ -25,6 +27,21 @@ from check_shapes.config import (
     set_enable_function_call_precompute,
     set_rewrite_docstrings,
 )
+
+
+@pytest.fixture
+def seed() -> tf.Tensor:
+    return tf.constant([123, 456], dtype=tf.int32)
+
+
+@pytest.fixture
+def mk_seed(seed: tf.Tensor) -> Callable[[], tf.Tensor]:
+    def next_seed() -> tf.Tensor:
+        nonlocal seed
+        seed, s = tfp.random.split_seed(seed)
+        return s
+
+    return next_seed
 
 
 @pytest.fixture(autouse=True)

--- a/tests/gpflow/conditionals/test_broadcasted_conditionals.py
+++ b/tests/gpflow/conditionals/test_broadcasted_conditionals.py
@@ -16,7 +16,7 @@ This test suite will check if the conditionals broadcast correctly
 when the input tensors have leading dimensions.
 """
 
-from typing import cast
+from typing import Callable, cast
 
 import numpy as np
 import pytest
@@ -58,7 +58,9 @@ class Data:
 @pytest.mark.parametrize("full_cov", [False, True])
 @pytest.mark.parametrize("white", [True, False])
 @pytest.mark.parametrize("conditional_type", ["mixing", "Z", "inducing_points"])
-def test_conditional_broadcasting(full_cov: bool, white: bool, conditional_type: str) -> None:
+def test_conditional_broadcasting(
+    full_cov: bool, white: bool, conditional_type: str, mk_seed: Callable[[], tf.Tensor]
+) -> None:
     """
     Test that the `conditional` and `sample_conditional` broadcasts correctly
     over leading dimensions of Xnew. Xnew can be shape [..., N, D],
@@ -104,6 +106,7 @@ def test_conditional_broadcasting(full_cov: bool, white: bool, conditional_type:
                 white=white,
                 full_cov=full_cov,
                 num_samples=num_samples,
+                seed=mk_seed(),
             ),
         )
 
@@ -120,6 +123,7 @@ def test_conditional_broadcasting(full_cov: bool, white: bool, conditional_type:
         white=white,
         full_cov=full_cov,
         num_samples=num_samples,
+        seed=mk_seed(),
     )
 
     samples_S1_S2, means_S1_S2, vars_S1_S2 = sample_conditional(
@@ -131,6 +135,7 @@ def test_conditional_broadcasting(full_cov: bool, white: bool, conditional_type:
         white=white,
         full_cov=full_cov,
         num_samples=num_samples,
+        seed=mk_seed(),
     )
 
     assert_allclose(samples_S12.shape, samples.shape)

--- a/tests/gpflow/conditionals/test_uncertain_conditional.py
+++ b/tests/gpflow/conditionals/test_uncertain_conditional.py
@@ -178,7 +178,7 @@ MEANS: Collection[Optional[str]] = ["Constant", "Linear", "Zero", None]
 
 @pytest.mark.parametrize("white", [True, False])
 @pytest.mark.parametrize("mean", MEANS)
-def test_no_uncertainty(white: bool, mean: Optional[str]) -> None:
+def test_no_uncertainty(white: bool, mean: Optional[str], seed: tf.Tensor) -> None:
     mean_function = mean_function_factory(mean, Data.D_in, Data.D_out)
     kernel = gpflow.kernels.SquaredExponential(variance=rng.rand())
     model = MomentMatchingSVGP(
@@ -192,7 +192,7 @@ def test_no_uncertainty(white: bool, mean: Optional[str]) -> None:
     model.full_output_cov = False
 
     training_loop(
-        model.training_loss_closure(Data.data),
+        model.training_loss_closure(Data.data, seed=seed),
         optimizer=tf.optimizers.Adam(),
         var_list=model.trainable_variables,
         maxiter=100,
@@ -211,7 +211,7 @@ def test_no_uncertainty(white: bool, mean: Optional[str]) -> None:
 
 @pytest.mark.parametrize("white", [True, False])
 @pytest.mark.parametrize("mean", MEANS)
-def test_monte_carlo_1_din(white: bool, mean: Optional[str]) -> None:
+def test_monte_carlo_1_din(white: bool, mean: Optional[str], seed: tf.Tensor) -> None:
     kernel = gpflow.kernels.SquaredExponential(variance=rng.rand())
     mean_function = mean_function_factory(mean, DataMC1.D_in, DataMC1.D_out)
     model = MomentMatchingSVGP(
@@ -225,7 +225,7 @@ def test_monte_carlo_1_din(white: bool, mean: Optional[str]) -> None:
     model.full_output_cov = True
 
     training_loop(
-        model.training_loss_closure(DataMC1.data),
+        model.training_loss_closure(DataMC1.data, seed=seed),
         optimizer=tf.optimizers.Adam(),
         var_list=model.trainable_variables,
         maxiter=200,
@@ -246,7 +246,7 @@ def test_monte_carlo_1_din(white: bool, mean: Optional[str]) -> None:
 
 @pytest.mark.parametrize("white", [True, False])
 @pytest.mark.parametrize("mean", MEANS)
-def test_monte_carlo_2_din(white: bool, mean: Optional[str]) -> None:
+def test_monte_carlo_2_din(white: bool, mean: Optional[str], seed: tf.Tensor) -> None:
     kernel = gpflow.kernels.SquaredExponential(variance=rng.rand())
     mean_function = mean_function_factory(mean, DataMC2.D_in, DataMC2.D_out)
     model = MomentMatchingSVGP(
@@ -260,7 +260,7 @@ def test_monte_carlo_2_din(white: bool, mean: Optional[str]) -> None:
     model.full_output_cov = True
 
     training_loop(
-        model.training_loss_closure(DataMC2.data),
+        model.training_loss_closure(DataMC2.data, seed=seed),
         optimizer=tf.optimizers.Adam(),
         var_list=model.trainable_variables,
         maxiter=100,

--- a/tests/gpflow/conditionals/test_util.py
+++ b/tests/gpflow/conditionals/test_util.py
@@ -113,7 +113,12 @@ def test_rollaxis_idempotent(rolls: int) -> None:
 @pytest.mark.parametrize("num_samples", [None, 1, 5])
 @pytest.mark.parametrize("full_cov", [True, False])
 def test_sample_mvn_shapes(
-    leading_dims: Tuple[int, ...], n: int, d: int, num_samples: Optional[int], full_cov: bool
+    leading_dims: Tuple[int, ...],
+    n: int,
+    d: int,
+    num_samples: Optional[int],
+    full_cov: bool,
+    seed: tf.Tensor,
 ) -> None:
     mean_shape = leading_dims + (n, d)
     means = tf.zeros(mean_shape, dtype=default_float())
@@ -126,7 +131,7 @@ def test_sample_mvn_shapes(
         covariance_shape = leading_dims + (n, d)
         covariances = tf.random.normal(covariance_shape, dtype=default_float())
 
-    samples = sample_mvn(means, covariances, full_cov, num_samples)
+    samples = sample_mvn(means, covariances, full_cov, num_samples, seed=seed)
 
     if num_samples:
         expected_shape = leading_dims + (num_samples, n, d)

--- a/tests/gpflow/likelihoods/test_function_params.py
+++ b/tests/gpflow/likelihoods/test_function_params.py
@@ -178,44 +178,52 @@ def test_conditional_variance__negative(setup: LikelihoodSetup) -> None:
 
 
 @pytest.mark.parametrize("setup", LIKELIHOODS)
-def test_predict_mean_and_var__positive(setup: LikelihoodSetup) -> None:
-    mu, var = setup.likelihood.predict_mean_and_var(Datum.X_positive, Datum.Fmu, Datum.Fvar)
+def test_predict_mean_and_var__positive(setup: LikelihoodSetup, seed: tf.Tensor) -> None:
+    mu, var = setup.likelihood.predict_mean_and_var(Datum.X_positive, Datum.Fmu, Datum.Fvar, seed)
     setup.mean_assert(mu, axis=-2)
     setup.variance_assert(var, axis=-2)
 
 
 @pytest.mark.parametrize("setup", LIKELIHOODS)
-def test_predict_mean_and_var__negative(setup: LikelihoodSetup) -> None:
+def test_predict_mean_and_var__negative(setup: LikelihoodSetup, seed: tf.Tensor) -> None:
     # We expect the negative parameter values to be clamped to the same value, so output should be
     # constant:
-    mu, var = setup.likelihood.predict_mean_and_var(Datum.X_negative, Datum.Fmu, Datum.Fvar)
+    mu, var = setup.likelihood.predict_mean_and_var(Datum.X_negative, Datum.Fmu, Datum.Fvar, seed)
     assert_constant(mu, axis=-2)
     assert_constant(var, axis=-2)
 
 
 @pytest.mark.parametrize("setup", LIKELIHOODS)
-def test_predict_log_density__positive(setup: LikelihoodSetup) -> None:
-    ld = setup.likelihood.predict_log_density(Datum.X_positive, Datum.Fmu, Datum.Fvar, Datum.Y)
+def test_predict_log_density__positive(setup: LikelihoodSetup, seed: tf.Tensor) -> None:
+    ld = setup.likelihood.predict_log_density(
+        Datum.X_positive, Datum.Fmu, Datum.Fvar, Datum.Y, seed
+    )
     setup.likelihood_assert(ld, axis=-1)
 
 
 @pytest.mark.parametrize("setup", LIKELIHOODS)
-def test_predict_log_density__negative(setup: LikelihoodSetup) -> None:
+def test_predict_log_density__negative(setup: LikelihoodSetup, seed: tf.Tensor) -> None:
     # We expect the negative parameter values to be clamped to the same value, so output should be
     # constant:
-    ld = setup.likelihood.predict_log_density(Datum.X_negative, Datum.Fmu, Datum.Fvar, Datum.Y)
+    ld = setup.likelihood.predict_log_density(
+        Datum.X_negative, Datum.Fmu, Datum.Fvar, Datum.Y, seed
+    )
     assert_constant(ld, axis=-2)
 
 
 @pytest.mark.parametrize("setup", LIKELIHOODS)
-def test_variational_expectation__positive(setup: LikelihoodSetup) -> None:
-    ve = setup.likelihood.variational_expectations(Datum.X_positive, Datum.Fmu, Datum.Fvar, Datum.Y)
+def test_variational_expectation__positive(setup: LikelihoodSetup, seed: tf.Tensor) -> None:
+    ve = setup.likelihood.variational_expectations(
+        Datum.X_positive, Datum.Fmu, Datum.Fvar, Datum.Y, seed
+    )
     setup.variational_expectations_assert(ve, axis=-1)
 
 
 @pytest.mark.parametrize("setup", LIKELIHOODS)
-def test_variational_expectation__negative(setup: LikelihoodSetup) -> None:
+def test_variational_expectation__negative(setup: LikelihoodSetup, seed: tf.Tensor) -> None:
     # We expect the negative parameter values to be clamped to the same value, so output should be
     # constant:
-    ve = setup.likelihood.variational_expectations(Datum.X_negative, Datum.Fmu, Datum.Fvar, Datum.Y)
+    ve = setup.likelihood.variational_expectations(
+        Datum.X_negative, Datum.Fmu, Datum.Fvar, Datum.Y, seed
+    )
     assert_constant(ve, axis=-2)

--- a/tests/gpflow/likelihoods/test_heteroskedastic.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic.py
@@ -30,7 +30,7 @@ class Data:
     f_var: AnyNDArray = rng.randn(N, 2) ** 2
 
 
-def test_analytic_mean_and_var() -> None:
+def test_analytic_mean_and_var(seed: tf.Tensor) -> None:
     """
     Test that quadrature computation used in HeteroskedasticTFPConditional
     of the predictive mean and variance is close to the analytical version,
@@ -41,7 +41,7 @@ def test_analytic_mean_and_var() -> None:
     analytic_variance = np.exp(Data.f_mean[:, [1]] + Data.f_var[:, [1]]) ** 2 + Data.f_var[:, [0]]
 
     likelihood = HeteroskedasticTFPConditional()
-    y_mean, y_var = likelihood.predict_mean_and_var(Data.X, Data.f_mean, Data.f_var)
+    y_mean, y_var = likelihood.predict_mean_and_var(Data.X, Data.f_mean, Data.f_var, seed)
 
     np.testing.assert_allclose(y_mean, analytic_mean)
     np.testing.assert_allclose(y_var, analytic_variance, rtol=1.5e-6)

--- a/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
+++ b/tests/gpflow/likelihoods/test_heteroskedastic_constant_variance.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple, Type
+from typing import Callable, Tuple, Type
 
 import numpy as np
 import pytest
@@ -97,22 +97,30 @@ def test_log_prob(equivalent_likelihoods: EquivalentLikelihoods) -> None:
     )
 
 
-def test_variational_expectations(equivalent_likelihoods: EquivalentLikelihoods) -> None:
+def test_variational_expectations(
+    equivalent_likelihoods: EquivalentLikelihoods, mk_seed: Callable[[], tf.Tensor]
+) -> None:
     homoskedastic_likelihood, heteroskedastic_likelihood = equivalent_likelihoods
     np.testing.assert_array_almost_equal(
-        homoskedastic_likelihood.variational_expectations(Data.X, Data.f_mean, Data.f_var, Data.Y),
+        homoskedastic_likelihood.variational_expectations(
+            Data.X, Data.f_mean, Data.f_var, Data.Y, mk_seed()
+        ),
         heteroskedastic_likelihood.variational_expectations(
-            Data.X, Data.F2_mean, Data.F2_var, Data.Y
+            Data.X, Data.F2_mean, Data.F2_var, Data.Y, mk_seed()
         ),
         decimal=2,  # student-t case has a max absolute difference of 0.0034
     )
 
 
-def test_predict_mean_and_var(equivalent_likelihoods: EquivalentLikelihoods) -> None:
+def test_predict_mean_and_var(
+    equivalent_likelihoods: EquivalentLikelihoods, mk_seed: Callable[[], tf.Tensor]
+) -> None:
     homoskedastic_likelihood, heteroskedastic_likelihood = equivalent_likelihoods
     np.testing.assert_allclose(
-        homoskedastic_likelihood.predict_mean_and_var(Data.X, Data.f_mean, Data.f_var),
-        heteroskedastic_likelihood.predict_mean_and_var(Data.X, Data.F2_mean, Data.F2_var),
+        homoskedastic_likelihood.predict_mean_and_var(Data.X, Data.f_mean, Data.f_var, mk_seed()),
+        heteroskedastic_likelihood.predict_mean_and_var(
+            Data.X, Data.F2_mean, Data.F2_var, mk_seed()
+        ),
     )
 
 
@@ -132,10 +140,16 @@ def test_conditional_variance(equivalent_likelihoods: EquivalentLikelihoods) -> 
     )
 
 
-def test_predict_log_density(equivalent_likelihoods: EquivalentLikelihoods) -> None:
+def test_predict_log_density(
+    equivalent_likelihoods: EquivalentLikelihoods, mk_seed: Callable[[], tf.Tensor]
+) -> None:
     homoskedastic_likelihood, heteroskedastic_likelihood = equivalent_likelihoods
     np.testing.assert_array_almost_equal(
-        homoskedastic_likelihood.predict_log_density(Data.X, Data.f_mean, Data.f_var, Data.Y),
-        heteroskedastic_likelihood.predict_log_density(Data.X, Data.F2_mean, Data.F2_var, Data.Y),
+        homoskedastic_likelihood.predict_log_density(
+            Data.X, Data.f_mean, Data.f_var, Data.Y, mk_seed()
+        ),
+        heteroskedastic_likelihood.predict_log_density(
+            Data.X, Data.F2_mean, Data.F2_var, Data.Y, mk_seed()
+        ),
         decimal=1,  # student-t has a max absolute difference of 0.025
     )

--- a/tests/gpflow/models/test_mcmc.py
+++ b/tests/gpflow/models/test_mcmc.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Callable
 
 import numpy as np
 import tensorflow as tf
@@ -20,7 +21,7 @@ import gpflow
 from gpflow.config import default_float
 
 
-def test_sparse_mcmc_likelihoods_and_gradients() -> None:
+def test_sparse_mcmc_likelihoods_and_gradients(mk_seed: Callable[[], tf.Tensor]) -> None:
     """
     This test makes sure that when the inducing points are the same as the data
     points, the sparse mcmc is the same as full mcmc
@@ -47,5 +48,8 @@ def test_sparse_mcmc_likelihoods_and_gradients() -> None:
     model_2.kernel.variance.assign(4.2)
 
     assert_allclose(
-        model_1.log_posterior_density(), model_2.log_posterior_density(), rtol=1e-5, atol=1e-5
+        model_1.log_posterior_density(seed=mk_seed()),
+        model_2.log_posterior_density(seed=mk_seed()),
+        rtol=1e-5,
+        atol=1e-5,
     )

--- a/tests/gpflow/models/test_methods.py
+++ b/tests/gpflow/models/test_methods.py
@@ -17,6 +17,7 @@ from typing import List
 
 import numpy as np
 import pytest
+import tensorflow as tf
 from numpy.testing import assert_array_equal, assert_array_less
 
 import gpflow
@@ -77,16 +78,16 @@ def test_methods_predict_f(model: gpflow.models.GPModel) -> None:
 
 
 @pytest.mark.parametrize("model", _state_less_gp_models + _gp_models)
-def test_methods_predict_y(model: gpflow.models.GPModel) -> None:
-    mf, vf = model.predict_y(default_datum.Xs)
+def test_methods_predict_y(model: gpflow.models.GPModel, seed: tf.Tensor) -> None:
+    mf, vf = model.predict_y(default_datum.Xs, seed=seed)
     assert_array_equal(mf.shape, vf.shape)
     assert_array_equal(mf.shape, (10, 1))
     assert_array_less(np.full_like(vf, -1e-6), vf)
 
 
 @pytest.mark.parametrize("model", _state_less_gp_models + _gp_models)
-def test_methods_predict_log_density(model: gpflow.models.GPModel) -> None:
+def test_methods_predict_log_density(model: gpflow.models.GPModel, seed: tf.Tensor) -> None:
     rng = Datum().rng
     Ys = rng.randn(10, 1)
-    d = model.predict_log_density((default_datum.Xs, Ys))
+    d = model.predict_log_density((default_datum.Xs, Ys), seed=seed)
     assert_array_equal(d.shape, (10,))

--- a/tests/gpflow/models/test_sgpr.py
+++ b/tests/gpflow/models/test_sgpr.py
@@ -29,7 +29,7 @@ class Datum:
     Z: AnyNDArray = rng.randn(20, 2)
 
 
-def test_sgpr_qu() -> None:
+def test_sgpr_qu(seed: tf.Tensor) -> None:
     rng = np.random.RandomState(1)
     X = to_default_float(Datum.X)
     Z = to_default_float(Datum.Z)
@@ -38,7 +38,9 @@ def test_sgpr_qu() -> None:
         (X, Y), kernel=gpflow.kernels.SquaredExponential(), inducing_variable=Z
     )
 
-    gpflow.optimizers.Scipy().minimize(model.training_loss, variables=model.trainable_variables)
+    gpflow.optimizers.Scipy().minimize(
+        model.training_loss_closure(seed=seed), variables=model.trainable_variables
+    )
 
     qu_mean, qu_cov = model.compute_qu()
     f_at_Z_mean, f_at_Z_cov = model.predict_f(model.inducing_variable.Z, full_cov=True)

--- a/tests/gpflow/models/test_variational.py
+++ b/tests/gpflow/models/test_variational.py
@@ -16,6 +16,7 @@ from typing import Tuple, cast
 
 import numpy as np
 import pytest
+import tensorflow as tf
 from check_shapes import check_shapes
 from numpy.testing import assert_allclose
 
@@ -190,7 +191,7 @@ def test_variational_univariate_prior_KL(diag: bool, whiten: bool) -> None:
 
 @pytest.mark.parametrize("diag", [True, False])
 @pytest.mark.parametrize("whiten", [True, False])
-def test_variational_univariate_log_likelihood(diag: bool, whiten: bool) -> None:
+def test_variational_univariate_log_likelihood(diag: bool, whiten: bool, seed: tf.Tensor) -> None:
     # reference marginal likelihood estimate
     reference_log_marginal_likelihood = univariate_log_marginal_likelihood(
         y=Datum.y_data, K=Datum.K, noise_var=Datum.noise_var
@@ -208,7 +209,7 @@ def test_variational_univariate_log_likelihood(diag: bool, whiten: bool) -> None
         q_mu=q_mu,
         q_sqrt=q_sqrt,
     )
-    model_likelihood = model.elbo(Datum.data).numpy()
+    model_likelihood = model.elbo(Datum.data, seed=seed).numpy()
     assert_allclose(model_likelihood, reference_log_marginal_likelihood, atol=4)
 
 

--- a/tests/gpflow/models/test_vgp.py
+++ b/tests/gpflow/models/test_vgp.py
@@ -18,7 +18,7 @@ import gpflow
 from gpflow.config import default_float
 
 
-def test_update_vgp_data() -> None:
+def test_update_vgp_data(seed: tf.Tensor) -> None:
     rng = np.random.default_rng(20220223)
     sample = lambda *shape: tf.convert_to_tensor(rng.standard_normal(shape), dtype=default_float())
 
@@ -37,7 +37,7 @@ def test_update_vgp_data() -> None:
         num_latent_gps=n_outputs,
     )
     gpflow.optimizers.Scipy().minimize(
-        model.training_loss_closure(),
+        model.training_loss_closure(seed=seed, compile=False),
         variables=model.trainable_variables,
         options=dict(maxiter=25),
         compile=True,

--- a/tests/gpflow/optimizers/test_scipy.py
+++ b/tests/gpflow/optimizers/test_scipy.py
@@ -45,7 +45,7 @@ def _create_full_gp_model() -> GPModel:
     )
 
 
-def test_scipy_jit() -> None:
+def test_scipy_jit(seed: tf.Tensor) -> None:
     m1 = _create_full_gp_model()
     m2 = _create_full_gp_model()
 
@@ -53,13 +53,13 @@ def test_scipy_jit() -> None:
     opt2 = gpflow.optimizers.Scipy()
 
     opt1.minimize(
-        m1.training_loss,
+        m1.training_loss_closure(seed=seed),
         variables=m1.trainable_variables,
         options=dict(maxiter=50),
         compile=False,
     )
     opt2.minimize(
-        m2.training_loss,
+        m2.training_loss_closure(seed=seed),
         variables=m2.trainable_variables,
         options=dict(maxiter=50),
         compile=True,

--- a/tests/gpflow/posteriors/test_bo_integration.py
+++ b/tests/gpflow/posteriors/test_bo_integration.py
@@ -344,10 +344,10 @@ def _X_new(_data: Tuple[tf.Variable, tf.Variable]) -> tf.Tensor:
 
 
 @pytest.fixture
-def _optimize(_data: Tuple[tf.Variable, tf.Variable]) -> Callable[[GPModel], None]:
+def _optimize(_data: Tuple[tf.Variable, tf.Variable], seed: tf.Tensor) -> Callable[[GPModel], None]:
     def optimize(model: GPModel) -> None:
         gpflow.optimizers.Scipy().minimize(
-            training_loss_closure(model, _data, compile=_COMPILE),
+            training_loss_closure(model, _data, seed=seed, compile=_COMPILE),
             variables=model.trainable_variables,
             options=dict(maxiter=_MAXITER),
             method="BFGS",

--- a/tests/gpflow/test_base_prior.py
+++ b/tests/gpflow/test_base_prior.py
@@ -8,7 +8,7 @@ from tensorflow_probability.python.bijectors import Exp
 from tensorflow_probability.python.distributions import Uniform
 
 import gpflow
-from gpflow.base import AnyNDArray, PriorOn
+from gpflow.base import AnyNDArray, PriorOn, Seed
 from gpflow.config import set_default_float
 from gpflow.utilities import to_default_float
 
@@ -109,17 +109,20 @@ class DummyModel(gpflow.models.BayesianModel):
 
         self.theta = gpflow.Parameter(self.value, prior=prior, transform=transform)
 
-    def maximum_log_likelihood_objective(self, *args: Any, **kwargs: Any) -> tf.Tensor:
+    def maximum_log_likelihood_objective(
+        self, *args: Any, seed: Seed = None, **kwargs: Any
+    ) -> tf.Tensor:
         assert not args
+        assert isinstance(seed, tf.Tensor)
         assert not kwargs
         return (self.theta + 5) ** 2
 
 
-def test_map_invariance_to_transform() -> None:
+def test_map_invariance_to_transform(seed: tf.Tensor) -> None:
     m1 = DummyModel(with_transform=True)
     m2 = DummyModel(with_transform=False)
     assert np.allclose(
-        m1.log_posterior_density().numpy(), m2.log_posterior_density().numpy()
+        m1.log_posterior_density(seed=seed).numpy(), m2.log_posterior_density(seed=seed).numpy()
     ), "log posterior density should not be affected by a transform"
 
 

--- a/tests/gpflow/test_inducing_variables.py
+++ b/tests/gpflow/test_inducing_variables.py
@@ -34,7 +34,7 @@ class TestContext(ErrorContext):
         builder.add_line(self.message)
 
 
-def test_inducing_points_with_variable_shape() -> None:
+def test_inducing_points_with_variable_shape(seed: tf.Tensor) -> None:
     N, M1, D, P = 50, 13, 3, 1
     X, Y = np.random.randn(N, D), np.random.randn(N, P)
 
@@ -48,13 +48,14 @@ def test_inducing_points_with_variable_shape() -> None:
     # TensorFlow optimizers expect shape to be known at construction time.
 
     m = gpflow.models.SGPR(data=(X, Y), kernel=gpflow.kernels.Matern32(), inducing_variable=iv)
+    loss = m.training_loss_closure(seed=seed)
 
     # Check 1: that we can still optimize with None shape
     opt = tf.optimizers.Adam()
 
     @tf.function
     def optimization_step() -> None:
-        opt.minimize(m.training_loss, m.trainable_variables)
+        opt.minimize(loss, m.trainable_variables)
 
     optimization_step()
 

--- a/tests/gpflow/test_logdensities.py
+++ b/tests/gpflow/test_logdensities.py
@@ -23,8 +23,6 @@ from gpflow import logdensities
 from gpflow.base import AnyNDArray
 from gpflow.utilities import to_default_float
 
-rng = np.random.RandomState(1)
-
 
 @pytest.mark.parametrize("x, mu, var", [(0.9, 0.5, 1.3)])
 def test_gaussian(x: float, mu: float, var: float) -> None:
@@ -100,7 +98,7 @@ def test_student_t(x: float, mean: float, scale: float, df: int) -> None:
 def test_beta(x: float, alpha: float, beta: float) -> None:
     gpf = logdensities.beta(x, alpha, beta).numpy()
     sps = scipy.stats.beta(a=alpha, b=beta).logpdf(x)
-    np.testing.assert_allclose(gpf, sps)
+    np.testing.assert_allclose(gpf, sps, rtol=1e-6)
 
 
 @pytest.mark.parametrize("x, mu, sigma", [(0.9, 0.5, 1.3)])

--- a/tests/integration/test_linear_noise.py
+++ b/tests/integration/test_linear_noise.py
@@ -16,6 +16,7 @@ from typing import Callable
 
 import numpy as np
 import pytest
+import tensorflow as tf
 from check_shapes import ShapeChecker
 
 import gpflow
@@ -112,10 +113,10 @@ CREATE_MODELS = (
 
 
 @pytest.mark.parametrize("create_model", CREATE_MODELS)
-def test_infer_noise(create_model: Callable[[RegressionData], GPModel]) -> None:
+def test_infer_noise(create_model: Callable[[RegressionData], GPModel], seed: tf.Tensor) -> None:
     model = create_model(Datum.data)
     gpflow.optimizers.Scipy().minimize(
-        training_loss_closure(model, Datum.data),
+        training_loss_closure(model, Datum.data, seed=seed),
         variables=model.trainable_variables,
     )
 


### PR DESCRIPTION
Fixes: #1956 

So, we add a `seed = None` parameter. We use [tfp.random.sanitize_seed](https://www.tensorflow.org/probability/api_docs/python/tfp/random/sanitize_seed) to transform this into a random state, in a backwards-compatible manner, and then we use `tensorflow.random.stateless_*` function to get randomness that only depends on our random state.

This affects our likelihoods and models. This will be a *breaking change* for anybody who implements custom models or likelihoods, but not for people who only call existing code.

I've also added a notebook explaining how this works.