### PR TITLE
Always copy the final point found by scipy

### DIFF
--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -39,7 +39,6 @@ class Scipy:
         step_callback: Optional[StepCallback] = None,
         compile: bool = True,
         allow_unused_variables: bool = False,
-        always_copy_last_good_state: bool = False,
         **scipy_kwargs: Any,
     ) -> OptimizeResult:
         """
@@ -95,9 +94,8 @@ class Scipy:
         opt_result = scipy.optimize.minimize(
             func, initial_params, jac=True, method=method, **scipy_kwargs
         )
-        if always_copy_last_good_state:
-            values = self.unpack_tensors(variables, opt_result.x)
-            self.assign_tensors(variables, values)
+        values = self.unpack_tensors(variables, opt_result.x)
+        self.assign_tensors(variables, values)
         return opt_result
 
     @classmethod

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -39,6 +39,7 @@ class Scipy:
         step_callback: Optional[StepCallback] = None,
         compile: bool = True,
         allow_unused_variables: bool = False,
+        always_copy_last_good_state: bool = False,
         **scipy_kwargs: Any,
     ) -> OptimizeResult:
         """
@@ -94,8 +95,9 @@ class Scipy:
         opt_result = scipy.optimize.minimize(
             func, initial_params, jac=True, method=method, **scipy_kwargs
         )
-        values = self.unpack_tensors(variables, opt_result.x)
-        self.assign_tensors(variables, values)
+        if always_copy_last_good_state:
+            values = self.unpack_tensors(variables, opt_result.x)
+            self.assign_tensors(variables, values)
         return opt_result
 
     @classmethod

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -91,9 +91,12 @@ class Scipy:
             callback = self.callback_func(variables, step_callback)
             scipy_kwargs.update(dict(callback=callback))
 
-        return scipy.optimize.minimize(
+        opt_result = scipy.optimize.minimize(
             func, initial_params, jac=True, method=method, **scipy_kwargs
         )
+        values = self.unpack_tensors(variables, opt_result.x)
+        self.assign_tensors(variables, values)
+        return opt_result
 
     @classmethod
     def initial_parameters(cls, variables: Sequence[tf.Variable]) -> tf.Tensor:


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix

## Summary
We have observed some instability during model training, where occasionally the SGPR model loss is unexpectadly very poor. We have tracked the problem down to how the _gpflow_ wrapper calls the _scipy_ optimiser (using BFGS in our case).

The wrapper uses `tf.Variable`s for the model hyperparameters and these are updated on every evaluation of the training loss. On those occasions where the BFGS line-search fails for an iteration, the _scipy_ optimiser returns the previous good point that it found and sets appropriate flags in the `OptimizeResult` class. However, the model hyperparameters will have the value of the last evaluation of the failed line-search, which can be quite poor. One solution is for the caller to look at the returned result, realise that there was a fail and copy over the final point from `OptimizeResult` back to the model hyperparameters. However it's perhaps better for the wrapper to always copy the final _scipy_ optimiser point to the model just before returning.

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
* ...
* ...
* ...

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```python
# Put your example code in here
```

### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** yes / no

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

