### PR TITLE
replace types-pkg_resources with types-setuptools

### DIFF
--- a/gpflow/optimizers/mcmc.py
+++ b/gpflow/optimizers/mcmc.py
@@ -73,9 +73,7 @@ class SamplingHelper:
         return self._variables
 
     @property
-    def target_log_prob_fn(
-        self,
-    ) -> Callable[..., Tuple[tf.Tensor, Callable[..., Tuple[tf.Tensor, Sequence[None]]]]]:
+    def target_log_prob_fn(self) -> Callable[..., tf.Tensor]:
         """
         The target log probability, adjusted to allow for optimisation to occur on the tracked
         unconstrained underlying variables.

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     "check_shapes>=1.0.0",
     "deprecated",
     "multipledispatch>=0.6",
-    "numpy",
+    "numpy<2",
     "packaging",
     "scipy",
     "setuptools>=41.0.0",  # to satisfy dependency constraints

--- a/tests/gpflow/test_initial_value.py
+++ b/tests/gpflow/test_initial_value.py
@@ -74,7 +74,7 @@ def test_assignment_value(path: Path) -> None:
             these problems.
             """
 
-            self.bad_assigns: List[ast.AST] = []
+            self.bad_assigns: List[Union[ast.Assign, ast.AugAssign, ast.AnnAssign]] = []
             """
             List of bad assignments, so that we can report multiple errors at the same time.
             """

--- a/tests_requirements.txt
+++ b/tests_requirements.txt
@@ -8,7 +8,7 @@ pytest-random-order
 pytest-xdist
 pytest>=3.5.0
 types-Deprecated
-types-pkg_resources
+types-setuptools
 types-tabulate
 
 # Notebooks and documentation:


### PR DESCRIPTION
<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** bugfix

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

replace types-pkg_resources was recently yanked from pypi, breaking the test pipeline

this PR replaces it with types-setuptools and fixes the revealed typing bugs

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

### Release notes

Pin to numpy<2.

**Fully backwards compatible:** yes

## PR checklist
<!-- tick off [X] as applicable -->
- [ ] New features: code is well-documented
  - [ ] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ ] The bug case / new feature is covered by unit tests
- [ ] Code has type annotations
- [ ] Build checks
  - [ ] I ran the black+isort formatter (`make format`)
  - [ ] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

