### PR TITLE
Noted cpython 3.8 bug

### DIFF
--- a/benchmark/grouping.py
+++ b/benchmark/grouping.py
@@ -33,6 +33,10 @@ class GroupingKeySource(str, Enum):
     PLOTTER = "plotter"
 
 
+# FIXME: WARNING!  There is a [bug](https://github.com/python/cpython/issues/91267)
+# in cpython3.8 which causes this construction to fail on declaration, throwing
+# TypeError: 'GroupingKey': too many data types: [<class 'tuple'>, <class 'typing.Generic'>]
+# Using any other version of python fixes this.
 class GroupingKey(Tuple[GroupingKeySource, type, bool, float], Enum):
     """ Keys we can group by. """
 


### PR DESCRIPTION
**PR type:** doc improvement

[**Related issue(s)/PRs**](https://github.com/python/cpython/issues/91267)

## Summary
The bug in cpython3.8 linked above is causing our benchmarking to fail.  This isn't really fixable by us, so I've added a warning comment to prevent people banging their heads against this issue.

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [x] Build checks
  - [x] I ran the black+isort formatter (`make format`)
  - [x] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

