### PR TITLE
Switch to using aenum pkg for config constants

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ requirements = [
     "tensorflow-macos>=2.4.0; platform_system=='Darwin' and platform_machine=='arm64'",
     # NOTE: once we require tensorflow-probability>=0.12, we can remove our custom deepcopy handling
     "typing_extensions",
+    "aenum",
 ]
 
 


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix

**Related issue(s)/PRs:** related to [1985](https://github.com/GPflow/GPflow/pull/1985) <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

<!-- A clear and concise description of the contents of this pull request. -->
The [wrapper](https://github.com/GPflow/GPflow/blob/awav/likelihoods-positive-minimum/gpflow/config/__config__.py#L97-L99) for config constants is a standard Enum. Enums don't work correctly when two members have the same value and result in an alias for the first entry. The PR [1985](https://github.com/GPflow/GPflow/pull/1985) has this issue since both `LIKELIHOODS_POSITIVE_MINIMUM` and `JITTER` have the value `1e-6`.

As proposed by this PR, one simple solution is to use `Constant` from the `aenum` package, which supports duplicate entries correctly for this purpose. However this adds another package dependency to GPflow.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->
We could remove the wrapper and simply have global constants, similar to how it was in the [past](https://github.com/GPflow/GPflow/blob/2974b94deea2dd84ec90059f946159bbd8b1fc43/gpflow/config/__config__.py#L22).

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```python
# Buggy behaviour
class _Values(enum.Enum):
     POSITIVE_MINIMUM = 0.0
     LIKELIHOODS_POSITIVE_MINIMUM = 1e-6
     JITTER = 1e-6

print(_Values.JITTER)
<_Values.LIKELIHOODS_POSITIVE_MINIMUM: 1e-06>

# Fixed behaviour
class _Values(aenum.Constant):
     POSITIVE_MINIMUM = 0.0
     LIKELIHOODS_POSITIVE_MINIMUM = 1e-6
     JITTER = 1e-6

print(_Values.JITTER)
<_Values.JITTER: 1e-06>
```

### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [X] The bug case / new feature is covered by unit tests
- [X] Code has type annotations
- [X] Build checks
  - [X] I ran the black+isort formatter (`make format`)
  - [X] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

