### PR TITLE
Updated to compensate for new mypy version

### DIFF
--- a/benchmark/benchmark_api.py
+++ b/benchmark/benchmark_api.py
@@ -184,7 +184,7 @@ class BenchmarkSet:
                 set(self.file_by.by) | set(self.column_by.by) | set(self.row_by.by)
             )
             line_by = set(GroupingKey) - used_by
-            sorted_line_by: Sequence[GroupingKey] = sorted(line_by, key=lambda k: k.key_cost)   # type: ignore
+            sorted_line_by: Sequence[GroupingKey] = sorted(line_by, key=lambda k: k.key_cost)   # type: ignore[arg-type] # for lambda
             return GroupingSpec(sorted_line_by, minimise=True)
 
         return self.line_by

--- a/benchmark/benchmark_api.py
+++ b/benchmark/benchmark_api.py
@@ -17,7 +17,7 @@ Classes and other infrastructure for defining which benchmarks to run and what p
 See ``benchmarks.py`` for concrete instances of these.
 """
 from dataclasses import dataclass
-from typing import Any, Collection, Dict, List, Optional, Tuple, Sequence
+from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple
 
 import pandas as pd
 

--- a/benchmark/benchmark_api.py
+++ b/benchmark/benchmark_api.py
@@ -180,11 +180,11 @@ class BenchmarkSet:
         Get ``line_by``, or a default value if ``line_by`` is ``None``.
         """
         if self.line_by is None:
-            used_by: Sequence[GroupingKey] = (
+            used_by: Set[GroupingKey] = (
                 set(self.file_by.by) | set(self.column_by.by) | set(self.row_by.by)
             )
             line_by = set(GroupingKey) - used_by
-            sorted_line_by: Set[GroupingKey] = sorted(line_by, key=lambda k: k.key_cost)
+            sorted_line_by: Sequence[GroupingKey] = sorted(line_by, key=lambda k: k.key_cost)   # type: ignore
             return GroupingSpec(sorted_line_by, minimise=True)
 
         return self.line_by

--- a/benchmark/benchmark_api.py
+++ b/benchmark/benchmark_api.py
@@ -180,7 +180,9 @@ class BenchmarkSet:
         Get ``line_by``, or a default value if ``line_by`` is ``None``.
         """
         if self.line_by is None:
-            used_by = set(self.file_by.by) | set(self.column_by.by) | set(self.row_by.by)
+            used_by: Sequence[GroupingKey] = (
+                set(self.file_by.by) | set(self.column_by.by) | set(self.row_by.by)
+            )
             line_by = set(GroupingKey) - used_by
             sorted_line_by: Sequence[GroupingKey] = sorted(line_by, key=lambda k: k.key_cost)
             return GroupingSpec(sorted_line_by, minimise=True)

--- a/benchmark/benchmark_api.py
+++ b/benchmark/benchmark_api.py
@@ -17,7 +17,7 @@ Classes and other infrastructure for defining which benchmarks to run and what p
 See ``benchmarks.py`` for concrete instances of these.
 """
 from dataclasses import dataclass
-from typing import Any, Collection, Dict, List, Optional, Tuple
+from typing import Any, Collection, Dict, List, Optional, Tuple, Sequence
 
 import pandas as pd
 
@@ -182,7 +182,7 @@ class BenchmarkSet:
         if self.line_by is None:
             used_by = set(self.file_by.by) | set(self.column_by.by) | set(self.row_by.by)
             line_by = set(GroupingKey) - used_by
-            sorted_line_by = sorted(line_by, key=lambda k: k.key_cost)
+            sorted_line_by: Sequence[GroupingKey] = sorted(line_by, key=lambda k: k.key_cost)
             return GroupingSpec(sorted_line_by, minimise=True)
 
         return self.line_by

--- a/benchmark/benchmark_api.py
+++ b/benchmark/benchmark_api.py
@@ -184,7 +184,7 @@ class BenchmarkSet:
                 set(self.file_by.by) | set(self.column_by.by) | set(self.row_by.by)
             )
             line_by = set(GroupingKey) - used_by
-            sorted_line_by: Sequence[GroupingKey] = sorted(line_by, key=lambda k: k.key_cost)   # type: ignore[arg-type] # for lambda
+            sorted_line_by: Sequence[GroupingKey] = sorted(line_by, key=lambda k: k.key_cost)  # type: ignore[arg-type] # for lambda
             return GroupingSpec(sorted_line_by, minimise=True)
 
         return self.line_by

--- a/benchmark/benchmark_api.py
+++ b/benchmark/benchmark_api.py
@@ -17,7 +17,7 @@ Classes and other infrastructure for defining which benchmarks to run and what p
 See ``benchmarks.py`` for concrete instances of these.
 """
 from dataclasses import dataclass
-from typing import Any, Collection, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Collection, Dict, List, Optional, Sequence, Set, Tuple
 
 import pandas as pd
 
@@ -184,7 +184,7 @@ class BenchmarkSet:
                 set(self.file_by.by) | set(self.column_by.by) | set(self.row_by.by)
             )
             line_by = set(GroupingKey) - used_by
-            sorted_line_by: Sequence[GroupingKey] = sorted(line_by, key=lambda k: k.key_cost)
+            sorted_line_by: Set[GroupingKey] = sorted(line_by, key=lambda k: k.key_cost)
             return GroupingSpec(sorted_line_by, minimise=True)
 
         return self.line_by

--- a/tests/gpflow/models/test_model_predict.py
+++ b/tests/gpflow/models/test_model_predict.py
@@ -79,7 +79,7 @@ model_setups = [
     ModelSetup(model_class=gpflow.models.SVGP, whiten=True, q_diag=True),
     ModelSetup(model_class=gpflow.models.SVGP, whiten=False, q_diag=False),
     ModelSetup(
-        model_class=gpflow.models.SGPR,  # type: ignore[misc]  # mypy thinks SPGR is abstract.
+        model_class=gpflow.models.SGPR,  # type: ignore[type-abstract]  # mypy thinks SPGR is abstract.
         requires_data=True,
         requires_likelihood=False,
     ),

--- a/tests/gpflow/models/test_model_predict.py
+++ b/tests/gpflow/models/test_model_predict.py
@@ -79,7 +79,7 @@ model_setups = [
     ModelSetup(model_class=gpflow.models.SVGP, whiten=True, q_diag=True),
     ModelSetup(model_class=gpflow.models.SVGP, whiten=False, q_diag=False),
     ModelSetup(
-        model_class=gpflow.models.SGPR,  # type: ignore  # mypy thinks SPGR is abstract.
+        model_class=gpflow.models.SGPR,  # type: ignore[type-abstract]  # mypy thinks SPGR is abstract.
         requires_data=True,
         requires_likelihood=False,
     ),

--- a/tests/gpflow/models/test_model_predict.py
+++ b/tests/gpflow/models/test_model_predict.py
@@ -79,7 +79,7 @@ model_setups = [
     ModelSetup(model_class=gpflow.models.SVGP, whiten=True, q_diag=True),
     ModelSetup(model_class=gpflow.models.SVGP, whiten=False, q_diag=False),
     ModelSetup(
-        model_class=gpflow.models.SGPR,  # type: ignore[type-abstract]  # mypy thinks SPGR is abstract.
+        model_class=gpflow.models.SGPR,  # type: ignore  # mypy thinks SPGR is abstract.
         requires_data=True,
         requires_likelihood=False,
     ),

--- a/tests/gpflow/models/test_model_predict.py
+++ b/tests/gpflow/models/test_model_predict.py
@@ -79,7 +79,7 @@ model_setups = [
     ModelSetup(model_class=gpflow.models.SVGP, whiten=True, q_diag=True),
     ModelSetup(model_class=gpflow.models.SVGP, whiten=False, q_diag=False),
     ModelSetup(
-        model_class=gpflow.models.SGPR,  # type: ignore[type-abstract]  # mypy thinks SPGR is abstract.
+        model_class=gpflow.models.SGPR,  # type: ignore[type-abstract, misc]  # mypy thinks SPGR is abstract.
         requires_data=True,
         requires_likelihood=False,
     ),

--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -21,8 +21,8 @@ from typing import Sequence, Set
 import jupytext
 import nbformat
 import pytest
-from nbconvert.preprocessors.execute import ExecutePreprocessor
 from nbclient.exceptions import CellExecutionError
+from nbconvert.preprocessors.execute import ExecutePreprocessor
 
 _NOTEBOOK_DIR = (Path(__file__) / "../../../doc/sphinx/notebooks").resolve()
 

--- a/tests/integration/test_notebooks.py
+++ b/tests/integration/test_notebooks.py
@@ -21,8 +21,8 @@ from typing import Sequence, Set
 import jupytext
 import nbformat
 import pytest
-from nbconvert.preprocessors import ExecutePreprocessor
-from nbconvert.preprocessors.execute import CellExecutionError
+from nbconvert.preprocessors.execute import ExecutePreprocessor
+from nbclient.exceptions import CellExecutionError
 
 _NOTEBOOK_DIR = (Path(__file__) / "../../../doc/sphinx/notebooks").resolve()
 

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -32,6 +32,7 @@ tensorflow-datasets
 matplotlib
 ipywidgets  # Required by tensorflow-datasets
 sklearn  # for mixture-density-network notebook
+scikit-learn
 
 # For benchmarks
 GitPython

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -31,8 +31,7 @@ tensorflow-datasets
 
 matplotlib
 ipywidgets  # Required by tensorflow-datasets
-sklearn  # for mixture-density-network notebook
-scikit-learn
+scikit-learn  # for mixture-density-network notebook
 
 # For benchmarks
 GitPython


### PR DESCRIPTION
**PR type:** bugfix

**Related issue(s)/PRs:** Attempt at solving #2015 

## Summary

**Proposed changes**
Update the `#type: ignore` to specifically ignore the new `type-abstract` error added to mypy this morning.  This is required because mypy is incorrectly identifying SGPR as abstract.

There's also an error relating to implicit exports which doesn't appear to have been there before which I've fixed, plus addition of scikit-learn as the sklearn package wasn't correctly pulling in the necessary dependencies (and is probably unrelated but was required to make a PR that would pass CI).

### Minimal working example

See #2015 for details of the error.  This PR will trigger the CI tests that will demonstrate whether this fix works.

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [x] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

