### PR TITLE
Allow setting lengthscale transform in kernel init

### DIFF
--- a/tests/gpflow/kernels/test_kernels.py
+++ b/tests/gpflow/kernels/test_kernels.py
@@ -21,7 +21,7 @@ from check_shapes import check_shapes
 from numpy.testing import assert_allclose
 
 import gpflow.ci_utils
-from gpflow.base import AnyNDArray, TensorType
+from gpflow.base import AnyNDArray, TensorType, Transform
 from gpflow.config import default_float, default_positive_bijector
 from gpflow.kernels import (
     RBF,
@@ -258,25 +258,31 @@ kernel_setups: Tuple[Kernel, ...] = tuple(
 
 @pytest.mark.parametrize("kernel_type", gpflow.ci_utils.subclasses(Stationary))
 @pytest.mark.parametrize("transform", ["exp", "softplus", None])
-def test_kernel_lengthscale_transform(kernel_type: Type[Stationary], transform: str):
+def test_kernel_lengthscale_transform(kernel_type: Type[Stationary], transform: str) -> None:
     kernel = kernel_type(
         lengthscales=[1.0],
         lengthscale_transform=transform,
     )
     expected_transform = transform or default_positive_bijector()
-    assert kernel.lengthscales.transform.name == expected_transform
+    _assert_lengthscale_transform(kernel=kernel, expected_transform=expected_transform)
 
 
 @pytest.mark.parametrize("ard", [True, False])
 @pytest.mark.parametrize("transform", ["exp", "softplus", None])
-def test_anisotropic_kernel_lengthscale_transform_when_using_ard(ard: bool, transform: str):
+def test_anisotropic_kernel_lengthscale_transform_when_using_ard(ard: bool, transform: str) -> None:
     kernel = AnisotropicStationary(
         lengthscales=[1.0, 1.0] if ard else 1.0,
         lengthscale_transform=transform,
         active_dims=[0, 1] if ard else None,
     )
     expected_transform = transform or default_positive_bijector()
-    assert kernel.lengthscales.transform.name == expected_transform
+    _assert_lengthscale_transform(kernel=kernel, expected_transform=expected_transform)
+
+
+def _assert_lengthscale_transform(kernel: Stationary, expected_transform: str) -> None:
+    transform_bijector = kernel.lengthscales.transform
+    assert transform_bijector is not None
+    assert transform_bijector.name == expected_transform
 
 
 @pytest.mark.parametrize("D", [1, 5])


### PR DESCRIPTION
**PR type:** enhancement 

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

This PR allow the lengthscale parameter transform used by `Stationary` kernels to be configured when constructing the kernel. AFAICS, currently it is only possible to control which transformation is used by setting the default using `set_default_positive_bijector`.

The motivation for this is that I've encountered a repeatable cholesky decomposition error when training a SGPR model (using a  custom kernel) on a particular dataset. Unfortunately I can't share the reproduction here because it uses customer data, but the root of the problem is that the lengthscale hits zero for one of the `CosineKernels` from which the custom kernel is comprised, resulting in the cholesky error. This doesn't happen if I use an `exp` transform rather than `softplus`, presumably because it's better suited to handling small values. For this reason, I'd like to be able to use the `exp` transformation for those cosine terms.

However, this codebase is used for various other model and kernel types, all of which would need to be re-validated if I were to use `set_default_positive_bijector`, because that would change the transform for all of them. Also, this validation could quite possible uncover cases when softplus is better than exp. Even just setting it temporarily when constructing this kernel wouldn't be a great solution because the kernel contains several other terms, some of which wouldn't we wouldn't necessarily want to use the `exp` transform for. Instead it would be better to be able to specify the correct transform to use on a more granular level by specifying it through `__init__`.


**What alternatives have you considered?**

- Using `set_default_positive_bijector` to set the default everywhere, and re-validating the behaviour or all other model/kernels types used.
- Just setting the default when constructing this particular kernel type, and then resetting it to softplus afterwards.
 


### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** yes


## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

