### PR TITLE
test CI build

### DIFF
--- a/gpflow/__init__.py
+++ b/gpflow/__init__.py
@@ -73,3 +73,5 @@ __all__ = [
     "utilities",
     "versions",
 ]
+
+# trivial change to trigger build


### PR DESCRIPTION
The build of #2050 is failing, but this doesn't seem to be anything introduced by the PR. This PR is a null change to check whether the build system is working correctly.