### PR TITLE
Fix mypy error.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,10 @@ def test_auto_graph_compile(caplog: LogCaptureFixture) -> Iterable[None]:
     yield
 
     for when in ["setup", "call", "teardown"]:
-        for record in caplog.get_records(when):
+        # Type ignore below is because `when` should have type
+        # `Literal['setup', 'call', 'teardown']`. We should be able to remove this when we no longer
+        # need to support Python 3.7.
+        for record in caplog.get_records(when):  # type: ignore[arg-type]
             assert not record.msg.startswith("AutoGraph could not transform"), record.getMessage()
 
 


### PR DESCRIPTION
Seems there's been some kind of updated library that's now causing a `mypy` error. Maybe it's a new `pytest`?