### PR TITLE
turn jitter into an argument of inv_probit instead of hard-coded inside

### DIFF
--- a/gpflow/likelihoods/utils.py
+++ b/gpflow/likelihoods/utils.py
@@ -16,6 +16,11 @@ import numpy as np
 import tensorflow as tf
 
 
-def inv_probit(x: tf.Tensor) -> tf.Tensor:
-    jitter = 1e-3  # ensures output is strictly between 0 and 1
+def inv_probit(x: tf.Tensor, jitter: float = 1e-3) -> tf.Tensor:
+    """
+    Compute the inverse probit, i.e. the N(0,1) CDF, at x.
+
+    :param x: argument
+    :param jitter: small jitter that ensures output is strictly between 0 and 1
+    """
     return 0.5 * (1.0 + tf.math.erf(x / np.sqrt(2.0))) * (1 - 2 * jitter) + jitter


### PR DESCRIPTION
## Summary

Turn jitter of `inv_probit` utility function into an argument. Add docstring.

### Release notes

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [x] New features: code is well-documented
  - [x] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [x] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

