### PR TITLE
Fix api doc generation for aliases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,11 +55,13 @@ This release contains contributions from:
 ## Bug Fixes and Other Changes
 
 * Fixed bug related to `tf.saved_model` and methods wrapped in `@check_shapes`.
+* Fixed missing docs for `SquaredExponential` and `Constant` kernels.
 
 ## Thanks to our Contributors
 
 This release contains contributions from:
 
+khurram-ghani
 <INSERT>, <NAME>, <HERE>, <USING>, <GITHUB>, <HANDLE>
 
 

--- a/doc/generate_module_rst.py
+++ b/doc/generate_module_rst.py
@@ -170,9 +170,11 @@ class DocumentableModule:
             module.seen_in_dispatchers(seen)
         for function in self.functions:
             if isinstance(function, DocumentableDispatcher):
-                impls = function.obj.funcs.values()
-                for impl in impls:
-                    seen.add(id(impl))
+                # See comment below (for classes) about aliases.
+                if function.name.endswith("." + function.obj.__name__):
+                    impls = function.obj.funcs.values()
+                    for impl in impls:
+                        seen.add(id(impl))
 
     def prune_duplicates(self) -> None:
         seen: Set[int] = set()

--- a/doc/generate_module_rst.py
+++ b/doc/generate_module_rst.py
@@ -18,7 +18,7 @@ import inspect
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, Deque, Dict, List, Mapping, Set, TextIO, Type, Union
+from typing import Any, Callable, Deque, Dict, List, Mapping, Set, TextIO, Tuple, Type, Union
 
 from gpflow.utilities import Dispatcher
 
@@ -165,7 +165,7 @@ class DocumentableModule:
 
         return DocumentableModule(root_name, root, modules, classes, functions)
 
-    def seen_in_dispatchers(self, seen: Set[int]) -> None:
+    def seen_in_dispatchers(self, seen: Set[Tuple[str, int]]) -> None:
         for module in self.modules:
             module.seen_in_dispatchers(seen)
         for function in self.functions:
@@ -177,7 +177,7 @@ class DocumentableModule:
                     seen.add(key)
 
     def prune_duplicates(self) -> None:
-        seen: Set[int] = set()
+        seen: Set[Tuple[str, int]] = set()
         self.seen_in_dispatchers(seen)
 
         # Breadth-first search so that we prefer objects with shorter names.
@@ -189,7 +189,7 @@ class DocumentableModule:
             for c in module.classes:
                 # Account for objects to have aliases, hence include the object name in the key.
                 # We want to generate documentation for both the alias and the original object.
-                key = (c.name[c.name.rfind(".")+1:], id(c.obj))
+                key = (c.name[c.name.rfind(".") + 1 :], id(c.obj))
                 if key not in seen:
                     seen.add(key)
                     new_classes.append(c)
@@ -198,7 +198,7 @@ class DocumentableModule:
             new_functions = []
             for f in module.functions:
                 # See comment above (for classes) about aliases.
-                key = (f.name[f.name.rfind(".")+1:], id(f.obj))
+                key = (f.name[f.name.rfind(".") + 1 :], id(f.obj))
                 if key not in seen:
                     seen.add(key)
                     new_functions.append(f)

--- a/doc/generate_module_rst.py
+++ b/doc/generate_module_rst.py
@@ -186,14 +186,19 @@ class DocumentableModule:
             new_classes = []
             for c in module.classes:
                 if id(c.obj) not in seen:
-                    seen.add(id(c.obj))
+                    # Special treatment for aliases, i.e. when names don't match.
+                    # Don't mark them as seen to avoid the original object being skipped.
+                    if c.name.endswith("." + c.obj.__name__):
+                        seen.add(id(c.obj))
                     new_classes.append(c)
             module.classes = new_classes
 
             new_functions = []
             for f in module.functions:
                 if id(f.obj) not in seen:
-                    seen.add(id(f.obj))
+                    # See comment above (for classes) about aliases.
+                    if f.name.endswith("." + f.obj.__name__):
+                        seen.add(id(f.obj))
                     new_functions.append(f)
             module.functions = new_functions
 


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** doc improvement

**Related issue(s)/PRs:** resolves #2056 <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
* Fix issues with API doc generation for `SquaredExponential` and `Constant` kernels.
* Due to use of aliases, previously the doc generation for these two kernels was missing. Only the minimal docs for `RBF` and `Bias` aliases (respectively) were present.

Doc example with missing classes: https://gpflow.github.io/GPflow/2.7.1/api/gpflow/kernels/index.html#gpflow-kernels-rbf

Generated fixed documentation locally and checked the classes are present.

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [X] Build checks
  - [X] I ran the black+isort formatter (`make format`)
  - [X] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [X] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

