### PR TITLE
Sc336/sphinx version switcher

### DIFF
--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -21,7 +21,7 @@ nbformat
 nbsphinx
 pandoc
 # Version 0.10.* bad: https://github.com/pydata/pydata-sphinx-theme/issues/952
-pydata-sphinx-theme!=0.10.*
+pydata-sphinx-theme<0.10.0
 sphinx
 sphinx-autoapi
 # Version 1.19.3 bad: https://github.com/tox-dev/sphinx-autodoc-typehints/issues/259


### PR DESCRIPTION

**PR type:** bugfix

**Related issue(s)/PRs:** resolves #2006

## Summary

**Proposed changes**
This issue is caused by breaking changes in pydata-sphinx-theme (https://github.com/pydata/pydata-sphinx-theme/issues/932).  It doesn't look like the team there know what a fix would look like or see it as a high priority, so pinning the version to avoid further problems.

* pydata-sphinx-theme pinned to <0.10.0 (i.e. 0.9.0)

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [x] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

