### PR TITLE
Update max_tf_version and see what breaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
     default: "2.8.4"
   max_tf_ver:
     type: string
-    default: "2.12.0"
+    default: "2.15.0"
   min_tfp_ver:
     type: string
     default: "0.12.0"
@@ -27,7 +27,7 @@ parameters:
     default: "0.16.0"
   max_tfp_ver:
     type: string
-    default: "0.20.0"
+    default: "0.23.0"
   min_venv_dir:
     type: string
     default: min_venv


### PR DESCRIPTION
**PR type:** 

**Related issue(s)/PRs:** #2097 

## Summary

**Proposed changes**
Update the maximum version of tensorflow we test against and fix any exposed issues.

**What alternatives have you considered?**
Stop pinning the maximum version at all so it always tests against the latest. However, this would force us to resolve issues at a specific time, not when convenient.

### Release notes

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

