### PR TITLE
Use PyPi token for package uploading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,8 +404,8 @@ jobs:
           name: Init .pypirc
           command: |
             echo -e "[pypi]" >> ~/.pypirc
-            echo -e "username = artemav" >> ~/.pypirc
-            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+            echo -e "username = __token__" >> ~/.pypirc
+            echo -e "password = $PYPI_TOKEN" >> ~/.pypirc
       - run:
           name: Create pip package
           command: |


### PR DESCRIPTION
Use PyPi [token](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#id71) for uploading the GPflow's python package via CircleCI instead of the password.
