### PR TITLE
Avoid loss of precision in to_default_float when input is a python float

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -83,5 +83,6 @@ Because GitHub's [graph of contributors](http://github.com/GPflow/GPflow/graphs/
 [@tmct](https://github.com/tmct)
 [@ltiao](https://github.com/ltiao)
 [@corwinpro](https://github.com/corwinpro)
+[@ChrisMorter](https://github.com/ChrisMorter)
 
 Add yourself when you first contribute to GPflow's code, tests, or documentation!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -66,7 +66,21 @@ This release contains contributions from:
 <INSERT>, <NAME>, <HERE>, <USING>, <GITHUB>, <HANDLE>
 
 
-# Release 2.6.3 (next upcoming release in progress)
+# Release 2.6.4
+
+This is yet another bug-fix release.
+
+## Bug Fixes and Other Changes
+
+* Fix to `to_defualt_float` to avoid losing precision when called with python floats.
+
+## Thanks to our Contributors
+
+This release contains contributions from:
+
+ChrisMorter
+
+# Release 2.6.3
 
 This is yet another bug-fix release.
 

--- a/gpflow/utilities/misc.py
+++ b/gpflow/utilities/misc.py
@@ -43,6 +43,12 @@ def to_default_int(x: TensorData) -> tf.Tensor:
     "return: [any...]",
 )
 def to_default_float(x: TensorData) -> tf.Tensor:
+    if not tf.is_tensor(x):
+        # workaround for the fact that tf.cast(, dtype=tf.float64) doesn't directly convert
+        # python floats to tf.float64 tensors. Instead, it converts the python float to a
+        # tf.float32 tensor, and then casts that to be tf.float64. This results in a loss
+        # of precision. See https://github.com/tensorflow/tensorflow/issues/57779 for more context.
+        return tf.convert_to_tensor(x, default_float())
     return tf.cast(x, dtype=default_float())
 
 


### PR DESCRIPTION
**PR type:** bugfix 

## Summary

It seems that `to_default_float` can result in a loss of precision when the input value is a python float. This was previously not the case because `to_default_float` used to use gpflow's `cast` function internally, which used `tf.convert_to_tensor(..., dtype=tf.float64)` in the case that the input is a python float. 

However, this function was declared obsolete in gpflow 2.6.1, and was replaced by Tensorflow's `tf.cast` instead. The implementation of `tf.cast` is such that it converts the python float to a tf.float32 tensor (thereby losing precision), which it then casts to tf.float64.

You can see the essence of the problem as follows (note that 0.99999999 and 1.0 are distinct at 64 bit precision, so the fact that the lhs is rounded to 1.0 demonstrates a loss of precision):

```
lhs = tf.cast(0.99999999, dtype=tf.float64)
rhs = tf.convert_to_tensor(1.0, dtype=tf.float64)
assert lhs != rhs
```

### Release notes


**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [x] The bug case / new feature is covered by unit tests
- [x] Code has type annotations
- [x] Build checks
  - [x] I ran the black+isort formatter (`make format`)
  - [x] I locally tested that the tests pass (`make check-all`)
- [x] Release management
  - [x] RELEASE.md updated with entry for this change
  - [x] New contributors: I've added myself to CONTRIBUTORS.md

