### PR TITLE
Don't try to save the compile cache when pickling Scipy optimizer

### DIFF
--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -17,6 +17,7 @@ from collections import OrderedDict
 from typing import (
     Any,
     Callable,
+    Dict,
     FrozenSet,
     Iterable,
     List,
@@ -68,7 +69,7 @@ class Scipy:
             )
         self.compile_cache_size = compile_cache_size
 
-    def __getstate__(self) -> dict[str, Any]:
+    def __getstate__(self) -> Dict[str, Any]:
         # Don't try to save the compile cache
         state = self.__dict__.copy()
         state["compile_cache"] = OrderedDict()

--- a/gpflow/optimizers/scipy.py
+++ b/gpflow/optimizers/scipy.py
@@ -68,6 +68,12 @@ class Scipy:
             )
         self.compile_cache_size = compile_cache_size
 
+    def __getstate__(self) -> dict[str, Any]:
+        # Don't try to save the compile cache
+        state = self.__dict__.copy()
+        state["compile_cache"] = OrderedDict()
+        return state
+
     def minimize(
         self,
         closure: LossClosure,


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

The recently introduced compile cache prevents scipy optimizers from being deepcopied. This can be worked around by simply not pickling them.

### Minimal working example

See tests

### Release notes

Bugfix: allow Scipy optimizer to be deepcopied when using compile cache.

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

