### PR TITLE
Don't round small values in print summary

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,15 +55,13 @@ This release contains contributions from:
 
 ## Bug Fixes and Other Changes
 
-* <SIMILAR TO ABOVE SECTION, BUT FOR OTHER IMPORTANT CHANGES / BUG FIXES>
-* <IF A CHANGE CLOSES A GITHUB ISSUE, IT SHOULD BE DOCUMENTED HERE>
-* <NOTES SHOULD BE GROUPED PER AREA>
+* Don't round small values in kernel summary printout
 
 ## Thanks to our Contributors
 
 This release contains contributions from:
 
-<INSERT>, <NAME>, <HERE>, <USING>, <GITHUB>, <HANDLE>
+uri-granta
 
 
 # Release 2.9.0

--- a/gpflow/utilities/traversal.py
+++ b/gpflow/utilities/traversal.py
@@ -331,7 +331,7 @@ def _first_three_elements_regexp() -> Pattern[str]:
 
 
 def _str_tensor_value(value: AnyNDArray) -> str:
-    value_str = str(np.around(value, 5))
+    value_str = str(np.where(np.abs(value) < 1, value, np.around(value, 5)))
     if value.size <= 3:
         return value_str
 

--- a/tests/gpflow/utilities/test_traversal.py
+++ b/tests/gpflow/utilities/test_traversal.py
@@ -38,7 +38,8 @@ class Data:
     H1 = 2
     M = 10
     D = 1
-    Z: AnyNDArray = 0.5 * np.ones((M, 1))
+    # use a small Z value to check we don't round it to zero in the print summary
+    Z: AnyNDArray = 0.000005 * np.ones((M, 1))
     ls = 2.0
     var = 1.0
 
@@ -219,11 +220,11 @@ SquaredExponential.lengthscales  Parameter  Softplus + Shift           False    
 
 model_gp_param_print_string = """\
 name                      class      transform    prior    trainable    shape    dtype    value\n\
-------------------------  ---------  -----------  -------  -----------  -------  -------  --------\n\
+------------------------  ---------  -----------  -------  -----------  -------  -------  -----------\n\
 SVGP.kernel.variance      Parameter  Softplus              True         ()       float64  1.0\n\
 SVGP.kernel.lengthscales  Parameter  Softplus              False        ()       float64  2.0\n\
 SVGP.likelihood.variance  Parameter  Softplus              True         ()       float64  1.0\n\
-SVGP.inducing_variable.Z  Parameter  Identity              True         (10, 1)  float64  [[0.5...\n\
+SVGP.inducing_variable.Z  Parameter  Identity              True         (10, 1)  float64  [[5.e-06...\n\
 SVGP.q_mu                 Parameter  Identity              False        (10, 1)  float64  [[0....\n\
 SVGP.q_sqrt               Parameter  Softplus              True         (10, 1)  float64  [[1...."""
 


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

**Proposed changes**

PR #1924 resulted in values in print summary being truncated to 5 decimal places, which is a problem for eg small variances. This PR prevents rounding for values less than 1.

**What alternatives have you considered?**

Arguably any rounding is unnecessary. However, the print summary tests currently have hardcoded expecations and fail when run on MacOS if the values aren't rounded. Since the values are meant to be human readable there is no harm in rounding large values.

### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** yes

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

