### PR TITLE
Allow separate inducing variables with different input dimensions

### DIFF
--- a/gpflow/inducing_variables/multioutput/inducing_variables.py
+++ b/gpflow/inducing_variables/multioutput/inducing_variables.py
@@ -129,7 +129,7 @@ class FallbackSeparateIndependentInducingVariables(MultioutputInducingVariables)
     """
 
     @check_shapes(
-        "inducing_variable_list[all]: [., D, 1]",
+        "inducing_variable_list[all]: [., ., 1]",
     )
     def __init__(self, inducing_variable_list: Sequence[InducingVariables]):
         super().__init__()

--- a/tests/gpflow/test_inducing_variables.py
+++ b/tests/gpflow/test_inducing_variables.py
@@ -133,3 +133,16 @@ def test_shape__inconsistent(none_shape: bool) -> None:
         iv.num_inducing
     with pytest.raises(tf.errors.InvalidArgumentError):
         len(iv)
+
+
+def test_separate_independent_allows_different_input_dimensions() -> None:
+    iv = giv.SeparateIndependentInducingVariables(
+        [
+            giv.InducingPatches([[0, 1], [2, 3]]),
+            giv.InducingPatches([[0], [1]]),
+            giv.InducingPoints([[0, 1, 2], [3, 4, 5]]),
+        ]
+    )
+
+    assert 2 == iv.num_inducing
+    assert get_shape(iv, TestContext()) is None


### PR DESCRIPTION
**PR type:** bugfix

**Related issue(s)/PRs:** resolves #2145

## Summary

**Proposed changes**

* Stop requiring separate inducing variables to share an input dimension.
* Preserve the rank and trailing singleton-dimension checks.
* Add regression coverage using interdomain inducing variables with different input dimensions.

**What alternatives have you considered?**

Removing the shape check entirely would also permit the example, but would discard useful validation. Using an anonymous dimension keeps that validation without coupling unrelated latent-process input dimensions.

### Minimal working example

```python
from gpflow.inducing_variables import (
    InducingPatches,
    InducingPoints,
    SeparateIndependentInducingVariables,
)

iv = SeparateIndependentInducingVariables(
    [
        InducingPatches([[0, 1], [2, 3]]),
        InducingPatches([[0], [1]]),
        InducingPoints([[0, 1, 2], [3, 4, 5]]),
    ]
)
assert iv.num_inducing == 2
```

### Release notes

Separate independent inducing variables can now use different input dimensions.

**Fully backwards compatible:** yes

## PR checklist

- [x] The bug case / new feature is covered by unit tests
- [x] Code has type annotations
- [x] Build checks
  - [x] I ran the black+isort formatter
  - [x] I locally tested that the relevant tests pass
