### PR TITLE
Add axiom validator for hierarchical-kernel compositions

### DIFF
--- a/gpflow/kernels/__init__.py
+++ b/gpflow/kernels/__init__.py
@@ -26,6 +26,7 @@ from .hierarchical import (
     HierarchyNode,
     WedgeHierarchical,
 )
+from .hierarchical_axioms import AxiomCheck, AxiomReport, validate_hierarchical_axioms
 from .linears import Linear, Polynomial
 from .misc import ArcCosine, Coregion
 from .multioutput import (
@@ -61,6 +62,8 @@ __all__ = [
     "AnisotropicStationary",
     "ArcCosine",
     "ArcHierarchical",
+    "AxiomCheck",
+    "AxiomReport",
     "Bias",
     "ChangePoints",
     "Combination",
@@ -98,10 +101,12 @@ __all__ = [
     "changepoints",
     "convolutional",
     "hierarchical",
+    "hierarchical_axioms",
     "linears",
     "misc",
     "multioutput",
     "periodic",
     "statics",
     "stationaries",
+    "validate_hierarchical_axioms",
 ]

--- a/gpflow/kernels/hierarchical_axioms.py
+++ b/gpflow/kernels/hierarchical_axioms.py
@@ -53,7 +53,7 @@ import tensorflow as tf
 
 from ..base import AnyNDArray
 from ..experimental.utils import experimental
-from .base import Kernel
+from .base import ActiveDims, Kernel
 from .hierarchical import ActivityCondition, HierarchyNode
 
 
@@ -124,26 +124,77 @@ def _violating_value(required: int) -> int:
     return required + 1
 
 
-def _set_active(x: AnyNDArray, condition: ActivityCondition) -> AnyNDArray:
-    """Return a copy of ``x`` with every indicator dim set to satisfy
-    ``condition``."""
+def _set_active_at(x: AnyNDArray, requirements_full: Dict[int, int]) -> AnyNDArray:
+    """Return a copy of ``x`` with every full-input column listed in
+    ``requirements_full`` set to its required integer value (satisfies the
+    activity condition the mapping was derived from)."""
     out = x.copy()
-    for ind_dim, required in condition.requirements.items():
-        out[ind_dim] = float(required)
+    for full_pos, required in requirements_full.items():
+        out[full_pos] = float(required)
     return out
 
 
-def _set_inactive(x: AnyNDArray, condition: ActivityCondition) -> AnyNDArray:
-    """Return a copy of ``x`` with one indicator dim set so that
-    ``condition`` is violated. The other indicators in the condition are
-    set to satisfy it, isolating the flip as much as possible."""
+def _set_inactive_at(x: AnyNDArray, requirements_full: Dict[int, int]) -> AnyNDArray:
+    """Return a copy of ``x`` with one full-input column set to a value that
+    violates the activity condition the mapping was derived from; the other
+    listed columns are still set to their required values, so the flip is
+    isolated to a single indicator."""
     out = x.copy()
-    items = list(condition.requirements.items())
-    flip_dim, flip_required = items[0]
-    out[flip_dim] = float(_violating_value(flip_required))
-    for ind_dim, required in items[1:]:
-        out[ind_dim] = float(required)
+    items = list(requirements_full.items())
+    flip_pos, flip_required = items[0]
+    out[flip_pos] = float(_violating_value(flip_required))
+    for full_pos, required in items[1:]:
+        out[full_pos] = float(required)
     return out
+
+
+def _resolve_active_dims_mapping(
+    active_dims: Optional[ActiveDims],
+    max_hierarchy_position: int,
+    input_dim: Optional[int],
+) -> Tuple[Dict[int, int], int]:
+    """Resolve ``active_dims`` into a ``{sliced_position: full_position}``
+    mapping table and the implied ``input_dim``.
+
+    ``active_dims`` semantics mirror :class:`gpflow.kernels.Kernel`: ``None``
+    means identity, a ``slice`` selects a sub-range of the input, and a
+    sequence of ``int`` lists the full-input columns in sliced-position
+    order. The returned mapping covers every sliced position the hierarchy
+    references (``0..max_hierarchy_position`` inclusive). The returned
+    ``input_dim`` is either the caller-supplied value or a default inferred
+    from ``active_dims``.
+    """
+    n_sliced_required = max_hierarchy_position + 1 if max_hierarchy_position >= 0 else 0
+
+    if active_dims is None:
+        mapping = {i: i for i in range(n_sliced_required)}
+        resolved_input_dim = input_dim if input_dim is not None else max(n_sliced_required, 1)
+        return mapping, resolved_input_dim
+
+    if isinstance(active_dims, slice):
+        if input_dim is None:
+            if active_dims.stop is None:
+                raise ValueError(
+                    "`active_dims` is an open-ended slice; `input_dim` must be "
+                    "provided so the slice can be resolved."
+                )
+            input_dim = int(active_dims.stop)
+        full_positions = list(range(input_dim))[active_dims]
+    else:
+        full_positions = [int(d) for d in active_dims]
+        if input_dim is None:
+            input_dim = (max(full_positions) + 1) if full_positions else 1
+
+    if len(full_positions) < n_sliced_required:
+        raise ValueError(
+            f"`active_dims` resolves to {len(full_positions)} column(s) "
+            f"({full_positions!r}), but the hierarchy references sliced "
+            f"position {max_hierarchy_position}; need at least "
+            f"{n_sliced_required} columns."
+        )
+
+    mapping = {i: full_positions[i] for i in range(n_sliced_required)}
+    return mapping, input_dim
 
 
 def _within(a: float, b: float, *, atol: float, rtol: float) -> Tuple[bool, float]:
@@ -160,6 +211,7 @@ def validate_hierarchical_axioms(
     *,
     n_samples: int = 8,
     input_dim: Optional[int] = None,
+    active_dims: Optional[ActiveDims] = None,
     atol: float = 1e-8,
     rtol: float = 1e-6,
     seed: Optional[int] = 0,
@@ -175,19 +227,28 @@ def validate_hierarchical_axioms(
     reported.
 
     :param kernel: any GPflow :class:`Kernel`. The validator only calls
-        ``kernel.K`` and is agnostic to whether the kernel is a single
-        hierarchical kernel, a ``Sum`` / ``Product`` composition, a scaling
-        with ``Constant``, or anything else.
+        ``kernel(...)`` (i.e. :meth:`Kernel.__call__`), never ``kernel.K``
+        directly. ``__call__`` is what routes per-child ``active_dims``
+        slicing through ``Sum`` / ``Product`` / future combination kernels;
+        ``Sum.K`` bypasses that slicing and would feed the raw input to
+        every child.
     :param hierarchy: the same :class:`HierarchyNode` sequence the user
         passed (or would pass) to a
         :class:`gpflow.kernels.HierarchicalEmbeddingKernel`. Used only to
         construct test inputs; the kernel itself is treated as a black box.
     :param n_samples: number of random backgrounds per (node, feature, axiom)
         triple. Each background drives independent feature samples.
-    :param input_dim: width of the test input vectors. Defaults to
-        ``max(referenced column) + 1`` across the hierarchy. Override
-        when the kernel expects a wider input (e.g. its ``active_dims``
-        slices a sub-range).
+    :param input_dim: width of the test input vectors. Defaults to the
+        smallest value compatible with ``active_dims``: when ``active_dims``
+        is ``None``, that is ``max(referenced column) + 1`` across the
+        hierarchy; when ``active_dims`` is provided, it is
+        ``max(active_dims) + 1`` (or the slice's ``stop``).
+    :param active_dims: optional mapping from the hierarchy's sliced-coord
+        positions to full-input column indices, matching the ``active_dims``
+        of the hierarchical kernel under test. Use this when the kernel
+        slices an offset sub-range of a wider input (e.g.
+        ``active_dims=[2, 3, 4, 5]`` inside a width-6 input). ``None``
+        (the default) is the identity mapping.
     :param atol: absolute tolerance used by the equality predicates
         (axioms 1 and 2) and as the minimum margin for axiom 3.
     :param rtol: relative tolerance used by the equality predicates.
@@ -209,27 +270,29 @@ def validate_hierarchical_axioms(
             indicator_dims.add(int(k))
 
     feature_dim_set = {fd for _, fd, _, _ in per_feature}
-    if input_dim is None:
-        all_dims = feature_dim_set | indicator_dims
-        input_dim = (max(all_dims) + 1) if all_dims else 1
+    all_hier_positions = feature_dim_set | indicator_dims
+    max_hier_pos = max(all_hier_positions) if all_hier_positions else -1
+
+    mapping, input_dim = _resolve_active_dims_mapping(active_dims, max_hier_pos, input_dim)
     if input_dim <= 0:
         raise ValueError(f"`input_dim` must be positive; got {input_dim}.")
 
-    bounds_by_col: Dict[int, Tuple[float, float]] = {
-        fd: bnds for _, fd, bnds, _ in per_feature
+    # Bounds keyed by *full-input* column.
+    bounds_by_full_col: Dict[int, Tuple[float, float]] = {
+        mapping[fd]: bnds for _, fd, bnds, _ in per_feature
     }
 
     def _sample_background() -> AnyNDArray:
         x = np.zeros(input_dim, dtype=np.float64)
-        for fd, (lo, hi) in bounds_by_col.items():
+        for full_col, (lo, hi) in bounds_by_full_col.items():
             span = hi - lo
             if span > 0:
                 eps = 0.05 * span
-                x[fd] = rng.uniform(lo + eps, hi - eps)
+                x[full_col] = rng.uniform(lo + eps, hi - eps)
             else:
-                x[fd] = lo
-        # Indicators default to 0; they'll be overridden by _set_active /
-        # _set_inactive on the condition under test.
+                x[full_col] = lo
+        # Indicators default to 0; they'll be overridden by
+        # _set_active_at / _set_inactive_at on the condition under test.
         return x
 
     def _K(a: AnyNDArray, b: AnyNDArray) -> float:
@@ -246,6 +309,12 @@ def validate_hierarchical_axioms(
     for node_name, fd, (lo, hi), condition in per_feature:
         if not condition.requirements:
             continue
+        full_fd = mapping[fd]
+        # Indicator requirements re-keyed to full-input columns.
+        requirements_full: Dict[int, int] = {
+            mapping[ind_dim]: required
+            for ind_dim, required in condition.requirements.items()
+        }
         span = hi - lo
         eps = 0.05 * span if span > 0 else 0.0
 
@@ -256,13 +325,13 @@ def validate_hierarchical_axioms(
         max_vio_1 = 0.0
         a1_passed = True
         for _ in range(n_samples):
-            base = _set_inactive(_sample_background(), condition)
+            base = _set_inactive_at(_sample_background(), requirements_full)
             v_a = _sample_in_range()
             v_b = _sample_in_range()
             x_a = base.copy()
-            x_a[fd] = v_a
+            x_a[full_fd] = v_a
             x_b = base.copy()
-            x_b[fd] = v_b
+            x_b[full_fd] = v_b
             K_aa = _K(x_a, x_a)
             K_ab = _K(x_a, x_b)
             ok, diff = _within(K_aa, K_ab, atol=atol, rtol=rtol)
@@ -286,7 +355,7 @@ def validate_hierarchical_axioms(
         max_vio_2 = 0.0
         a2_passed = True
         for _ in range(n_samples):
-            base = _set_active(_sample_background(), condition)
+            base = _set_active_at(_sample_background(), requirements_full)
             if span <= 0:
                 # Degenerate bounds: nothing meaningful to test; record a pass.
                 continue
@@ -299,13 +368,13 @@ def validate_hierarchical_axioms(
                 continue
             shift = float(rng.uniform(lo_shift, hi_shift))
             x_a = base.copy()
-            x_a[fd] = v_a
+            x_a[full_fd] = v_a
             y_a = base.copy()
-            y_a[fd] = v_y
+            y_a[full_fd] = v_y
             x_b = base.copy()
-            x_b[fd] = v_a + shift
+            x_b[full_fd] = v_a + shift
             y_b = base.copy()
-            y_b[fd] = v_y + shift
+            y_b[full_fd] = v_y + shift
             K_a = _K(x_a, y_a)
             K_b = _K(x_b, y_b)
             ok, diff = _within(K_a, K_b, atol=atol, rtol=rtol)
@@ -331,10 +400,10 @@ def validate_hierarchical_axioms(
         for _ in range(n_samples):
             bg = _sample_background()
             v = _sample_in_range()
-            x_active = _set_active(bg, condition)
-            x_active[fd] = v
-            x_inactive = _set_inactive(bg, condition)
-            x_inactive[fd] = v
+            x_active = _set_active_at(bg, requirements_full)
+            x_active[full_fd] = v
+            x_inactive = _set_inactive_at(bg, requirements_full)
+            x_inactive[full_fd] = v
             K_self = _K(x_active, x_active)
             K_cross = _K(x_active, x_inactive)
             margin = K_self - K_cross

--- a/gpflow/kernels/hierarchical_axioms.py
+++ b/gpflow/kernels/hierarchical_axioms.py
@@ -264,7 +264,12 @@ def validate_hierarchical_axioms(
         bounds = np.asarray(node.feature_bounds, dtype=np.float64)
         for i, fd in enumerate(node.feature_dims):
             per_feature.append(
-                (node.name, int(fd), (float(bounds[i, 0]), float(bounds[i, 1])), node.activity_condition)
+                (
+                    node.name,
+                    int(fd),
+                    (float(bounds[i, 0]), float(bounds[i, 1])),
+                    node.activity_condition,
+                )
             )
         for k in node.activity_condition.requirements:
             indicator_dims.add(int(k))
@@ -312,8 +317,7 @@ def validate_hierarchical_axioms(
         full_fd = mapping[fd]
         # Indicator requirements re-keyed to full-input columns.
         requirements_full: Dict[int, int] = {
-            mapping[ind_dim]: required
-            for ind_dim, required in condition.requirements.items()
+            mapping[ind_dim]: required for ind_dim, required in condition.requirements.items()
         }
         span = hi - lo
         eps = 0.05 * span if span > 0 else 0.0

--- a/gpflow/kernels/hierarchical_axioms.py
+++ b/gpflow/kernels/hierarchical_axioms.py
@@ -368,7 +368,10 @@ def validate_hierarchical_axioms(
             v_y = float(rng.uniform(lo + eps, hi - eps - half))
             lo_shift = (lo + eps) - min(v_a, v_y)
             hi_shift = (hi - eps) - max(v_a, v_y)
-            if hi_shift <= lo_shift:
+            # Defensive: with v_a, v_y drawn from [L, L + 0.4*span] (L = lo + eps),
+            # hi_shift >= 0.5*span > 0 >= lo_shift always, so the shift window is
+            # never empty here. Kept in case the sampling bounds above change.
+            if hi_shift <= lo_shift:  # pragma: no cover
                 continue
             shift = float(rng.uniform(lo_shift, hi_shift))
             x_a = base.copy()

--- a/gpflow/kernels/hierarchical_axioms.py
+++ b/gpflow/kernels/hierarchical_axioms.py
@@ -1,0 +1,360 @@
+# Copyright 2026 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Runtime validation of the three hierarchical-kernel axioms on
+arbitrary kernel compositions.
+
+The three axioms are stated in
+``doc/sphinx/notebooks/advanced/hierarchical_kernels.pct.py`` as
+properties of a *per-dimension distance* ``d_i`` on a conditional
+input dimension ``i``:
+
+1. **both inactive:** ``d_i = 0``;
+2. **both active:** ``d_i`` is a function of the difference in feature value;
+3. **incomparable** (one active, one inactive): ``d_i`` is positive and
+   places the two points in distinct regions of the embedded space.
+
+A composed kernel (``Sum``, ``Product``, scaling, ...) no longer exposes
+``d_i`` directly, so this module checks the **kernel-level shadows**:
+
+* Axiom 1 shadow: ``K(x, x) == K(x, x')`` when ``x'`` differs from ``x``
+  only on the target feature column and the activity condition is
+  violated on both sides.
+* Axiom 2 shadow: ``K`` is stationary in the target feature column when
+  the activity condition is satisfied on both sides — i.e.
+  ``K(x_a, y_a) == K(x_b, y_b)`` whenever ``x_a, y_a`` and ``x_b, y_b``
+  agree on every other coordinate and their target-column differences
+  match.
+* Axiom 3 shadow: ``K(x_active, x_inactive) < K(x_active, x_active)``
+  when the only change is the activity status of the target feature.
+
+The validator does not walk the kernel tree; it only calls ``kernel.K``,
+so it works on any GPflow kernel — including arbitrary
+``Sum`` / ``Product`` compositions and future combination types.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+import numpy as np
+import tensorflow as tf
+
+from ..base import AnyNDArray
+from ..experimental.utils import experimental
+from .base import Kernel
+from .hierarchical import ActivityCondition, HierarchyNode
+
+
+@dataclass(frozen=True)
+class AxiomCheck:
+    """Outcome of one axiom check on one conditional feature column.
+
+    :param node_name: name of the :class:`HierarchyNode` whose conditional
+        behaviour was tested.
+    :param feature_dim: column index (sliced coordinate system) of the
+        conditional feature dimension that was tested.
+    :param axiom: which axiom — ``1``, ``2``, or ``3``.
+    :param passed: ``True`` iff the predicate held within tolerance over
+        every sampled input.
+    :param max_violation: largest violation observed across samples
+        (always ``>= 0``). For axioms 1 and 2 this is ``|K_a - K_b|``;
+        for axiom 3 this is ``max(0, K_cross - K_self)`` — i.e. by how
+        much an incomparable pair was at least as similar as a self pair.
+    :param detail: one-line human-readable explanation.
+    """
+
+    node_name: str
+    feature_dim: int
+    axiom: int
+    passed: bool
+    max_violation: float
+    detail: str
+
+
+@dataclass(frozen=True)
+class AxiomReport:
+    """Aggregate report from :func:`validate_hierarchical_axioms`.
+
+    Use :attr:`passed` for the boolean summary, :meth:`for_axiom` to slice
+    by axiom number, and ``str(report)`` for a human-readable table.
+    """
+
+    checks: Tuple[AxiomCheck, ...]
+
+    @property
+    def passed(self) -> bool:
+        """``True`` iff every axiom check passed (vacuously ``True`` when
+        the hierarchy has no conditional nodes)."""
+        return all(c.passed for c in self.checks)
+
+    def for_axiom(self, n: int) -> Tuple[AxiomCheck, ...]:
+        """Return only the checks for axiom ``n`` (``1``, ``2``, or ``3``)."""
+        return tuple(c for c in self.checks if c.axiom == n)
+
+    def __str__(self) -> str:
+        if not self.checks:
+            return "AxiomReport: no conditional nodes to check (PASS by vacuity)"
+        header = f"AxiomReport (overall {'PASS' if self.passed else 'FAIL'})"
+        rows = [header]
+        for c in self.checks:
+            rows.append(
+                f"  {'PASS' if c.passed else 'FAIL'} axiom {c.axiom} "
+                f"node={c.node_name!r} feature_dim={c.feature_dim} "
+                f"max_violation={c.max_violation:.3e} -- {c.detail}"
+            )
+        return "\n".join(rows)
+
+
+def _violating_value(required: int) -> int:
+    """An integer guaranteed not to equal ``required`` after rounding to
+    int. ``ActivityCondition`` requires values be non-negative ints, so
+    ``required + 1`` always differs."""
+    return required + 1
+
+
+def _set_active(x: AnyNDArray, condition: ActivityCondition) -> AnyNDArray:
+    """Return a copy of ``x`` with every indicator dim set to satisfy
+    ``condition``."""
+    out = x.copy()
+    for ind_dim, required in condition.requirements.items():
+        out[ind_dim] = float(required)
+    return out
+
+
+def _set_inactive(x: AnyNDArray, condition: ActivityCondition) -> AnyNDArray:
+    """Return a copy of ``x`` with one indicator dim set so that
+    ``condition`` is violated. The other indicators in the condition are
+    set to satisfy it, isolating the flip as much as possible."""
+    out = x.copy()
+    items = list(condition.requirements.items())
+    flip_dim, flip_required = items[0]
+    out[flip_dim] = float(_violating_value(flip_required))
+    for ind_dim, required in items[1:]:
+        out[ind_dim] = float(required)
+    return out
+
+
+def _within(a: float, b: float, *, atol: float, rtol: float) -> Tuple[bool, float]:
+    """``(ok, |a - b|)``: ``ok`` iff ``|a - b| <= atol + rtol * max(|a|, |b|)``."""
+    diff = abs(a - b)
+    tol = atol + rtol * max(abs(a), abs(b))
+    return diff <= tol, diff
+
+
+@experimental
+def validate_hierarchical_axioms(
+    kernel: Kernel,
+    hierarchy: Sequence[HierarchyNode],
+    *,
+    n_samples: int = 8,
+    input_dim: Optional[int] = None,
+    atol: float = 1e-8,
+    rtol: float = 1e-6,
+    seed: Optional[int] = 0,
+) -> AxiomReport:
+    """Numerically check that ``kernel`` obeys the three conditional-distance
+    axioms (kernel-level shadows) on every conditional :class:`HierarchyNode`
+    in ``hierarchy``.
+
+    Test inputs are constructed in the sliced coordinate system used by
+    :class:`gpflow.kernels.HierarchicalEmbeddingKernel`. For each conditional
+    feature column, three predicates on ``K`` are evaluated over
+    ``n_samples`` random backgrounds; the worst violation across samples is
+    reported.
+
+    :param kernel: any GPflow :class:`Kernel`. The validator only calls
+        ``kernel.K`` and is agnostic to whether the kernel is a single
+        hierarchical kernel, a ``Sum`` / ``Product`` composition, a scaling
+        with ``Constant``, or anything else.
+    :param hierarchy: the same :class:`HierarchyNode` sequence the user
+        passed (or would pass) to a
+        :class:`gpflow.kernels.HierarchicalEmbeddingKernel`. Used only to
+        construct test inputs; the kernel itself is treated as a black box.
+    :param n_samples: number of random backgrounds per (node, feature, axiom)
+        triple. Each background drives independent feature samples.
+    :param input_dim: width of the test input vectors. Defaults to
+        ``max(referenced column) + 1`` across the hierarchy. Override
+        when the kernel expects a wider input (e.g. its ``active_dims``
+        slices a sub-range).
+    :param atol: absolute tolerance used by the equality predicates
+        (axioms 1 and 2) and as the minimum margin for axiom 3.
+    :param rtol: relative tolerance used by the equality predicates.
+    :param seed: RNG seed for reproducibility. ``None`` uses fresh entropy.
+    :returns: an :class:`AxiomReport` whose ``passed`` is ``True`` iff every
+        check held. The caller decides whether to assert, log, or display.
+    """
+    rng = np.random.default_rng(seed)
+
+    per_feature: List[Tuple[str, int, Tuple[float, float], ActivityCondition]] = []
+    indicator_dims: Set[int] = set()
+    for node in hierarchy:
+        bounds = np.asarray(node.feature_bounds, dtype=np.float64)
+        for i, fd in enumerate(node.feature_dims):
+            per_feature.append(
+                (node.name, int(fd), (float(bounds[i, 0]), float(bounds[i, 1])), node.activity_condition)
+            )
+        for k in node.activity_condition.requirements:
+            indicator_dims.add(int(k))
+
+    feature_dim_set = {fd for _, fd, _, _ in per_feature}
+    if input_dim is None:
+        all_dims = feature_dim_set | indicator_dims
+        input_dim = (max(all_dims) + 1) if all_dims else 1
+    if input_dim <= 0:
+        raise ValueError(f"`input_dim` must be positive; got {input_dim}.")
+
+    bounds_by_col: Dict[int, Tuple[float, float]] = {
+        fd: bnds for _, fd, bnds, _ in per_feature
+    }
+
+    def _sample_background() -> AnyNDArray:
+        x = np.zeros(input_dim, dtype=np.float64)
+        for fd, (lo, hi) in bounds_by_col.items():
+            span = hi - lo
+            if span > 0:
+                eps = 0.05 * span
+                x[fd] = rng.uniform(lo + eps, hi - eps)
+            else:
+                x[fd] = lo
+        # Indicators default to 0; they'll be overridden by _set_active /
+        # _set_inactive on the condition under test.
+        return x
+
+    def _K(a: AnyNDArray, b: AnyNDArray) -> float:
+        # Use ``__call__`` rather than ``K``: combination kernels (``Sum``,
+        # ``Product``, ...) route through each child's ``__call__`` which
+        # applies the child's ``active_dims`` slice, whereas ``Sum.K``
+        # bypasses slicing and passes the raw input to each child.
+        ta = tf.constant(a.reshape(1, -1), dtype=tf.float64)
+        tb = tf.constant(b.reshape(1, -1), dtype=tf.float64)
+        return float(kernel(ta, tb).numpy().item())
+
+    checks: List[AxiomCheck] = []
+
+    for node_name, fd, (lo, hi), condition in per_feature:
+        if not condition.requirements:
+            continue
+        span = hi - lo
+        eps = 0.05 * span if span > 0 else 0.0
+
+        def _sample_in_range() -> float:
+            return float(rng.uniform(lo + eps, hi - eps)) if span > 0 else float(lo)
+
+        # ---- Axiom 1: both inactive, K invariant in target feature value.
+        max_vio_1 = 0.0
+        a1_passed = True
+        for _ in range(n_samples):
+            base = _set_inactive(_sample_background(), condition)
+            v_a = _sample_in_range()
+            v_b = _sample_in_range()
+            x_a = base.copy()
+            x_a[fd] = v_a
+            x_b = base.copy()
+            x_b[fd] = v_b
+            K_aa = _K(x_a, x_a)
+            K_ab = _K(x_a, x_b)
+            ok, diff = _within(K_aa, K_ab, atol=atol, rtol=rtol)
+            max_vio_1 = max(max_vio_1, diff)
+            a1_passed = a1_passed and ok
+        checks.append(
+            AxiomCheck(
+                node_name=node_name,
+                feature_dim=fd,
+                axiom=1,
+                passed=a1_passed,
+                max_violation=max_vio_1,
+                detail=(
+                    f"K(x,x) == K(x,x') when both points violate {node_name!r}'s "
+                    f"condition and differ only on feature dim {fd}"
+                ),
+            )
+        )
+
+        # ---- Axiom 2: both active, K stationary in the target feature value.
+        max_vio_2 = 0.0
+        a2_passed = True
+        for _ in range(n_samples):
+            base = _set_active(_sample_background(), condition)
+            if span <= 0:
+                # Degenerate bounds: nothing meaningful to test; record a pass.
+                continue
+            half = 0.5 * span
+            v_a = float(rng.uniform(lo + eps, hi - eps - half))
+            v_y = float(rng.uniform(lo + eps, hi - eps - half))
+            lo_shift = (lo + eps) - min(v_a, v_y)
+            hi_shift = (hi - eps) - max(v_a, v_y)
+            if hi_shift <= lo_shift:
+                continue
+            shift = float(rng.uniform(lo_shift, hi_shift))
+            x_a = base.copy()
+            x_a[fd] = v_a
+            y_a = base.copy()
+            y_a[fd] = v_y
+            x_b = base.copy()
+            x_b[fd] = v_a + shift
+            y_b = base.copy()
+            y_b[fd] = v_y + shift
+            K_a = _K(x_a, y_a)
+            K_b = _K(x_b, y_b)
+            ok, diff = _within(K_a, K_b, atol=atol, rtol=rtol)
+            max_vio_2 = max(max_vio_2, diff)
+            a2_passed = a2_passed and ok
+        checks.append(
+            AxiomCheck(
+                node_name=node_name,
+                feature_dim=fd,
+                axiom=2,
+                passed=a2_passed,
+                max_violation=max_vio_2,
+                detail=(
+                    f"K stationary in feature dim {fd} when {node_name!r}'s "
+                    f"condition is satisfied on both sides"
+                ),
+            )
+        )
+
+        # ---- Axiom 3: K(active, inactive) < K(active, active).
+        max_vio_3 = 0.0
+        a3_passed = True
+        for _ in range(n_samples):
+            bg = _sample_background()
+            v = _sample_in_range()
+            x_active = _set_active(bg, condition)
+            x_active[fd] = v
+            x_inactive = _set_inactive(bg, condition)
+            x_inactive[fd] = v
+            K_self = _K(x_active, x_active)
+            K_cross = _K(x_active, x_inactive)
+            margin = K_self - K_cross
+            tol = atol + rtol * abs(K_self)
+            if margin <= tol:
+                a3_passed = False
+            violation = max(0.0, K_cross - K_self + tol)
+            max_vio_3 = max(max_vio_3, violation)
+        checks.append(
+            AxiomCheck(
+                node_name=node_name,
+                feature_dim=fd,
+                axiom=3,
+                passed=a3_passed,
+                max_violation=max_vio_3,
+                detail=(
+                    f"K(x_active, x_inactive) < K(x_active, x_active) when "
+                    f"{node_name!r}'s condition is flipped at feature dim {fd}"
+                ),
+            )
+        )
+
+    return AxiomReport(tuple(checks))

--- a/tests/gpflow/kernels/test_hierarchical_axioms.py
+++ b/tests/gpflow/kernels/test_hierarchical_axioms.py
@@ -87,31 +87,23 @@ def _silence_experimental_warning() -> None:
 
 class TestPassingCompositions:
     def test_arc_alone_passes_all_axioms(self) -> None:
-        report = validate_hierarchical_axioms(
-            _arc(), _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(_arc(), _canonical_disjunction_hierarchy(), seed=0)
         assert report.passed, str(report)
         # Two conditional nodes × three axioms = 6 checks.
         assert len(report.checks) == 6
 
     def test_wedge_alone_passes_all_axioms(self) -> None:
-        report = validate_hierarchical_axioms(
-            _wedge(), _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(_wedge(), _canonical_disjunction_hierarchy(), seed=0)
         assert report.passed, str(report)
 
     def test_constant_times_arc_passes(self) -> None:
         kernel = Constant() * _arc()
-        report = validate_hierarchical_axioms(
-            kernel, _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(kernel, _canonical_disjunction_hierarchy(), seed=0)
         assert report.passed, str(report)
 
     def test_arc_plus_wedge_same_hierarchy_passes(self) -> None:
         kernel = _arc() + _wedge()
-        report = validate_hierarchical_axioms(
-            kernel, _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(kernel, _canonical_disjunction_hierarchy(), seed=0)
         assert report.passed, str(report)
 
     def test_arc_plus_matern_on_unconditional_dim_only_passes(self) -> None:
@@ -119,9 +111,7 @@ class TestPassingCompositions:
         # the activity mask or to the conditional feature dims, so the
         # composition inherits the axiom-respecting behaviour of arc.
         kernel = _arc() + Matern52(active_dims=[0])
-        report = validate_hierarchical_axioms(
-            kernel, _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(kernel, _canonical_disjunction_hierarchy(), seed=0)
         assert report.passed, str(report)
 
 
@@ -134,9 +124,7 @@ class TestFailingCompositions:
         # responds to changes in those columns regardless of the activity
         # mask. Axiom 1 must flag this.
         kernel = _arc() + Matern52(active_dims=list(range(4)))
-        report = validate_hierarchical_axioms(
-            kernel, _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(kernel, _canonical_disjunction_hierarchy(), seed=0)
         assert not report.passed
         a1_checks = report.for_axiom(1)
         assert any(not c.passed for c in a1_checks)
@@ -149,9 +137,7 @@ class TestFailingCompositions:
         # because Matern responds to the conditional feature value when
         # the activity condition is violated.
         kernel = Matern52()
-        report = validate_hierarchical_axioms(
-            kernel, _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(kernel, _canonical_disjunction_hierarchy(), seed=0)
         assert not report.passed
         assert all(not c.passed for c in report.for_axiom(1))
 
@@ -159,9 +145,7 @@ class TestFailingCompositions:
         # Polynomial is non-stationary, so K depends on absolute coordinate
         # values rather than just their differences. Axiom 2 must flag this.
         kernel = _arc() + Polynomial(active_dims=list(range(4)))
-        report = validate_hierarchical_axioms(
-            kernel, _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(kernel, _canonical_disjunction_hierarchy(), seed=0)
         assert not report.passed
         a2_checks = report.for_axiom(2)
         assert any(not c.passed for c in a2_checks)
@@ -171,9 +155,7 @@ class TestFailingCompositions:
         # K(active, inactive) == K(active, active): axiom 3 has zero
         # margin and must fail.
         kernel = Constant()
-        report = validate_hierarchical_axioms(
-            kernel, _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(kernel, _canonical_disjunction_hierarchy(), seed=0)
         assert not report.passed
         a3_checks = report.for_axiom(3)
         assert all(not c.passed for c in a3_checks)
@@ -184,9 +166,7 @@ class TestFailingCompositions:
 
 class TestReportStructure:
     def test_report_breaks_down_per_node_and_per_axiom(self) -> None:
-        report = validate_hierarchical_axioms(
-            _arc(), _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(_arc(), _canonical_disjunction_hierarchy(), seed=0)
         node_names = {c.node_name for c in report.checks}
         axioms = {c.axiom for c in report.checks}
         assert node_names == {"branch_A", "branch_B"}
@@ -214,9 +194,7 @@ class TestReportStructure:
         assert "no conditional nodes" in str(report)
 
     def test_str_contains_pass_fail_summary(self) -> None:
-        report = validate_hierarchical_axioms(
-            _arc(), _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(_arc(), _canonical_disjunction_hierarchy(), seed=0)
         s = str(report)
         assert "PASS" in s
         assert "axiom 1" in s
@@ -238,9 +216,7 @@ class TestReportStructure:
             check.passed = False  # type: ignore[misc]
 
     def test_axiom_report_is_immutable_tuple_of_checks(self) -> None:
-        report = AxiomReport(checks=(
-            AxiomCheck("x", 0, 1, True, 0.0, "ok"),
-        ))
+        report = AxiomReport(checks=(AxiomCheck("x", 0, 1, True, 0.0, "ok"),))
         assert isinstance(report.checks, tuple)
         assert report.passed
 
@@ -268,9 +244,7 @@ class TestDeterminism:
 
 class TestInputDim:
     def test_input_dim_default_uses_max_referenced_column(self) -> None:
-        report = validate_hierarchical_axioms(
-            _arc(), _canonical_disjunction_hierarchy(), seed=0
-        )
+        report = validate_hierarchical_axioms(_arc(), _canonical_disjunction_hierarchy(), seed=0)
         assert report.passed
 
     def test_explicit_input_dim_overrides_default(self) -> None:

--- a/tests/gpflow/kernels/test_hierarchical_axioms.py
+++ b/tests/gpflow/kernels/test_hierarchical_axioms.py
@@ -335,3 +335,97 @@ class TestActiveDimsSlice:
                 input_dim=4,
                 active_dims=[2, 3],
             )
+
+
+class TestEdgeCaseBranches:
+    """Exercise branches the happy-path tests above skip: multi-indicator
+    conditions, ``active_dims`` resolved without an explicit ``input_dim``, and
+    degenerate (zero-width) feature bounds."""
+
+    def test_multi_indicator_condition(self) -> None:
+        # A conditional node gated by *two* indicators. Sliced coords:
+        # [x1(0, uncond), y1(1, ind), y2(2, ind), x2(3, active when y1=1 & y2=0)].
+        # Valid because sorted(feature_dims + indicator_dims) == range(4).
+        hierarchy = [
+            HierarchyNode(
+                "shared",
+                feature_dims=[0],
+                feature_bounds=tf.constant([[0.0, 1.0]], dtype=tf.float64),
+            ),
+            HierarchyNode(
+                "branch_AND",
+                feature_dims=[3],
+                feature_bounds=tf.constant([[0.0, 5.0]], dtype=tf.float64),
+                activity_condition=ActivityCondition({1: 1, 2: 0}),
+            ),
+        ]
+        kernel = ArcHierarchical(hierarchy=hierarchy, active_dims=[0, 1, 2, 3])
+        report = validate_hierarchical_axioms(kernel, hierarchy, seed=0)
+        assert report.passed, str(report)
+        # One conditional node x three axioms.
+        assert len(report.checks) == 3
+        assert {c.node_name for c in report.checks} == {"branch_AND"}
+
+    def test_bounded_slice_without_input_dim(self) -> None:
+        # Bounded slice with no explicit input_dim: input_dim is inferred from
+        # the slice's stop.
+        report = validate_hierarchical_axioms(
+            _arc(),
+            _canonical_disjunction_hierarchy(),
+            seed=0,
+            active_dims=slice(0, 4),
+        )
+        assert report.passed, str(report)
+
+    def test_open_ended_slice_without_input_dim_rejected(self) -> None:
+        # Open-ended slice cannot be resolved without an input_dim.
+        with pytest.raises(ValueError, match="open-ended"):
+            validate_hierarchical_axioms(
+                _arc(),
+                _canonical_disjunction_hierarchy(),
+                seed=0,
+                active_dims=slice(None, None),
+            )
+
+    def test_sequence_active_dims_without_input_dim(self) -> None:
+        # Sequence active_dims with no explicit input_dim: input_dim defaults to
+        # max(active_dims) + 1.
+        report = validate_hierarchical_axioms(
+            _arc(),
+            _canonical_disjunction_hierarchy(),
+            seed=0,
+            active_dims=[0, 1, 2, 3],
+        )
+        assert report.passed, str(report)
+
+    def test_degenerate_feature_bounds(self) -> None:
+        # A conditional feature with zero-width bounds (lo == hi) exercises the
+        # span == 0 paths: the background sampler pins the column to lo, and the
+        # axiom-2 loop has nothing to vary so it records a vacuous pass.
+        hierarchy = [
+            HierarchyNode(
+                "shared",
+                feature_dims=[0],
+                feature_bounds=tf.constant([[0.0, 1.0]], dtype=tf.float64),
+            ),
+            HierarchyNode(
+                "branch_fixed",
+                feature_dims=[2],
+                feature_bounds=tf.constant([[2.0, 2.0]], dtype=tf.float64),
+                activity_condition=ActivityCondition({1: 1}),
+            ),
+            HierarchyNode(
+                "branch_B",
+                feature_dims=[3],
+                feature_bounds=tf.constant([[-1.0, 1.0]], dtype=tf.float64),
+                activity_condition=ActivityCondition({1: 0}),
+            ),
+        ]
+        kernel = ArcHierarchical(hierarchy=hierarchy, active_dims=[0, 1, 2, 3])
+        report = validate_hierarchical_axioms(kernel, hierarchy, seed=0)
+        assert report.passed, str(report)
+        # The degenerate node's axiom-2 check passes vacuously (no value to vary).
+        fixed_a2 = [c for c in report.for_axiom(2) if c.node_name == "branch_fixed"]
+        assert len(fixed_a2) == 1
+        assert fixed_a2[0].passed
+        assert fixed_a2[0].max_violation == 0.0

--- a/tests/gpflow/kernels/test_hierarchical_axioms.py
+++ b/tests/gpflow/kernels/test_hierarchical_axioms.py
@@ -1,0 +1,294 @@
+# Copyright 2026 The GPflow Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``gpflow.kernels.hierarchical_axioms``."""
+
+import warnings
+from typing import List
+
+import pytest
+import tensorflow as tf
+
+from gpflow.kernels import (
+    ActivityCondition,
+    ArcHierarchical,
+    Constant,
+    HierarchyNode,
+    Matern52,
+    Polynomial,
+    WedgeHierarchical,
+    validate_hierarchical_axioms,
+)
+from gpflow.kernels.hierarchical_axioms import AxiomCheck, AxiomReport
+
+
+def _canonical_disjunction_hierarchy() -> List[HierarchyNode]:
+    """4-variable disjunction in sliced coords: ``[x1, y1, x2, x3]`` — ``x1``
+    unconditional, ``y1`` indicator (col 1), ``x2`` active when ``y1=1``,
+    ``x3`` active when ``y1=0``. Matches the canonical hierarchy used by
+    ``tests/gpflow/kernels/test_hierarchical.py``."""
+    return [
+        HierarchyNode(
+            "shared",
+            feature_dims=[0],
+            feature_bounds=tf.constant([[0.0, 1.0]], dtype=tf.float64),
+        ),
+        HierarchyNode(
+            "branch_A",
+            feature_dims=[2],
+            feature_bounds=tf.constant([[0.0, 5.0]], dtype=tf.float64),
+            activity_condition=ActivityCondition({1: 1}),
+        ),
+        HierarchyNode(
+            "branch_B",
+            feature_dims=[3],
+            feature_bounds=tf.constant([[-1.0, 1.0]], dtype=tf.float64),
+            activity_condition=ActivityCondition({1: 0}),
+        ),
+    ]
+
+
+def _arc() -> ArcHierarchical:
+    return ArcHierarchical(
+        hierarchy=_canonical_disjunction_hierarchy(),
+        active_dims=list(range(4)),
+    )
+
+
+def _wedge() -> WedgeHierarchical:
+    return WedgeHierarchical(
+        hierarchy=_canonical_disjunction_hierarchy(),
+        active_dims=list(range(4)),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _silence_experimental_warning() -> None:
+    """``validate_hierarchical_axioms`` is marked ``@experimental`` and warns
+    on first call; that's expected and we don't want to fail tests on it."""
+    warnings.filterwarnings(
+        "ignore",
+        message=r".*validate_hierarchical_axioms.*experimental.*",
+    )
+
+
+# ------------- Passing compositions ---------------------------------------
+
+
+class TestPassingCompositions:
+    def test_arc_alone_passes_all_axioms(self) -> None:
+        report = validate_hierarchical_axioms(
+            _arc(), _canonical_disjunction_hierarchy(), seed=0
+        )
+        assert report.passed, str(report)
+        # Two conditional nodes × three axioms = 6 checks.
+        assert len(report.checks) == 6
+
+    def test_wedge_alone_passes_all_axioms(self) -> None:
+        report = validate_hierarchical_axioms(
+            _wedge(), _canonical_disjunction_hierarchy(), seed=0
+        )
+        assert report.passed, str(report)
+
+    def test_constant_times_arc_passes(self) -> None:
+        kernel = Constant() * _arc()
+        report = validate_hierarchical_axioms(
+            kernel, _canonical_disjunction_hierarchy(), seed=0
+        )
+        assert report.passed, str(report)
+
+    def test_arc_plus_wedge_same_hierarchy_passes(self) -> None:
+        kernel = _arc() + _wedge()
+        report = validate_hierarchical_axioms(
+            kernel, _canonical_disjunction_hierarchy(), seed=0
+        )
+        assert report.passed, str(report)
+
+    def test_arc_plus_matern_on_unconditional_dim_only_passes(self) -> None:
+        # Matern only touches dim 0 (x1, unconditional) — it cannot react to
+        # the activity mask or to the conditional feature dims, so the
+        # composition inherits the axiom-respecting behaviour of arc.
+        kernel = _arc() + Matern52(active_dims=[0])
+        report = validate_hierarchical_axioms(
+            kernel, _canonical_disjunction_hierarchy(), seed=0
+        )
+        assert report.passed, str(report)
+
+
+# ------------- Failing compositions ---------------------------------------
+
+
+class TestFailingCompositions:
+    def test_arc_plus_matern_on_conditional_dim_fails_axiom_1(self) -> None:
+        # Matern52 with active_dims that include conditional feature columns
+        # responds to changes in those columns regardless of the activity
+        # mask. Axiom 1 must flag this.
+        kernel = _arc() + Matern52(active_dims=list(range(4)))
+        report = validate_hierarchical_axioms(
+            kernel, _canonical_disjunction_hierarchy(), seed=0
+        )
+        assert not report.passed
+        a1_checks = report.for_axiom(1)
+        assert any(not c.passed for c in a1_checks)
+        for c in a1_checks:
+            if not c.passed:
+                assert c.max_violation > 1e-6
+
+    def test_plain_matern_over_full_space_fails_axiom_1(self) -> None:
+        # No hierarchy awareness at all — every axiom-1 check must fail
+        # because Matern responds to the conditional feature value when
+        # the activity condition is violated.
+        kernel = Matern52()
+        report = validate_hierarchical_axioms(
+            kernel, _canonical_disjunction_hierarchy(), seed=0
+        )
+        assert not report.passed
+        assert all(not c.passed for c in report.for_axiom(1))
+
+    def test_polynomial_plus_arc_fails_axiom_2(self) -> None:
+        # Polynomial is non-stationary, so K depends on absolute coordinate
+        # values rather than just their differences. Axiom 2 must flag this.
+        kernel = _arc() + Polynomial(active_dims=list(range(4)))
+        report = validate_hierarchical_axioms(
+            kernel, _canonical_disjunction_hierarchy(), seed=0
+        )
+        assert not report.passed
+        a2_checks = report.for_axiom(2)
+        assert any(not c.passed for c in a2_checks)
+
+    def test_constant_alone_fails_axiom_3(self) -> None:
+        # Constant kernel returns the same variance for every pair, so
+        # K(active, inactive) == K(active, active): axiom 3 has zero
+        # margin and must fail.
+        kernel = Constant()
+        report = validate_hierarchical_axioms(
+            kernel, _canonical_disjunction_hierarchy(), seed=0
+        )
+        assert not report.passed
+        a3_checks = report.for_axiom(3)
+        assert all(not c.passed for c in a3_checks)
+
+
+# ------------- Report structure & determinism -----------------------------
+
+
+class TestReportStructure:
+    def test_report_breaks_down_per_node_and_per_axiom(self) -> None:
+        report = validate_hierarchical_axioms(
+            _arc(), _canonical_disjunction_hierarchy(), seed=0
+        )
+        node_names = {c.node_name for c in report.checks}
+        axioms = {c.axiom for c in report.checks}
+        assert node_names == {"branch_A", "branch_B"}
+        assert axioms == {1, 2, 3}
+        # Each conditional node has its single feature dim tested for each axiom.
+        per_node = {n: 0 for n in node_names}
+        for c in report.checks:
+            per_node[c.node_name] += 1
+        assert per_node == {"branch_A": 3, "branch_B": 3}
+
+    def test_unconditional_only_hierarchy_passes_vacuously(self) -> None:
+        # A hierarchy with no conditional nodes has no axioms to check;
+        # the report should be empty and `passed` True by vacuity.
+        hierarchy = [
+            HierarchyNode(
+                "all",
+                feature_dims=[0, 1],
+                feature_bounds=tf.constant([[0.0, 1.0], [0.0, 1.0]], dtype=tf.float64),
+            ),
+        ]
+        kernel = ArcHierarchical(hierarchy=hierarchy, active_dims=[0, 1])
+        report = validate_hierarchical_axioms(kernel, hierarchy, seed=0)
+        assert report.checks == ()
+        assert report.passed
+        assert "no conditional nodes" in str(report)
+
+    def test_str_contains_pass_fail_summary(self) -> None:
+        report = validate_hierarchical_axioms(
+            _arc(), _canonical_disjunction_hierarchy(), seed=0
+        )
+        s = str(report)
+        assert "PASS" in s
+        assert "axiom 1" in s
+        assert "axiom 2" in s
+        assert "axiom 3" in s
+
+    def test_axiom_check_has_expected_fields(self) -> None:
+        check = AxiomCheck(
+            node_name="x",
+            feature_dim=2,
+            axiom=1,
+            passed=True,
+            max_violation=0.0,
+            detail="ok",
+        )
+        # Frozen dataclass: attribute access works, mutation does not.
+        assert check.feature_dim == 2
+        with pytest.raises(Exception):
+            check.passed = False  # type: ignore[misc]
+
+    def test_axiom_report_is_immutable_tuple_of_checks(self) -> None:
+        report = AxiomReport(checks=(
+            AxiomCheck("x", 0, 1, True, 0.0, "ok"),
+        ))
+        assert isinstance(report.checks, tuple)
+        assert report.passed
+
+
+class TestDeterminism:
+    def test_same_seed_gives_identical_report(self) -> None:
+        h = _canonical_disjunction_hierarchy()
+        r1 = validate_hierarchical_axioms(_arc(), h, seed=42)
+        r2 = validate_hierarchical_axioms(_arc(), h, seed=42)
+        assert r1.checks == r2.checks
+
+    def test_different_seeds_can_give_different_reports(self) -> None:
+        # Seed only controls the test-input RNG; the kernel itself is
+        # deterministic. With a passing kernel both reports still pass,
+        # but the per-check `max_violation` values should differ across
+        # seeds because the sampled inputs differ.
+        h = _canonical_disjunction_hierarchy()
+        r1 = validate_hierarchical_axioms(_arc(), h, seed=1)
+        r2 = validate_hierarchical_axioms(_arc(), h, seed=2)
+        assert r1.passed and r2.passed
+        v1 = tuple(c.max_violation for c in r1.checks)
+        v2 = tuple(c.max_violation for c in r2.checks)
+        assert v1 != v2
+
+
+class TestInputDim:
+    def test_input_dim_default_uses_max_referenced_column(self) -> None:
+        report = validate_hierarchical_axioms(
+            _arc(), _canonical_disjunction_hierarchy(), seed=0
+        )
+        assert report.passed
+
+    def test_explicit_input_dim_overrides_default(self) -> None:
+        # Pass a wider input_dim; the kernel still has active_dims=[0..3] so
+        # extra columns are ignored. The validator should still pass.
+        report = validate_hierarchical_axioms(
+            _arc(),
+            _canonical_disjunction_hierarchy(),
+            seed=0,
+            input_dim=6,
+        )
+        assert report.passed
+
+    def test_negative_input_dim_rejected(self) -> None:
+        with pytest.raises(ValueError, match="input_dim"):
+            validate_hierarchical_axioms(
+                _arc(),
+                _canonical_disjunction_hierarchy(),
+                seed=0,
+                input_dim=-1,
+            )

--- a/tests/gpflow/kernels/test_hierarchical_axioms.py
+++ b/tests/gpflow/kernels/test_hierarchical_axioms.py
@@ -292,3 +292,72 @@ class TestInputDim:
                 seed=0,
                 input_dim=-1,
             )
+
+
+class TestActiveDimsSlice:
+    """The hierarchy is authored in sliced coordinates; the kernel may slice
+    an offset sub-range of a wider input. The validator's ``active_dims``
+    parameter maps sliced positions to full-input columns so test values
+    land where the kernel will actually read them."""
+
+    @staticmethod
+    def _arc_with_offset() -> ArcHierarchical:
+        # Hierarchy uses sliced positions [0, 1, 2, 3]; kernel slices full
+        # columns [2, 3, 4, 5] from a wider input.
+        return ArcHierarchical(
+            hierarchy=_canonical_disjunction_hierarchy(),
+            active_dims=[2, 3, 4, 5],
+        )
+
+    def test_subrange_active_dims_passes(self) -> None:
+        report = validate_hierarchical_axioms(
+            self._arc_with_offset(),
+            _canonical_disjunction_hierarchy(),
+            seed=0,
+            input_dim=6,
+            active_dims=[2, 3, 4, 5],
+        )
+        assert report.passed, str(report)
+        # Sanity: without the mapping the kernel would only see zeros at
+        # columns 2..5, making every K(x,x') equal and producing
+        # max_violation=0 across the board. A non-zero axiom-1 floor
+        # confirms the kernel actually observed the placed values.
+        assert any(c.max_violation > 0 for c in report.checks)
+
+    def test_subrange_active_dims_with_extra_child_kernel_passes(self) -> None:
+        # Matern52 slices full column 0 — disjoint from the hierarchy's
+        # mapped range [2..5]. The composition should still satisfy every
+        # axiom (Matern cannot react to any indicator or conditional
+        # feature, so it cannot break axioms 1 or 3, and both children are
+        # stationary so axiom 2 holds).
+        kernel = self._arc_with_offset() + Matern52(active_dims=[0])
+        report = validate_hierarchical_axioms(
+            kernel,
+            _canonical_disjunction_hierarchy(),
+            seed=0,
+            input_dim=6,
+            active_dims=[2, 3, 4, 5],
+        )
+        assert report.passed, str(report)
+
+    def test_active_dims_slice_object_resolves_against_input_dim(self) -> None:
+        report = validate_hierarchical_axioms(
+            self._arc_with_offset(),
+            _canonical_disjunction_hierarchy(),
+            seed=0,
+            input_dim=6,
+            active_dims=slice(2, 6),
+        )
+        assert report.passed, str(report)
+
+    def test_active_dims_too_few_columns_rejected(self) -> None:
+        # Hierarchy references sliced position 3, but the mapping only
+        # supplies 2 columns -> ValueError.
+        with pytest.raises(ValueError, match="active_dims"):
+            validate_hierarchical_axioms(
+                self._arc_with_offset(),
+                _canonical_disjunction_hierarchy(),
+                seed=0,
+                input_dim=4,
+                active_dims=[2, 3],
+            )


### PR DESCRIPTION
Introduces a method to check composition of kernels respects hierarchical kernel axioms.

<!-- (Lines like this are comments and will be invisible - you can leave them as is, or remove them) -->

<!-- Thank you very much for spending time on contributing to GPflow!
This template exists to simplify communicating basic information that is required to understand your contribution.
Please fill it in as far as possible; if anything about this template is unclear, please do mention it! -->

**PR type:** new feature 

**Related issue(s)/PRs:** <!-- GitHub issue number, e.g. "resolves #1216" -->

## Summary

**Proposed changes**
<!-- Large PRs should ideally be preceded by a design discussion on a separate issue! -->
See #2146. 
<!-- A clear and concise description of the contents of this pull request. -->
* Introduces a helper method (validate_hierarchical_axioms) to determine whether a constructed kernel satisfies the logic introduced by the hierarchy.
* tests to ensure those that should pass do, and those that should fail, do.

**What alternatives have you considered?**
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

### Minimal working example

<!-- Short code snippet with relevant comments.
* Bug fixes: show what happens before (without this PR) and after.
* New feature: show different use cases and demonstrate its benefits.
-->

```python
# Put your example code in here
import numpy as np
import tensorflow as tf

from gpflow.kernels import ActivityCondition, HierarchyNode, ArcHierarchical, validate_hierarchical_axioms

np.random.seed(1793)
tf.random.set_seed(1793)


def objective(X: np.ndarray) -> np.ndarray:
    x1, y1, x2, x3 = X[:, 0], X[:, 1], X[:, 2], X[:, 3]
    return (
        np.sin(2.0 * np.pi * x1)
        + (y1 > 0.5).astype(float) * 0.5 * np.cos(np.pi * x2 / 5.0)
        + (y1 < 0.5).astype(float) * 0.5 * x3
    ).reshape(-1, 1)


def sample_inputs(n: int) -> np.ndarray:
    x1 = np.random.uniform(0.0, 1.0, size=n)
    y1 = np.random.randint(0, 2, size=n).astype(float)
    x2 = np.random.uniform(0.0, 5.0, size=n)
    x3 = np.random.uniform(-1.0, 1.0, size=n)
    return np.stack([x1, y1, x2, x3], axis=-1)


X_train = sample_inputs(40)
Y_train = objective(X_train) + 0.05 * np.random.randn(40, 1)
X_test = np.array(
    [
        [0.3, 1.0, 2.0, 0.0],  # y1 = 1 branch
        [0.3, 0.0, 0.0, 0.5],  # y1 = 0 branch
        [0.7, 1.0, 4.0, 0.0],
        [0.7, 0.0, 0.0, -0.4],
    ]
)

hierarchy = [
    HierarchyNode("shared", feature_dims=[0], feature_bounds=[[0.0, 1.0]]),
    HierarchyNode(
        "branch_A",
        feature_dims=[2],
        feature_bounds=[[0.0, 5.0]],
        activity_condition=ActivityCondition({1: 1}),
    ),
    HierarchyNode(
        "branch_B",
        feature_dims=[3],
        feature_bounds=[[-1.0, 1.0]],
        activity_condition=ActivityCondition({1: 0}),
    ),
]

arc = ArcHierarchical(hierarchy, active_dims=[0,1,2,3])
report = validate_hierarchical_axioms(arc, hierarchy)
print(report)

```

### Release notes
<!-- leave blank if unsure -->

**Fully backwards compatible:** yes 

**If not, why is it worth breaking backwards compatibility:**
<!-- include a short justification -->

## PR checklist
<!-- tick off [X] as applicable -->
- [ X] New features: code is well-documented
  - [ X] detailed docstrings (API documentation)
  - [ ] notebook examples (usage demonstration)
- [ X] The bug case / new feature is covered by unit tests
- [ X] Code has type annotations
- [ X] Build checks
  - [X ] I ran the black+isort formatter (`make format`)
  - [ X] I locally tested that the tests pass (`make check-all`)
- [ ] Release management
  - [ ] RELEASE.md updated with entry for this change
  - [ ] New contributors: I've added myself to CONTRIBUTORS.md

