### PR TITLE
Bump max_tf_ver to 2.16.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
     default: "2.8.4"
   max_tf_ver:
     type: string
-    default: "2.15.0"
+    default: "2.16.1"
   min_tfp_ver:
     type: string
     default: "0.12.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
               -e .
               -r tests_requirements.txt
               tensorflow==<<parameters.tf_ver>>
-              tensorflow-probability==<<parameters.tfp_ver>> \n
+              tensorflow-probability[tf]==<<parameters.tfp_ver>> \n
           "
       - run:
           name: Log dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ parameters:
     default: "0.16.0"
   max_tfp_ver:
     type: string
-    default: "0.23.0"
+    default: "0.24.0"
   min_venv_dir:
     type: string
     default: min_venv

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,31 +39,19 @@ This release contains contributions from:
 
 ## Breaking Changes
 
-* <DOCUMENT BREAKING CHANGES HERE>
-* <THIS SECTION SHOULD CONTAIN API AND BEHAVIORAL BREAKING CHANGES>
-
 ## Known Caveats
-
-* <CAVEATS REGARDING THE RELEASE (BUT NOT BREAKING CHANGES).>
-* <ADDING/BUMPING DEPENDENCIES SHOULD GO HERE>
-* <KNOWN LACK OF SUPPORT ON SOME PLATFORM SHOULD GO HERE>
 
 ## Major Features and Improvements
 
-* <INSERT MAJOR FEATURE HERE, USING MARKDOWN SYNTAX>
-* <IF RELEASE CONTAINS MULTIPLE FEATURES FROM SAME AREA, GROUP THEM TOGETHER>
-
 ## Bug Fixes and Other Changes
 
-* <SIMILAR TO ABOVE SECTION, BUT FOR OTHER IMPORTANT CHANGES / BUG FIXES>
-* <IF A CHANGE CLOSES A GITHUB ISSUE, IT SHOULD BE DOCUMENTED HERE>
-* <NOTES SHOULD BE GROUPED PER AREA>
+* Support and test against Tensorflow 2.16. **Note that (like tensorflow-probability) GPflow uses Keras 2. Since TF 2.16 defaults to Keras 3, `tf.keras` must now be imported from the `tf_keras` package. Alternatively, you can import `tf_keras` from the `gpflow.keras` module, which will automatically select the right source depending on which version of TF is installed.**
 
 ## Thanks to our Contributors
 
 This release contains contributions from:
 
-<INSERT>, <NAME>, <HERE>, <USING>, <GITHUB>, <HANDLE>
+uri-granta
 
 
 # Release 2.9.1

--- a/doc/sphinx/notebooks/advanced/gps_for_big_data.pct.py
+++ b/doc/sphinx/notebooks/advanced/gps_for_big_data.pct.py
@@ -27,6 +27,7 @@ import time
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
+import tf_keras
 
 import gpflow
 from gpflow.ci_utils import reduce_in_tests
@@ -214,7 +215,7 @@ def run_adam(model, iterations):
     logf = []
     train_iter = iter(train_dataset.batch(minibatch_size))
     training_loss = model.training_loss_closure(train_iter, compile=True)
-    optimizer = tf.optimizers.Adam()
+    optimizer = tf_keras.optimizers.Adam()
 
     @tf.function
     def optimization_step():

--- a/doc/sphinx/notebooks/advanced/gps_for_big_data.pct.py
+++ b/doc/sphinx/notebooks/advanced/gps_for_big_data.pct.py
@@ -27,7 +27,11 @@ import time
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
-import tf_keras
+
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
 
 import gpflow
 from gpflow.ci_utils import reduce_in_tests

--- a/doc/sphinx/notebooks/advanced/gps_for_big_data.pct.py
+++ b/doc/sphinx/notebooks/advanced/gps_for_big_data.pct.py
@@ -28,13 +28,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
 
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
-
 import gpflow
 from gpflow.ci_utils import reduce_in_tests
+from gpflow.keras import tf_keras
 
 plt.style.use("ggplot")
 

--- a/doc/sphinx/notebooks/advanced/heteroskedastic.pct.py
+++ b/doc/sphinx/notebooks/advanced/heteroskedastic.pct.py
@@ -39,6 +39,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
+import tf_keras
 
 import gpflow as gpf
 
@@ -186,7 +187,7 @@ variational_vars = [(model.q_mu, model.q_sqrt)]
 natgrad_opt = gpf.optimizers.NaturalGradient(gamma=0.1)
 
 adam_vars = model.trainable_variables
-adam_opt = tf.optimizers.Adam(0.01)
+adam_opt = tf_keras.optimizers.Adam(0.01)
 
 
 @tf.function

--- a/doc/sphinx/notebooks/advanced/heteroskedastic.pct.py
+++ b/doc/sphinx/notebooks/advanced/heteroskedastic.pct.py
@@ -39,7 +39,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
-import tf_keras
+
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
 
 import gpflow as gpf
 

--- a/doc/sphinx/notebooks/advanced/heteroskedastic.pct.py
+++ b/doc/sphinx/notebooks/advanced/heteroskedastic.pct.py
@@ -40,12 +40,8 @@ import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
 
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
-
 import gpflow as gpf
+from gpflow.keras import tf_keras
 
 # %% [markdown]
 # ## Data Generation

--- a/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
+++ b/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
@@ -22,21 +22,19 @@
 import numpy as np
 import tensorflow as tf
 
-try:
-    # use legacy Adam optimizer to support old TF versions
-    from tf_keras.optimizers.legacy import Adam
-except ModuleNotFoundError:
-    try:
-        from tensorflow.keras.optimizers.legacy import Adam
-    except ImportError:
-        from tensorflow.keras.optimizers import Adam
-
 import gpflow
 from gpflow import set_trainable
 from gpflow.ci_utils import reduce_in_tests
+from gpflow.keras import tf_keras
 from gpflow.models import GPR, SGPR, SVGP, VGP
 from gpflow.optimizers import NaturalGradient
 from gpflow.optimizers.natgrad import XiSqrtMeanVar
+
+try:
+    # use legacy Adam optimizer to support old TF versions
+    Adam = tf_keras.optimizers.legacy.Adam
+except AttributeError:
+    Adam = tf_keras.keras.optimizers.Adam
 
 # %matplotlib inline
 # %precision 4

--- a/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
+++ b/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
@@ -27,6 +27,12 @@ try:
 except ModuleNotFoundError:
     import tensorflow.keras as tf_keras
 
+try:
+    # use legacy Adam optimizer to support old TF versions
+    from tf_keras.optimizers.legacy import Adam
+except ImportError:
+    from tf_keras.optimizers import Adam
+
 import gpflow
 from gpflow import set_trainable
 from gpflow.ci_utils import reduce_in_tests
@@ -120,8 +126,8 @@ vgp.elbo().numpy()
 set_trainable(vgp.q_mu, False)
 set_trainable(vgp.q_sqrt, False)
 
-adam_opt_for_vgp = tf_keras.optimizers.Adam(adam_learning_rate)
-adam_opt_for_gpr = tf_keras.optimizers.Adam(adam_learning_rate)
+adam_opt_for_vgp = Adam(adam_learning_rate)
+adam_opt_for_gpr = Adam(adam_learning_rate)
 
 # %%
 for i in range(iterations):
@@ -248,7 +254,7 @@ svgp_natgrad = SVGP(
 )
 
 # ordinary gradients with Adam for SVGP
-ordinary_adam_opt = tf_keras.optimizers.Adam(adam_learning_rate)
+ordinary_adam_opt = Adam(adam_learning_rate)
 
 # NatGrads and Adam for SVGP
 # Stop Adam from optimizing the variational parameters
@@ -256,7 +262,7 @@ set_trainable(svgp_natgrad.q_mu, False)
 set_trainable(svgp_natgrad.q_sqrt, False)
 
 # Create the optimize_tensors for SVGP
-natgrad_adam_opt = tf_keras.optimizers.Adam(adam_learning_rate)
+natgrad_adam_opt = Adam(adam_learning_rate)
 
 natgrad_opt = NaturalGradient(gamma=0.1)
 variational_params = [(svgp_natgrad.q_mu, svgp_natgrad.q_sqrt)]
@@ -338,7 +344,7 @@ vgp_bernoulli_natgrad = VGP(
 )
 
 # ordinary gradients with Adam for VGP with Bernoulli likelihood
-adam_opt = tf_keras.optimizers.Adam(adam_learning_rate)
+adam_opt = Adam(adam_learning_rate)
 
 # NatGrads and Adam for VGP with Bernoulli likelihood
 # Stop Adam from optimizing the variational parameters
@@ -346,7 +352,7 @@ set_trainable(vgp_bernoulli_natgrad.q_mu, False)
 set_trainable(vgp_bernoulli_natgrad.q_sqrt, False)
 
 # Create the optimize_tensors for VGP with natural gradients
-natgrad_adam_opt = tf_keras.optimizers.Adam(adam_learning_rate)
+natgrad_adam_opt = Adam(adam_learning_rate)
 natgrad_opt = NaturalGradient(gamma=0.1)
 variational_params = [
     (vgp_bernoulli_natgrad.q_mu, vgp_bernoulli_natgrad.q_sqrt)
@@ -397,7 +403,7 @@ set_trainable(vgp_bernoulli_natgrads_xi.q_mu, False)
 set_trainable(vgp_bernoulli_natgrads_xi.q_sqrt, False)
 
 # Create the optimize_tensors for VGP with Bernoulli likelihood
-adam_opt = tf_keras.optimizers.Adam(adam_learning_rate)
+adam_opt = Adam(adam_learning_rate)
 natgrad_opt = NaturalGradient(gamma=0.01)
 
 variational_params = [

--- a/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
+++ b/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
@@ -31,7 +31,7 @@ from gpflow.optimizers import NaturalGradient
 from gpflow.optimizers.natgrad import XiSqrtMeanVar
 
 try:
-    # use legacy Adam optimizer to support old TF versions
+    # use the legacy Adam optimizer to support old TF versions
     Adam = tf_keras.optimizers.legacy.Adam
 except AttributeError:
     Adam = tf_keras.optimizers.Adam

--- a/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
+++ b/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
@@ -34,7 +34,7 @@ try:
     # use legacy Adam optimizer to support old TF versions
     Adam = tf_keras.optimizers.legacy.Adam
 except AttributeError:
-    Adam = tf_keras.keras.optimizers.Adam
+    Adam = tf_keras.optimizers.Adam
 
 # %matplotlib inline
 # %precision 4

--- a/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
+++ b/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
@@ -23,15 +23,13 @@ import numpy as np
 import tensorflow as tf
 
 try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
-
-try:
     # use legacy Adam optimizer to support old TF versions
     from tf_keras.optimizers.legacy import Adam
-except ImportError:
-    from tf_keras.optimizers import Adam
+except ModuleNotFoundError:
+    try:
+        from tensorflow.keras.optimizers.legacy import Adam
+    except ImportError:
+        from tensorflow.keras.optimizers import Adam
 
 import gpflow
 from gpflow import set_trainable

--- a/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
+++ b/doc/sphinx/notebooks/advanced/natural_gradients.pct.py
@@ -23,10 +23,9 @@ import numpy as np
 import tensorflow as tf
 
 try:
-    # use legacy Adam optimizer to support old TF versions
-    from tensorflow.keras.optimizers.legacy import Adam
-except ImportError:
-    from tensorflow.keras.optimizers import Adam
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
 
 import gpflow
 from gpflow import set_trainable
@@ -121,8 +120,8 @@ vgp.elbo().numpy()
 set_trainable(vgp.q_mu, False)
 set_trainable(vgp.q_sqrt, False)
 
-adam_opt_for_vgp = Adam(adam_learning_rate)
-adam_opt_for_gpr = Adam(adam_learning_rate)
+adam_opt_for_vgp = tf_keras.optimizers.Adam(adam_learning_rate)
+adam_opt_for_gpr = tf_keras.optimizers.Adam(adam_learning_rate)
 
 # %%
 for i in range(iterations):
@@ -249,7 +248,7 @@ svgp_natgrad = SVGP(
 )
 
 # ordinary gradients with Adam for SVGP
-ordinary_adam_opt = Adam(adam_learning_rate)
+ordinary_adam_opt = tf_keras.optimizers.Adam(adam_learning_rate)
 
 # NatGrads and Adam for SVGP
 # Stop Adam from optimizing the variational parameters
@@ -257,7 +256,7 @@ set_trainable(svgp_natgrad.q_mu, False)
 set_trainable(svgp_natgrad.q_sqrt, False)
 
 # Create the optimize_tensors for SVGP
-natgrad_adam_opt = Adam(adam_learning_rate)
+natgrad_adam_opt = tf_keras.optimizers.Adam(adam_learning_rate)
 
 natgrad_opt = NaturalGradient(gamma=0.1)
 variational_params = [(svgp_natgrad.q_mu, svgp_natgrad.q_sqrt)]
@@ -339,7 +338,7 @@ vgp_bernoulli_natgrad = VGP(
 )
 
 # ordinary gradients with Adam for VGP with Bernoulli likelihood
-adam_opt = Adam(adam_learning_rate)
+adam_opt = tf_keras.optimizers.Adam(adam_learning_rate)
 
 # NatGrads and Adam for VGP with Bernoulli likelihood
 # Stop Adam from optimizing the variational parameters
@@ -347,7 +346,7 @@ set_trainable(vgp_bernoulli_natgrad.q_mu, False)
 set_trainable(vgp_bernoulli_natgrad.q_sqrt, False)
 
 # Create the optimize_tensors for VGP with natural gradients
-natgrad_adam_opt = Adam(adam_learning_rate)
+natgrad_adam_opt = tf_keras.optimizers.Adam(adam_learning_rate)
 natgrad_opt = NaturalGradient(gamma=0.1)
 variational_params = [
     (vgp_bernoulli_natgrad.q_mu, vgp_bernoulli_natgrad.q_sqrt)
@@ -398,7 +397,7 @@ set_trainable(vgp_bernoulli_natgrads_xi.q_mu, False)
 set_trainable(vgp_bernoulli_natgrads_xi.q_sqrt, False)
 
 # Create the optimize_tensors for VGP with Bernoulli likelihood
-adam_opt = Adam(adam_learning_rate)
+adam_opt = tf_keras.optimizers.Adam(adam_learning_rate)
 natgrad_opt = NaturalGradient(gamma=0.01)
 
 variational_params = [

--- a/doc/sphinx/notebooks/getting_started/monitoring.pct.py
+++ b/doc/sphinx/notebooks/getting_started/monitoring.pct.py
@@ -29,6 +29,8 @@
 import os
 import warnings
 
+from gpflow.keras import tf_keras
+
 warnings.simplefilter("ignore")
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 # hide: end
@@ -37,11 +39,6 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
-
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
 
 import gpflow
 
@@ -260,7 +257,7 @@ opt = tf_keras.optimizers.Adam()
 
 
 @tf.function
-def optimization_step():
+def optimization_step() -> None:
     opt.minimize(model.training_loss, model.trainable_variables)
 
 

--- a/doc/sphinx/notebooks/getting_started/monitoring.pct.py
+++ b/doc/sphinx/notebooks/getting_started/monitoring.pct.py
@@ -37,7 +37,11 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
-import tf_keras
+
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
 
 import gpflow
 

--- a/doc/sphinx/notebooks/getting_started/monitoring.pct.py
+++ b/doc/sphinx/notebooks/getting_started/monitoring.pct.py
@@ -37,6 +37,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
+import tf_keras
 
 import gpflow
 
@@ -251,7 +252,7 @@ _ = opt.minimize(
 # `gpflow.optimizers.Scipy.minimize()` runs an optimizer until convergence.
 # Other optimizers, like `tensorflow.keras.optimizers.Adam()` need `.minimize()` to be called in a loop:
 
-opt = tf.keras.optimizers.Adam()
+opt = tf_keras.optimizers.Adam()
 
 
 @tf.function

--- a/doc/sphinx/notebooks/getting_started/parameters_and_their_optimisation.pct.py
+++ b/doc/sphinx/notebooks/getting_started/parameters_and_their_optimisation.pct.py
@@ -41,9 +41,13 @@ import numpy as np
 import pandas as pd
 import tensorflow as tf
 import tensorflow_probability as tfp
-import tf_keras
 from check_shapes import check_shapes
 from matplotlib.axes import Axes
+
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
 
 import gpflow
 

--- a/doc/sphinx/notebooks/getting_started/parameters_and_their_optimisation.pct.py
+++ b/doc/sphinx/notebooks/getting_started/parameters_and_their_optimisation.pct.py
@@ -30,6 +30,8 @@
 import os
 import warnings
 
+from gpflow.keras import tf_keras
+
 warnings.simplefilter("ignore")
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 # hide: end
@@ -43,11 +45,6 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 from check_shapes import check_shapes
 from matplotlib.axes import Axes
-
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
 
 import gpflow
 

--- a/doc/sphinx/notebooks/getting_started/parameters_and_their_optimisation.pct.py
+++ b/doc/sphinx/notebooks/getting_started/parameters_and_their_optimisation.pct.py
@@ -41,6 +41,7 @@ import numpy as np
 import pandas as pd
 import tensorflow as tf
 import tensorflow_probability as tfp
+import tf_keras
 from check_shapes import check_shapes
 from matplotlib.axes import Axes
 
@@ -498,7 +499,7 @@ model = gpflow.models.GPR(
     + gpflow.kernels.Periodic(gpflow.kernels.SquaredExponential(), period=1.0),
 )
 
-opt = tf.keras.optimizers.Adam()
+opt = tf_keras.optimizers.Adam()
 
 
 @tf.function

--- a/doc/sphinx/notebooks/tailor/external-mean-function.pct.py
+++ b/doc/sphinx/notebooks/tailor/external-mean-function.pct.py
@@ -26,6 +26,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
+import tf_keras
 
 import gpflow
 from gpflow.ci_utils import reduce_in_tests
@@ -142,14 +143,14 @@ from gpflow.config import default_float
 
 
 def build_mean_function():
-    tf.keras.backend.set_floatx("float64")
+    tf_keras.backend.set_floatx("float64")
     assert default_float() == np.float64
 
-    inputs = tf.keras.layers.Input(shape=(1,))
-    x = tf.keras.layers.Dense(64, activation="relu")(inputs)
-    x = tf.keras.layers.Dense(64, activation="relu")(x)
-    outputs = tf.keras.layers.Dense(1)(x)
-    return tf.keras.Model(inputs=inputs, outputs=outputs)
+    inputs = tf_keras.layers.Input(shape=(1,))
+    x = tf_keras.layers.Dense(64, activation="relu")(inputs)
+    x = tf_keras.layers.Dense(64, activation="relu")(x)
+    outputs = tf_keras.layers.Dense(1)(x)
+    return tf_keras.Model(inputs=inputs, outputs=outputs)
 
 
 # %% [markdown]

--- a/doc/sphinx/notebooks/tailor/external-mean-function.pct.py
+++ b/doc/sphinx/notebooks/tailor/external-mean-function.pct.py
@@ -26,7 +26,11 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
-import tf_keras
+
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
 
 import gpflow
 from gpflow.ci_utils import reduce_in_tests

--- a/doc/sphinx/notebooks/tailor/external-mean-function.pct.py
+++ b/doc/sphinx/notebooks/tailor/external-mean-function.pct.py
@@ -27,13 +27,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
 
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
-
 import gpflow
 from gpflow.ci_utils import reduce_in_tests
+from gpflow.keras import tf_keras
 from gpflow.kernels import RBF
 from gpflow.models import GPR
 

--- a/doc/sphinx/notebooks/tailor/external-mean-function.pct.py
+++ b/doc/sphinx/notebooks/tailor/external-mean-function.pct.py
@@ -196,7 +196,7 @@ def run_adam(model, iterations):
     """
     # Create an Adam Optimizer action
     logf = []
-    adam = tf.optimizers.Adam()
+    adam = tf_keras.optimizers.Adam()
     optimization_step = create_optimization_step(adam, model)
     for step in range(iterations):
         loss = optimization_step()

--- a/doc/sphinx/notebooks/tailor/gp_nn.pct.py
+++ b/doc/sphinx/notebooks/tailor/gp_nn.pct.py
@@ -24,6 +24,7 @@ from typing import Dict, Optional, Tuple
 import numpy as np
 import tensorflow as tf
 import tensorflow_datasets as tfds
+import tf_keras
 from scipy.cluster.vq import kmeans2
 
 import gpflow
@@ -81,29 +82,29 @@ class KernelWithConvNN(gpflow.kernels.Kernel):
             input_size = int(tf.reduce_prod(image_shape))
             input_shape = (input_size,)
 
-            self.cnn = tf.keras.Sequential(
+            self.cnn = tf_keras.Sequential(
                 [
-                    tf.keras.layers.InputLayer(
+                    tf_keras.layers.InputLayer(
                         input_shape=input_shape, batch_size=batch_size
                     ),
-                    tf.keras.layers.Reshape(image_shape),
-                    tf.keras.layers.Conv2D(
+                    tf_keras.layers.Reshape(image_shape),
+                    tf_keras.layers.Conv2D(
                         filters=32,
                         kernel_size=image_shape[:-1],
                         padding="same",
                         activation="relu",
                     ),
-                    tf.keras.layers.MaxPool2D(pool_size=(2, 2), strides=2),
-                    tf.keras.layers.Conv2D(
+                    tf_keras.layers.MaxPool2D(pool_size=(2, 2), strides=2),
+                    tf_keras.layers.Conv2D(
                         filters=64,
                         kernel_size=(5, 5),
                         padding="same",
                         activation="relu",
                     ),
-                    tf.keras.layers.MaxPool2D(pool_size=(2, 2), strides=2),
-                    tf.keras.layers.Flatten(),
-                    tf.keras.layers.Dense(output_dim, activation="relu"),
-                    tf.keras.layers.Lambda(to_default_float),
+                    tf_keras.layers.MaxPool2D(pool_size=(2, 2), strides=2),
+                    tf_keras.layers.Flatten(),
+                    tf_keras.layers.Dense(output_dim, activation="relu"),
+                    tf_keras.layers.Lambda(to_default_float),
                 ]
             )
 

--- a/doc/sphinx/notebooks/tailor/gp_nn.pct.py
+++ b/doc/sphinx/notebooks/tailor/gp_nn.pct.py
@@ -184,7 +184,7 @@ model = gpflow.models.SVGP(
 
 # %%
 data_iterator = iter(dataset)
-adam_opt = tf.optimizers.Adam(0.001)
+adam_opt = tf_keras.optimizers.Adam(0.001)
 
 training_loss = model.training_loss_closure(data_iterator)
 

--- a/doc/sphinx/notebooks/tailor/gp_nn.pct.py
+++ b/doc/sphinx/notebooks/tailor/gp_nn.pct.py
@@ -24,8 +24,12 @@ from typing import Dict, Optional, Tuple
 import numpy as np
 import tensorflow as tf
 import tensorflow_datasets as tfds
-import tf_keras
 from scipy.cluster.vq import kmeans2
+
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
 
 import gpflow
 from gpflow.ci_utils import reduce_in_tests

--- a/doc/sphinx/notebooks/tailor/gp_nn.pct.py
+++ b/doc/sphinx/notebooks/tailor/gp_nn.pct.py
@@ -26,13 +26,9 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 from scipy.cluster.vq import kmeans2
 
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
-
 import gpflow
 from gpflow.ci_utils import reduce_in_tests
+from gpflow.keras import tf_keras
 from gpflow.utilities import to_default_float
 
 iterations = reduce_in_tests(100)

--- a/doc/sphinx/notebooks/tailor/mixture_density_network.pct.py
+++ b/doc/sphinx/notebooks/tailor/mixture_density_network.pct.py
@@ -29,6 +29,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
+from gpflow.keras import tf_keras
+
 # %matplotlib inline
 
 np.random.seed(1)  # for reproducibility of this notebook
@@ -87,11 +89,6 @@ _ = plt.ylabel("$y$")
 from typing import Callable, Optional, Tuple
 
 import tensorflow as tf
-
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
 
 from gpflow.base import Parameter
 from gpflow.models import BayesianModel, ExternalDataTrainingLossMixin

--- a/doc/sphinx/notebooks/tailor/mixture_density_network.pct.py
+++ b/doc/sphinx/notebooks/tailor/mixture_density_network.pct.py
@@ -87,6 +87,7 @@ _ = plt.ylabel("$y$")
 from typing import Callable, Optional, Tuple
 
 import tensorflow as tf
+import tf_keras
 
 from gpflow.base import Parameter
 from gpflow.models import BayesianModel, ExternalDataTrainingLossMixin
@@ -105,7 +106,7 @@ class MDN(BayesianModel, ExternalDataTrainingLossMixin):
         inner_dims: Optional[list] = [10, 10],
         activation: Optional[
             Callable[[tf.Tensor], tf.Tensor]
-        ] = tf.keras.activations.relu,
+        ] = tf_keras.activations.relu,
     ):
         super().__init__()
 

--- a/doc/sphinx/notebooks/tailor/mixture_density_network.pct.py
+++ b/doc/sphinx/notebooks/tailor/mixture_density_network.pct.py
@@ -87,7 +87,11 @@ _ = plt.ylabel("$y$")
 from typing import Callable, Optional, Tuple
 
 import tensorflow as tf
-import tf_keras
+
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
 
 from gpflow.base import Parameter
 from gpflow.models import BayesianModel, ExternalDataTrainingLossMixin

--- a/gpflow/__init__.py
+++ b/gpflow/__init__.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 # flake8: noqa
-import os
-
-os.environ["TF_USE_LEGACY_KERAS"] = "1"
 
 from . import (
     conditionals,

--- a/gpflow/__init__.py
+++ b/gpflow/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "experimental",
     "functions",
     "inducing_variables",
+    "keras",
     "kernels",
     "kullback_leiblers",
     "likelihoods",

--- a/gpflow/__init__.py
+++ b/gpflow/__init__.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 # flake8: noqa
+import os
+
+os.environ["TF_USE_LEGACY_KERAS"] = "1"
 
 from . import (
     conditionals,

--- a/gpflow/keras.py
+++ b/gpflow/keras.py
@@ -1,0 +1,32 @@
+# Copyright 2024 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GPflow currently uses Keras 2. Depending on the version of Tensorflow installed,
+# this is available either at tf_keras or at tensorflow.keras. This module provides
+# a helpful version-agnostic shortcut for importing this. Note though that importing specific
+# identifiers can only be done via attribute lookups:
+#
+# >> from gpflow.keras import tf_keras
+# >> Adam = tf_keras.optimizers.Adam
+# >> # The following does NOT work
+# >> from tf_keras.optimizers import Adam
+
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
+
+tf_keras = tf_keras
+
+__all__ = ["tf_keras"]

--- a/gpflow/models/training_mixins.py
+++ b/gpflow/models/training_mixins.py
@@ -47,7 +47,7 @@ class InternalDataTrainingLossMixin:
       - a uniform API for the training loss :meth:`training_loss`
       - a convenience method :meth:`training_loss_closure` for constructing the closure expected by
         various optimizers, namely :class:`gpflow.optimizers.Scipy` and subclasses of
-        `tf.optimizers.Optimizer`.
+        `tf_keras.optimizers.Optimizer`.
 
     See :class:`ExternalDataTrainingLossMixin` for an equivalent mixin for models that do **not**
     own their own data.
@@ -67,7 +67,7 @@ class InternalDataTrainingLossMixin:
         """
         Convenience method. Returns a closure which itself returns the training loss. This closure
         can be passed to the minimize methods on :class:`gpflow.optimizers.Scipy` and subclasses of
-        `tf.optimizers.Optimizer`.
+        `tf_keras.optimizers.Optimizer`.
 
         :param compile: If `True` (default), compile the training loss function in a TensorFlow
             graph by wrapping it in tf.function()
@@ -86,7 +86,7 @@ class ExternalDataTrainingLossMixin:
       - a uniform API for the training loss :meth:`training_loss`
       - a convenience method :meth:`training_loss_closure` for constructing the closure expected by
         various optimizers, namely :class:`gpflow.optimizers.Scipy` and subclasses of
-        `tf.optimizers.Optimizer`.
+        `tf_keras.optimizers.Optimizer`.
 
     See :class:`InternalDataTrainingLossMixin` for an equivalent mixin for models that **do** own
     their own data.

--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -19,12 +19,8 @@ from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 import tensorflow as tf
 from check_shapes import check_shapes
 
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
-
 from ..base import AnyNDArray, Parameter, _to_constrained
+from ..keras import tf_keras
 
 Scalar = Union[float, tf.Tensor, AnyNDArray]
 LossClosure = Callable[[], tf.Tensor]

--- a/gpflow/optimizers/natgrad.py
+++ b/gpflow/optimizers/natgrad.py
@@ -19,6 +19,11 @@ from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Union
 import tensorflow as tf
 from check_shapes import check_shapes
 
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
+
 from ..base import AnyNDArray, Parameter, _to_constrained
 
 Scalar = Union[float, tf.Tensor, AnyNDArray]
@@ -172,7 +177,7 @@ class XiSqrtMeanVar(XiTransform):
         return natural_to_meanvarsqrt(nat1, nat2)
 
 
-class NaturalGradient(tf.optimizers.Optimizer):
+class NaturalGradient(tf_keras.optimizers.Optimizer):
     """
     Implements a natural gradient descent optimizer for variational models
     that are based on a distribution q(u) = N(q_mu, q_sqrt q_sqrtᵀ) that is
@@ -180,7 +185,7 @@ class NaturalGradient(tf.optimizers.Optimizer):
     of the covariance.
 
     Note that this optimizer does not implement the standard API of
-    tf.optimizers.Optimizer. Its only public method is minimize(), which has
+    tf_keras.optimizers.Optimizer. Its only public method is minimize(), which has
     a custom signature (var_list needs to be a list of (q_mu, q_sqrt) tuples,
     where q_mu and q_sqrt are gpflow.Parameter instances, not tf.Variable).
 

--- a/gpflow/utilities/misc.py
+++ b/gpflow/utilities/misc.py
@@ -78,7 +78,7 @@ def is_variable(t: TensorData) -> bool:
 
 def training_loop(
     closure: Callable[[], tf.Tensor],
-    optimizer: Optional[tf.optimizers.Optimizer] = None,
+    optimizer: Optional[tf_keras.optimizers.Optimizer] = None,
     var_list: Optional[List[tf.Variable]] = None,
     maxiter: int = 1_000,
     compile: bool = False,

--- a/gpflow/utilities/misc.py
+++ b/gpflow/utilities/misc.py
@@ -19,10 +19,9 @@ import tensorflow_probability as tfp
 from check_shapes import check_shapes
 
 try:
-    # use legacy Adam optimizer to support old TF versions
-    from tensorflow.keras.optimizers.legacy import Adam
-except ImportError:
-    from tensorflow.keras.optimizers import Adam
+    import tf_keras
+except ModuleNotFoundError:
+    import tf.keras as tf_keras
 
 from ..base import TensorData
 from ..config import default_float, default_int
@@ -96,7 +95,7 @@ def training_loop(
     :return:
     """
 
-    safe_optimizer = Adam() if optimizer is None else optimizer
+    safe_optimizer = tf_keras.optimizers.Adam() if optimizer is None else optimizer
     safe_var_list = [] if var_list is None else var_list
 
     def optimization_step() -> None:

--- a/gpflow/utilities/misc.py
+++ b/gpflow/utilities/misc.py
@@ -18,11 +18,6 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 from check_shapes import check_shapes
 
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
-
 from ..base import TensorData
 from ..config import default_float, default_int
 
@@ -33,6 +28,8 @@ __all__ = [
     "to_default_int",
     "training_loop",
 ]
+
+from ..keras import tf_keras
 
 
 @check_shapes(

--- a/gpflow/utilities/misc.py
+++ b/gpflow/utilities/misc.py
@@ -18,6 +18,12 @@ import tensorflow as tf
 import tensorflow_probability as tfp
 from check_shapes import check_shapes
 
+try:
+    # use legacy Adam optimizer to support old TF versions
+    from tensorflow.keras.optimizers.legacy import Adam
+except ImportError:
+    from tensorflow.keras.optimizers import Adam
+
 from ..base import TensorData
 from ..config import default_float, default_int
 
@@ -90,7 +96,7 @@ def training_loop(
     :return:
     """
 
-    safe_optimizer = tf.optimizers.Adam() if optimizer is None else optimizer
+    safe_optimizer = Adam() if optimizer is None else optimizer
     safe_var_list = [] if var_list is None else var_list
 
     def optimization_step() -> None:

--- a/gpflow/utilities/misc.py
+++ b/gpflow/utilities/misc.py
@@ -21,7 +21,7 @@ from check_shapes import check_shapes
 try:
     import tf_keras
 except ModuleNotFoundError:
-    import tf.keras as tf_keras
+    import tensorflow.keras as tf_keras
 
 from ..base import TensorData
 from ..config import default_float, default_int

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,12 @@ requirements = [
     "scipy",
     "setuptools>=41.0.0",  # to satisfy dependency constraints
     "tabulate",
-    "tensorflow-probability>=0.12.0",
+    "tensorflow-probability[tf]>=0.12.0",
     "tensorflow>=2.4.0; platform_system!='Darwin' or platform_machine!='arm64'",
     # NOTE: Support of Apple Silicon MacOS platforms is in an experimental mode
     "tensorflow-macos>=2.4.0; platform_system=='Darwin' and platform_machine=='arm64'",
     # NOTE: once we require tensorflow-probability>=0.12, we can remove our custom deepcopy handling
     "typing_extensions",
-    "tf-keras",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ requirements = [
     "tensorflow-macos>=2.4.0; platform_system=='Darwin' and platform_machine=='arm64'",
     # NOTE: once we require tensorflow-probability>=0.12, we can remove our custom deepcopy handling
     "typing_extensions",
+    "tf-keras",
 ]
 
 

--- a/tests/gpflow/conditionals/test_uncertain_conditional.py
+++ b/tests/gpflow/conditionals/test_uncertain_conditional.py
@@ -20,15 +20,11 @@ import tensorflow as tf
 from check_shapes import ShapeChecker, check_shapes
 from numpy.testing import assert_allclose
 
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
-
 import gpflow
 from gpflow.base import AnyNDArray, MeanAndVariance
 from gpflow.conditionals import conditional, uncertain_conditional
 from gpflow.config import default_float
+from gpflow.keras import tf_keras
 from gpflow.mean_functions import Constant, Linear, MeanFunction, Zero
 from gpflow.quadrature import mvnquad
 from gpflow.utilities import training_loop

--- a/tests/gpflow/conditionals/test_uncertain_conditional.py
+++ b/tests/gpflow/conditionals/test_uncertain_conditional.py
@@ -20,6 +20,11 @@ import tensorflow as tf
 from check_shapes import ShapeChecker, check_shapes
 from numpy.testing import assert_allclose
 
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
+
 import gpflow
 from gpflow.base import AnyNDArray, MeanAndVariance
 from gpflow.conditionals import conditional, uncertain_conditional
@@ -193,7 +198,7 @@ def test_no_uncertainty(white: bool, mean: Optional[str]) -> None:
 
     training_loop(
         model.training_loss_closure(Data.data),
-        optimizer=tf.optimizers.Adam(),
+        optimizer=tf_keras.optimizers.Adam(),
         var_list=model.trainable_variables,
         maxiter=100,
         compile=True,
@@ -226,7 +231,7 @@ def test_monte_carlo_1_din(white: bool, mean: Optional[str]) -> None:
 
     training_loop(
         model.training_loss_closure(DataMC1.data),
-        optimizer=tf.optimizers.Adam(),
+        optimizer=tf_keras.optimizers.Adam(),
         var_list=model.trainable_variables,
         maxiter=200,
         compile=True,
@@ -261,7 +266,7 @@ def test_monte_carlo_2_din(white: bool, mean: Optional[str]) -> None:
 
     training_loop(
         model.training_loss_closure(DataMC2.data),
-        optimizer=tf.optimizers.Adam(),
+        optimizer=tf_keras.optimizers.Adam(),
         var_list=model.trainable_variables,
         maxiter=100,
         compile=True,

--- a/tests/gpflow/models/test_svgp.py
+++ b/tests/gpflow/models/test_svgp.py
@@ -18,14 +18,10 @@ import pytest
 import tensorflow as tf
 from numpy.testing import assert_allclose
 
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
-
 import gpflow
 from gpflow import set_trainable
 from gpflow.base import AnyNDArray
+from gpflow.keras import tf_keras
 from gpflow.models import SVGP
 
 

--- a/tests/gpflow/models/test_svgp.py
+++ b/tests/gpflow/models/test_svgp.py
@@ -18,6 +18,11 @@ import pytest
 import tensorflow as tf
 from numpy.testing import assert_allclose
 
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
+
 import gpflow
 from gpflow import set_trainable
 from gpflow.base import AnyNDArray
@@ -184,7 +189,7 @@ def test_stochastic_gradients(
 
     def training_loop(indices: Sequence[int], num_data: int, max_iter: int) -> SVGP:
         model = get_model(num_data)
-        opt = tf.optimizers.SGD(learning_rate=0.001)
+        opt = tf_keras.optimizers.SGD(learning_rate=0.001)
         data = X[indices], Y[indices]
         for _ in range(max_iter):
             with tf.GradientTape() as tape:

--- a/tests/gpflow/test_all.py
+++ b/tests/gpflow/test_all.py
@@ -58,11 +58,11 @@ _MODULES_WITH_ALL = [m for m in _MODULES if hasattr(m, "__all__")]
 
 @pytest.mark.parametrize("package", _PACKAGES)
 def test_all_present_and_up_to_date(package: ModuleType) -> None:
-    imported_sorted = sorted(attr for attr in dir(package) if not is_dunder(attr))
+    imported_sorted = set(attr for attr in dir(package) if not is_dunder(attr))
     all_list = getattr(package, "__all__", None)
     assert all_list is not None, f"Package {package} is missing an explicit __all__."
-    all_sorted = sorted(attr for attr in all_list if not is_dunder(attr))
-    assert imported_sorted == all_sorted, (
+    all_sorted = set(attr for attr in all_list if not is_dunder(attr))
+    assert imported_sorted - {"os"} == all_sorted, (
         f"{package}.__all__ is outdated."
         f" Imported values are {imported_sorted}, but exported values are {all_list}."
     )

--- a/tests/gpflow/test_all.py
+++ b/tests/gpflow/test_all.py
@@ -58,14 +58,11 @@ _MODULES_WITH_ALL = [m for m in _MODULES if hasattr(m, "__all__")]
 
 @pytest.mark.parametrize("package", _PACKAGES)
 def test_all_present_and_up_to_date(package: ModuleType) -> None:
-    imported_sorted = set(attr for attr in dir(package) if not is_dunder(attr))
+    imported_set = set(attr for attr in dir(package) if not is_dunder(attr))
     all_list = getattr(package, "__all__", None)
     assert all_list is not None, f"Package {package} is missing an explicit __all__."
-    all_sorted = set(attr for attr in all_list if not is_dunder(attr))
-    assert imported_sorted - {"os"} == all_sorted, (
-        f"{package}.__all__ is outdated."
-        f" Imported values are {imported_sorted}, but exported values are {all_list}."
-    )
+    all_set = set(attr for attr in all_list if not is_dunder(attr))
+    assert imported_set == all_set, f"{package}.__all__ is outdated."
 
 
 @pytest.mark.parametrize("module", _MODULES_WITH_ALL)

--- a/tests/gpflow/test_inducing_variables.py
+++ b/tests/gpflow/test_inducing_variables.py
@@ -21,13 +21,9 @@ import tensorflow as tf
 from check_shapes import get_shape
 from check_shapes.error_contexts import ErrorContext, MessageBuilder
 
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
-
 import gpflow
 import gpflow.inducing_variables as giv
+from gpflow.keras import tf_keras
 
 
 @dataclass(frozen=True)

--- a/tests/gpflow/test_inducing_variables.py
+++ b/tests/gpflow/test_inducing_variables.py
@@ -21,6 +21,11 @@ import tensorflow as tf
 from check_shapes import get_shape
 from check_shapes.error_contexts import ErrorContext, MessageBuilder
 
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
+
 import gpflow
 import gpflow.inducing_variables as giv
 
@@ -50,7 +55,7 @@ def test_inducing_points_with_variable_shape() -> None:
     m = gpflow.models.SGPR(data=(X, Y), kernel=gpflow.kernels.Matern32(), inducing_variable=iv)
 
     # Check 1: that we can still optimize with None shape
-    opt = tf.optimizers.Adam()
+    opt = tf_keras.optimizers.Adam()
 
     @tf.function
     def optimization_step() -> None:

--- a/tests/gpflow/test_monitor.py
+++ b/tests/gpflow/test_monitor.py
@@ -10,13 +10,9 @@ from check_shapes import check_shapes
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
-
 import gpflow
 from gpflow.base import AnyNDArray
+from gpflow.keras import tf_keras
 from gpflow.models import GPR, GPModel
 from gpflow.monitor import (
     ExecuteCallback,

--- a/tests/gpflow/test_monitor.py
+++ b/tests/gpflow/test_monitor.py
@@ -10,6 +10,11 @@ from check_shapes import check_shapes
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
+try:
+    import tf_keras
+except ModuleNotFoundError:
+    import tensorflow.keras as tf_keras
+
 import gpflow
 from gpflow.base import AnyNDArray
 from gpflow.models import GPR, GPModel
@@ -304,7 +309,7 @@ def test_logdir_created(monitor: Monitor, model: GPModel, tmp_path: Path) -> Non
     size_before = _get_size_directory(tmp_path)
     assert size_before > 0
 
-    opt = tf.optimizers.Adam()
+    opt = tf_keras.optimizers.Adam()
     for step in range(Data.num_steps):
         opt.minimize(model.training_loss, model.trainable_variables)
         monitor(step)
@@ -314,7 +319,7 @@ def test_logdir_created(monitor: Monitor, model: GPModel, tmp_path: Path) -> Non
 
 
 def test_compile_monitor(monitor: Monitor, model: GPModel) -> None:
-    opt = tf.optimizers.Adam()
+    opt = tf_keras.optimizers.Adam()
 
     @tf.function
     def tf_func(step: tf.Tensor) -> None:

--- a/tests/gpflow/utilities/test_training_loop.py
+++ b/tests/gpflow/utilities/test_training_loop.py
@@ -1,14 +1,10 @@
 from typing import Any
 
 import numpy as np
-
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
 from check_shapes import ShapeChecker
 
 import gpflow
+from gpflow.keras import tf_keras
 from gpflow.utilities import training_loop
 
 

--- a/tests/gpflow/utilities/test_training_loop.py
+++ b/tests/gpflow/utilities/test_training_loop.py
@@ -1,13 +1,12 @@
 from typing import Any
 
 import numpy as np
-from check_shapes import ShapeChecker
 
 try:
-    # use legacy Adam optimizer to support old TF versions
-    from tensorflow.keras.optimizers.legacy import Adam
-except ImportError:
-    from tensorflow.keras.optimizers import Adam
+    import tf_keras
+except ModuleNotFoundError:
+    import tf.keras as tf_keras
+from check_shapes import ShapeChecker
 
 import gpflow
 from gpflow.utilities import training_loop
@@ -47,8 +46,20 @@ def assert_models_close(
 def test_training_loop_compiles() -> None:
     m1 = create_model()
     m2 = create_model()
-    training_loop(m1.training_loss, Adam(), m1.trainable_variables, maxiter=50, compile=True)
-    training_loop(m2.training_loss, Adam(), m2.trainable_variables, maxiter=50, compile=False)
+    training_loop(
+        m1.training_loss,
+        tf_keras.optimizers.Adam(),
+        m1.trainable_variables,
+        maxiter=50,
+        compile=True,
+    )
+    training_loop(
+        m2.training_loss,
+        tf_keras.optimizers.Adam(),
+        m2.trainable_variables,
+        maxiter=50,
+        compile=False,
+    )
     assert_models_close(m1, m2)
 
 
@@ -58,7 +69,7 @@ def test_training_loop_converges() -> None:
     gpflow.optimizers.Scipy().minimize(mref.training_loss, mref.trainable_variables)
     training_loop(
         m.training_loss,
-        Adam(learning_rate=0.01),
+        tf_keras.optimizers.Adam(learning_rate=0.01),
         m.trainable_variables,
         maxiter=5000,
         compile=True,

--- a/tests/gpflow/utilities/test_training_loop.py
+++ b/tests/gpflow/utilities/test_training_loop.py
@@ -1,8 +1,13 @@
 from typing import Any
 
 import numpy as np
-import tensorflow as tf
 from check_shapes import ShapeChecker
+
+try:
+    # use legacy Adam optimizer to support old TF versions
+    from tensorflow.keras.optimizers.legacy import Adam
+except ImportError:
+    from tensorflow.keras.optimizers import Adam
 
 import gpflow
 from gpflow.utilities import training_loop
@@ -42,12 +47,8 @@ def assert_models_close(
 def test_training_loop_compiles() -> None:
     m1 = create_model()
     m2 = create_model()
-    training_loop(
-        m1.training_loss, tf.optimizers.Adam(), m1.trainable_variables, maxiter=50, compile=True
-    )
-    training_loop(
-        m2.training_loss, tf.optimizers.Adam(), m2.trainable_variables, maxiter=50, compile=False
-    )
+    training_loop(m1.training_loss, Adam(), m1.trainable_variables, maxiter=50, compile=True)
+    training_loop(m2.training_loss, Adam(), m2.trainable_variables, maxiter=50, compile=False)
     assert_models_close(m1, m2)
 
 
@@ -57,7 +58,7 @@ def test_training_loop_converges() -> None:
     gpflow.optimizers.Scipy().minimize(mref.training_loss, mref.trainable_variables)
     training_loop(
         m.training_loss,
-        tf.optimizers.Adam(learning_rate=0.01),
+        Adam(learning_rate=0.01),
         m.trainable_variables,
         maxiter=5000,
         compile=True,

--- a/tests/gpflow/utilities/test_training_loop.py
+++ b/tests/gpflow/utilities/test_training_loop.py
@@ -5,7 +5,7 @@ import numpy as np
 try:
     import tf_keras
 except ModuleNotFoundError:
-    import tf.keras as tf_keras
+    import tensorflow.keras as tf_keras
 from check_shapes import ShapeChecker
 
 import gpflow

--- a/tests/gpflow/utilities/test_traversal.py
+++ b/tests/gpflow/utilities/test_traversal.py
@@ -17,6 +17,11 @@ from typing import Any, Callable, Mapping, Optional, Type
 import numpy as np
 import pytest
 import tensorflow as tf
+
+try:
+    import tf_keras
+except ImportError:
+    import tf.keras as tf_keras
 from _pytest.fixtures import SubRequest
 from packaging.version import Version
 
@@ -65,12 +70,12 @@ class B(tf.Module):
         self.var_fixed = tf.Variable(tf.ones((2, 2, 1)), trainable=False)
 
 
-class C(tf.keras.Model):
+class C(tf_keras.Model):
     def __init__(self, name: Optional[str] = None) -> None:
         super().__init__(name)
         self.variable = tf.Variable(tf.zeros((2, 2, 1)), trainable=True)
         self.param = gpflow.Parameter(0.0)
-        self.dense = tf.keras.layers.Dense(5)
+        self.dense = tf_keras.layers.Dense(5)
 
 
 def create_kernel() -> gpflow.kernels.Kernel:
@@ -409,7 +414,7 @@ def test_print_summary_output_string_with_positive_minimum() -> None:
 
 
 def test_print_summary_for_keras_model() -> None:
-    # Note: best to use `grid` formatting for `tf.keras.Model` printing
+    # Note: best to use `grid` formatting for `tf_keras.Model` printing
     # because of the duplicates in the references to the variables.
     assert tabulate_module_summary(C(), tablefmt="grid") == example_tf_keras_model
 

--- a/tests/gpflow/utilities/test_traversal.py
+++ b/tests/gpflow/utilities/test_traversal.py
@@ -17,17 +17,13 @@ from typing import Any, Callable, Mapping, Optional, Type
 import numpy as np
 import pytest
 import tensorflow as tf
-
-try:
-    import tf_keras
-except ModuleNotFoundError:
-    import tensorflow.keras as tf_keras
 from _pytest.fixtures import SubRequest
 from packaging.version import Version
 
 import gpflow
 from gpflow.base import AnyNDArray
 from gpflow.config import Config, as_context
+from gpflow.keras import tf_keras
 from gpflow.utilities import set_trainable
 from gpflow.utilities.traversal import (
     _merge_leaf_components,

--- a/tests/gpflow/utilities/test_traversal.py
+++ b/tests/gpflow/utilities/test_traversal.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 
 try:
     import tf_keras
-except ImportError:
+except ModuleNotFoundError:
     import tf.keras as tf_keras
 from _pytest.fixtures import SubRequest
 from packaging.version import Version

--- a/tests/gpflow/utilities/test_traversal.py
+++ b/tests/gpflow/utilities/test_traversal.py
@@ -21,7 +21,7 @@ import tensorflow as tf
 try:
     import tf_keras
 except ModuleNotFoundError:
-    import tf.keras as tf_keras
+    import tensorflow.keras as tf_keras
 from _pytest.fixtures import SubRequest
 from packaging.version import Version
 


### PR DESCRIPTION
**PR type:** enhancement

**Related issue(s)/PRs:** #2106 

## Summary

Add support for Tensorflow 2.16.1. Since this uses Keras 3 as the default keras, I've had to:

- explicitly depend on `tf_keras` (Keras 2) which is no longer installed by default; fortunately this can done by specifying the `[tf]` extra with `tensorflow-probability` (as TFP also requires Keras 2)
- switch all uses of `tf.keras` to use `tf_keras` instead if it's available

A simpler approach would be to make `tf.keras` automatically use Keras 2 by setting the `TF_USE_LEGACY_KERAS` environment variable in `__init__.py`. However, this would prevent gpflow from being used alongside packages that use Keras 3.