### PR TITLE
Test GPflow with Python 3.11.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "3.7"
   max_py_ver:
     type: string
-    default: "3.10"
+    default: "3.11"
   min_tf_ver:
     type: string
     default: "2.4.0"
@@ -274,7 +274,7 @@ jobs:
             mkdir docs_tmp
             python doc/build_docs.py --shard collect <<pipeline.git.branch>> docs_tmp
       - add_ssh_keys:
-          fingerprints:  # Add key to give write-access below 
+          fingerprints:  # Add key to give write-access below
             - "19:0a:d4:e6:43:fa:a4:d3:31:a6:0d:5b:43:05:db:63"
       - run:
           name: Commit documentation

--- a/.pylintrc
+++ b/.pylintrc
@@ -514,4 +514,4 @@ known-third-party=enchant
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,7 +33,7 @@ This release contains contributions from:
 <INSERT>, <NAME>, <HERE>, <USING>, <GITHUB>, <HANDLE>
 
 
-# Release 2.9.0 (next release)
+# Release 2.8.2 (next release)
 
 <INSERT SMALL BLURB ABOUT RELEASE FOCUS AREA AND POTENTIAL TOOLCHAIN CHANGES>
 
@@ -55,18 +55,13 @@ This release contains contributions from:
 
 ## Bug Fixes and Other Changes
 
-* <SIMILAR TO ABOVE SECTION, BUT FOR OTHER IMPORTANT CHANGES / BUG FIXES>
-* <IF A CHANGE CLOSES A GITHUB ISSUE, IT SHOULD BE DOCUMENTED HERE>
-* <NOTES SHOULD BE GROUPED PER AREA>
-* Scipy minimize wrapper caches compiled graphs and re-uses them if called with the same arguments.
-  This functionality can be disabled by setting the new `compile_cache_size` argument to 0. (#2074)
+* Support and test with Python 3.11
 
 ## Thanks to our Contributors
 
 This release contains contributions from:
 
-<INSERT>, <NAME>, <HERE>, <USING>, <GITHUB>, <HANDLE>
-khurram-ghani
+khurram-ghani, jesnie
 
 
 # Release 2.8.1

--- a/gpflow/config/__config__.py
+++ b/gpflow/config/__config__.py
@@ -50,10 +50,9 @@ manager :func:`as_context`:
 """
 
 import contextlib
-import enum
 import os
 from dataclasses import dataclass, field, replace
-from typing import Any, Dict, Generator, List, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, Generator, List, Mapping, Optional, Union
 
 import numpy as np
 import tabulate

--- a/gpflow/kernels/categorical.py
+++ b/gpflow/kernels/categorical.py
@@ -16,7 +16,6 @@ from typing import Any, Optional
 
 import numpy as np
 import tensorflow as tf
-import tensorflow_probability as tfp
 
 from .. import default_int, set_trainable
 from ..base import Parameter, TensorType

--- a/tests/gpflow/expectations/test_expectations.py
+++ b/tests/gpflow/expectations/test_expectations.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Optional, Sequence
 
 import numpy as np
 import pytest
@@ -128,9 +128,9 @@ def inducing_variable() -> iv.InducingVariables:
     return iv.InducingPoints(Z)
 
 
-def _check(params: Iterable[Any]) -> None:
+def _check(params: Iterable[Any], nghp: Optional[int] = None) -> None:
     analytic = expectation(*params)
-    quad = quadrature_expectation(*params)
+    quad = quadrature_expectation(*params, nghp=nghp)  # type: ignore[misc]
     assert_allclose(analytic, quad, rtol=RTOL)
 
 
@@ -302,7 +302,7 @@ def test_exKxz_markov(
     mean: mf.MeanFunction,
     inducing_variable: iv.InducingVariables,
 ) -> None:
-    _check((distribution, (kernel, inducing_variable), mean))
+    _check((distribution, (kernel, inducing_variable), mean), nghp=20)
 
 
 @pytest.mark.parametrize("distribution", distrs("dirac_markov_gauss"))

--- a/tests/gpflow/models/test_methods.py
+++ b/tests/gpflow/models/test_methods.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from dataclasses import dataclass
 from typing import List
 
 import numpy as np
@@ -27,7 +25,6 @@ from gpflow.base import AnyNDArray
 # ------------------------------------------
 
 
-@dataclass(frozen=True)
 class Datum:
     rng: np.random.RandomState = np.random.RandomState(0)
     X: AnyNDArray = rng.randn(100, 2)

--- a/tests/gpflow/models/test_sgpr.py
+++ b/tests/gpflow/models/test_sgpr.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from dataclasses import dataclass
-
 import numpy as np
 import tensorflow as tf
 
@@ -21,7 +19,6 @@ from gpflow.base import AnyNDArray
 from gpflow.utilities import to_default_float
 
 
-@dataclass(frozen=True)
 class Datum:
     rng: np.random.RandomState = np.random.RandomState(0)
     X: AnyNDArray = rng.randn(100, 2)

--- a/tests/gpflow/models/test_svgp.py
+++ b/tests/gpflow/models/test_svgp.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from dataclasses import dataclass
 from typing import Sequence
 
 import numpy as np
@@ -26,7 +24,6 @@ from gpflow.base import AnyNDArray
 from gpflow.models import SVGP
 
 
-@dataclass(frozen=True)
 class DatumSVGP:
     rng: np.random.RandomState = np.random.RandomState(0)
     X: AnyNDArray = rng.randn(20, 1)

--- a/tests/integration/test_linear_noise.py
+++ b/tests/integration/test_linear_noise.py
@@ -21,7 +21,6 @@ from check_shapes import ShapeChecker
 import gpflow
 from gpflow import default_float
 from gpflow.base import AnyNDArray, RegressionData
-from gpflow.config import default_float
 from gpflow.functions import Linear
 from gpflow.kernels import Kernel
 from gpflow.likelihoods import Gaussian


### PR DESCRIPTION
Fixes: #2007 
Fixes: #2078 

Test GPflow with Python 3.11.

I had to remove some `@dataclass` from some tests, because a dataclass cannot have default values that are numpy arrays in Python 3.11 (because it has more stricts tests that the default values must be immutable). Actually the values were only used statically anyways, so `@dataclass` was not needed.

Also removed some unused imports.
