### PR TITLE
Test against prod environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,24 +4,36 @@ parameters:
   min_py_ver:
     type: string
     default: "3.7"
+  prod_py_ver:
+    type: string
+    default: "3.10"
   max_py_ver:
     type: string
     default: "3.10"
   min_tf_ver:
     type: string
     default: "2.4.0"
+  prod_tf_ver:
+    type: string
+    default: "2.8.4"
   max_tf_ver:
     type: string
     default: "2.12.0"
   min_tfp_ver:
     type: string
     default: "0.12.0"
+  prod_tfp_ver:
+    type: string
+    default: "0.16.0"
   max_tfp_ver:
     type: string
     default: "0.20.0"
   min_venv_dir:
     type: string
     default: min_venv
+  prod_venv_dir:
+    type: string
+    default: prod_venv
   max_venv_dir:
     type: string
     default: max_venv
@@ -442,6 +454,15 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
       - install_gpflow:
+          name: install_gpflow_prod
+          py_ver: <<pipeline.parameters.prod_py_ver>>
+          tf_ver: <<pipeline.parameters.prod_tf_ver>>
+          tfp_ver: <<pipeline.parameters.prod_tfp_ver>>
+          venv_dir: <<pipeline.parameters.prod_venv_dir>>
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
+      - install_gpflow:
           name: install_gpflow_max
           py_ver: <<pipeline.parameters.max_py_ver>>
           tf_ver: <<pipeline.parameters.max_tf_ver>>
@@ -456,6 +477,15 @@ workflows:
           venv_dir: <<pipeline.parameters.min_venv_dir>>
           requires:
             - install_gpflow_min
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
+      - verify-install:
+          name: verify-install-prod
+          py_ver: <<pipeline.parameters.prod_py_ver>>
+          venv_dir: <<pipeline.parameters.prod_venv_dir>>
+          requires:
+            - install_gpflow_prod
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
@@ -478,6 +508,15 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
       - type-check:
+          name: type-check-prod
+          py_ver: <<pipeline.parameters.prod_py_ver>>
+          venv_dir: <<pipeline.parameters.prod_venv_dir>>
+          requires:
+            - install_gpflow_prod
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
+      - type-check:
           name: type-check-max
           py_ver: <<pipeline.parameters.max_py_ver>>
           venv_dir: <<pipeline.parameters.max_venv_dir>>
@@ -492,6 +531,15 @@ workflows:
           venv_dir: <<pipeline.parameters.min_venv_dir>>
           requires:
             - install_gpflow_min
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
+      - format-check:
+          name: format-check-prod
+          py_ver: <<pipeline.parameters.prod_py_ver>>
+          venv_dir: <<pipeline.parameters.prod_venv_dir>>
+          requires:
+            - install_gpflow_prod
           filters:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
@@ -514,10 +562,13 @@ workflows:
           name: fast-tests
           requires:
             - verify-install-min
+            - verify-install-prod
             - verify-install-max
             - type-check-min
+            - type-check-prod
             - type-check-max
             - format-check-min
+            - format-check-prod
             - format-check-max
             - docs-test
           filters:
@@ -529,6 +580,16 @@ workflows:
           venv_dir: <<pipeline.parameters.min_venv_dir>>
           requires:
             - install_gpflow_min
+            - fast-tests
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
+      - unit-test:
+          name: unit-test-prod
+          py_ver: <<pipeline.parameters.prod_py_ver>>
+          venv_dir: <<pipeline.parameters.prod_venv_dir>>
+          requires:
+            - install_gpflow_prod
             - fast-tests
           filters:
             tags:
@@ -554,6 +615,16 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
       - notebook-test:
+          name: notebook-test-prod
+          py_ver: <<pipeline.parameters.prod_py_ver>>
+          venv_dir: <<pipeline.parameters.prod_venv_dir>>
+          requires:
+            - install_gpflow_prod
+            - fast-tests
+          filters:
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*(-rc[0-9]+)?/
+      - notebook-test:
           name: notebook-test-max
           py_ver: <<pipeline.parameters.max_py_ver>>
           venv_dir: <<pipeline.parameters.max_venv_dir>>
@@ -568,8 +639,10 @@ workflows:
           requires:
             - fast-tests
             - unit-test-min
+            - unit-test-prod
             - unit-test-max
             - notebook-test-min
+            - notebook-test-prod
             - notebook-test-max
           filters:
             tags:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -60,6 +60,7 @@ This release contains contributions from:
 * <NOTES SHOULD BE GROUPED PER AREA>
 * Scipy minimize wrapper caches compiled graphs and re-uses them if called with the same arguments.
   This functionality can be disabled by setting the new `compile_cache_size` argument to 0. (#2074)
+* Test again 'production' environment (in addition to 'min' and 'max' environments).
 
 ## Thanks to our Contributors
 


### PR DESCRIPTION
**PR type:**  enhancement

**Related issue(s)/PRs:**

## Summary

**Proposed changes**

In addition to testing against the minimum and maximum supported versions of python and tensorflow, we should also check against a "production" environment corresponding to what we use further upstream in other packages.

**What alternatives have you considered?**

Matrix testing, but given how slow the tests are this is probably not plausible.

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

